### PR TITLE
docs: add monorepo README and contributing guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,833 +1,174 @@
-# WoLy Backend - AI Coding Agent Instructions
+# WoLy Server Monorepo - AI Coding Agent Instructions
 
 ## Project Overview
 
-Node.js backend for Wake-on-LAN application with automatic network discovery. **Dual-mode architecture**: operates standalone OR as agent connecting to C&C backend via WebSocket. Built with Express, TypeScript, better-sqlite3 (migrated from sqlite3 on 2026-02-07), and comprehensive test coverage (195 tests, 90%+).
+Monorepo for the WoLy distributed Wake-on-LAN system. Contains two backend services and a shared protocol package, managed with npm workspaces and Turborepo.
 
-**Recent Major Changes:**
+| Workspace | Description | Port | Database |
+|---|---|---|---|
+| `apps/node-agent` | Per-LAN WoL agent — ARP scanning, host discovery, magic packets | 8082 | SQLite (better-sqlite3) |
+| `apps/cnc` | C&C aggregator — multi-node management, command routing, JWT auth | 8080 | PostgreSQL or SQLite |
+| `packages/protocol` | Shared types & Zod schemas (`@kaonis/woly-protocol`) | — | — |
 
-- Database: Migrated to `better-sqlite3` for security and performance (see `docs/SECURITY_REMEDIATION_2026-02-07.md`)
-- Protocol: Adopting shared `@kaonis/woly-protocol` package for C&C communication (see `docs/adr/0002-shared-protocol-package.md`)
+**Stack:** Node.js 24, TypeScript 5.9 (strict), Express 5, Jest 30, Zod, Turborepo.
 
-## Architecture: Dual Operating Modes
+## Workspace Layout
+
+```
+woly-server/
+├── apps/
+│   ├── node-agent/src/          # Express app, controllers, services, middleware
+│   └── cnc/src/                 # Express app, controllers, services, websocket
+├── packages/
+│   └── protocol/src/index.ts    # All shared types + Zod schemas
+├── turbo.json                   # Build ordering: protocol → apps
+├── tsconfig.base.json           # Shared strict TS config
+└── CLAUDE.md                    # Claude Code agent instructions
+```
+
+## Commands
+
+```bash
+# Always run from monorepo root
+npm install                      # Install all workspaces
+npm run build                    # Build all (protocol first via turbo)
+npm run test                     # Test all
+npm run test:ci                  # CI mode with coverage
+npm run typecheck                # Type-check all
+npm run lint                     # Lint all
+npm run dev:node-agent           # Dev mode with hot reload
+npm run dev:cnc                  # Dev mode with hot reload
+
+# Per-workspace
+npm run test -w apps/node-agent
+npm run build -w packages/protocol
+```
+
+## Architecture: Dual Operating Modes (Node Agent)
 
 ### Standalone Mode (Default)
 
 ```
-Mobile App (REST) → woly-backend → Local Network (ARP/WoL)
-                         ↓
-                    SQLite (hosts)
+Mobile App (REST) → Node Agent → Local LAN (ARP/WoL)
 ```
 
-### Agent Mode (Distributed Architecture)
+### Agent Mode
 
 ```
-C&C Backend (WebSocket) ↔ woly-backend → Local Network (ARP/WoL)
-                               ↓
-                          SQLite (hosts)
+C&C Backend (WebSocket) ↔ Node Agent → Local LAN (ARP/WoL)
 ```
 
-**Mode Selection:** Set `NODE_MODE=agent` in `.env` to connect to C&C backend. See `config/agent.ts` for required fields (CNC_URL, NODE_ID, NODE_LOCATION, NODE_AUTH_TOKEN).
+Set `NODE_MODE=agent` in `apps/node-agent/.env` to connect to C&C. Required env vars: `CNC_URL`, `NODE_ID`, `NODE_LOCATION`, `NODE_AUTH_TOKEN`.
 
-**Critical Pattern:** `agentService` orchestrates agent mode - connects to C&C via `cncClient`, forwards host discovery events, and processes commands from C&C. In standalone mode, these services are never initialized.
+## Key Concepts
 
-## Host Status: Dual-Field System
+### Host Status: Dual-Field System
 
-**CRITICAL DISTINCTION - Two separate status indicators:**
+- **`status`** (awake/asleep) — Primary indicator, based on ARP response. Reliable.
+- **`pingResponsive`** (1/0/null) — Secondary diagnostic, ICMP ping. Many devices block ping, so `0` does NOT mean asleep.
 
-### `status` (awake/asleep) - PRIMARY INDICATOR
+Always use `status` for determining if a device is awake.
 
-- **Source:** ARP network discovery
-- **Meaning:** If device responds to ARP, it's on the network and awake
-- **Reliability:** Definitive - ARP response = device is active
-- **Usage:** Use this field for determining if device is awake
+### Protocol Package
 
-### `pingResponsive` (1/0/null) - SECONDARY DIAGNOSTIC
+`@kaonis/woly-protocol` defines the WebSocket contract:
 
-- **Source:** ICMP ping test (always performed, separate from status determination)
-- **Values:** 1 (responds), 0 (no response), null (not tested)
-- **Meaning:** Network reachability diagnostic only
-- **WARNING:** Many devices block ping due to firewalls, so `pingResponsive: 0` does NOT mean device is asleep
-- **Config:** `USE_PING_VALIDATION=true` uses ping to validate awake status, but defaults to false (ARP is sufficient)
+- `NodeMessage` — discriminated union for node → C&C messages (register, heartbeat, host events, command results)
+- `CncCommand` — discriminated union for C&C → node commands (wake, scan, update-host, delete-host, ping)
+- Zod schemas for runtime validation: `outboundNodeMessageSchema`, `inboundCncCommandSchema`
 
-**Key Implementation:** See `services/networkDiscovery.ts:140-188` for dual-tracking logic and `types.ts` for type definitions.
+Both apps consume it via workspace link (`"@kaonis/woly-protocol": "*"`). Protocol must build before apps (handled by turbo.json `dependsOn: ["^build"]`).
 
-## Service Layer Architecture
+### Service Initialization (Node Agent)
 
-### Core Services (Singleton Pattern)
+Order matters in `apps/node-agent/src/app.ts`:
 
-**HostDatabase** (`services/hostDatabase.ts`)
-
-- better-sqlite3 operations with EventEmitter pattern (synchronous API, no callbacks)
-- Emits: `host-discovered`, `host-updated`, `scan-complete`
-- **Periodic scanning:** `startPeriodicSync()` runs ARP scan at configurable interval (default: 5 min)
-- **Database initialization:** Synchronous connection, immediate schema creation
-- **Critical:** Database instance passed to controllers AND agent service in `app.ts:69,79`
-- **Migration note:** Switched from sqlite3 to better-sqlite3 (Feb 2026) for ~2-3x performance improvement and security
-
-**NetworkDiscovery** (`services/networkDiscovery.ts`)
-
-- Cross-platform ARP scanning via `local-devices` package
-- **Hostname resolution:** DNS reverse lookup → NetBIOS (Windows) → nmblookup (Linux) → auto-generated fallback
-- **Ping validation:** Optional ICMP testing (config: `USE_PING_VALIDATION`)
-- **Rate limiting:** MAC vendor API calls throttled to 1 req/sec (config: `MAC_VENDOR_RATE_LIMIT`)
-
-**AgentService** (`services/agentService.ts`) - Agent Mode Only
-
-- Orchestrates agent mode operations
-- Connects `HostDatabase` events to `CncClient` WebSocket
-- Command handlers: wake, scan, update-host, delete-host
-- **Setup:** `setHostDatabase()` must be called before `start()` - see `app.ts:79-81`
-
-**CncClient** (`services/cncClient.ts`) - Agent Mode Only
-
-- WebSocket connection to C&C backend
-- Automatic reconnection with exponential backoff (config: `RECONNECT_INTERVAL`, `MAX_RECONNECT_ATTEMPTS`)
-- Heartbeat mechanism (default: 30s interval)
-- Message protocol: `NodeMessage` (node→C&C) and `CncCommand` (C&C→node) - see `types.ts:65-113`
-
-### Dependency Flow (Critical Initialization Order)
-
-```typescript
-// app.ts initialization sequence
-1. hostDb = new HostDatabase()
-2. await hostDb.initialize()  // Creates tables, seeds data
-3. hostsController.setHostDatabase(hostDb)  // Pass to controller
-
-// AGENT MODE ONLY:
-4. agentService.setHostDatabase(hostDb)  // Connect events
-5. await agentService.start()  // Connects to C&C via cncClient
-
-// BOTH MODES:
-6. hostDb.startPeriodicSync()  // Background scanning
+```
+1. hostDb = new HostDatabase() → await hostDb.initialize()
+2. hostsController.setHostDatabase(hostDb)
+3. [Agent mode only] agentService.setHostDatabase(hostDb) → await agentService.start()
+4. hostDb.startPeriodicSync()
 ```
 
-**Why this order matters:** AgentService listens to HostDatabase events, so must be connected before scanning starts. Controllers need database instance for queries.
+AgentService must be connected before scanning starts so it can forward host events to C&C.
 
-## Network Discovery Algorithm Details
+## Testing
 
-### ARP Scanning Process (`networkDiscovery.ts`)
+**Node Agent:** 240+ tests, 50% coverage thresholds. Unit tests in `src/**/__tests__/`, integration tests with supertest.
 
-**Step 1: Device Discovery** (line 140-160)
+**C&C:** 90+ tests. Same pattern.
 
-```typescript
-// Uses local-devices package for cross-platform ARP scanning
-const devices = await localDevices();
-// Returns: [{ ip, mac, hostname }]
-```
+Both apps use `tsconfig.test.json` (relaxes `noUnusedLocals`/`noUnusedParameters` for test files) via ts-jest transform config.
 
-**Step 2: Hostname Resolution** (line 85-120) - **Fallback Chain:**
-
-1. **DNS Reverse Lookup** (fastest, works if device has DNS entry)
-
-   ```typescript
-   const hostnames = await dns.reverse(ip);
-   return hostnames[0].split('.')[0]; // Strip domain
-   ```
-
-2. **NetBIOS Query** (Windows: `nbtstat -A`, Linux: `nmblookup -A`)
-
-   - Timeout: 2s per query
-   - Parses output for `<00> UNIQUE` (workstation name)
-   - Fallback for devices without DNS entries
-
-3. **Auto-generated Hostname** (last resort)
-   ```typescript
-   return `device-${ip.replace(/\./g, '-')}`; // device-192-168-1-100
-   ```
-
-**Step 3: Status Determination** (line 160-188)
-
-```typescript
-// Primary: ARP response = awake
-host.status = 'awake'; // Device is on network
-
-// Secondary: Optional ping validation
-if (config.network.usePingValidation) {
-  const pingResult = await ping.promise.probe(ip, {
-    timeout: config.network.pingTimeout / 1000,
-  });
-  host.status = pingResult.alive ? 'awake' : 'asleep';
-}
-
-// Always test ping for diagnostic field (separate from status)
-const pingTest = await ping.promise.probe(ip);
-host.pingResponsive = pingTest.alive ? 1 : 0;
-```
-
-**Why separate fields?**
-
-- ARP response is definitive proof device is active
-- Ping may fail due to firewall rules (false negative)
-- `pingResponsive` provides additional diagnostic info without overriding ARP status
-
-**Step 4: MAC Vendor Lookup** (line 120-140)
-
-```typescript
-// Rate-limited API calls (1 req/sec)
-const vendor = await fetchMacVendor(mac);
-// Cached for 24h (MAC_VENDOR_TTL)
-```
-
-**Performance Optimizations:**
-
-- ARP scan: ~2-5s for typical home network (50-100 devices)
-- Hostname resolution: Parallel execution with 2s timeout
-- MAC vendor: LRU cache prevents repeated API calls
-- Deferred sync: Initial scan delayed 5s for faster API availability
-
-### Periodic Scanning (`hostDatabase.ts:200-250`)
-
-```typescript
-startPeriodicSync(interval: number, immediate: boolean) {
-  if (immediate) {
-    this.performNetworkScan(); // Run now
-  }
-
-  this.syncInterval = setInterval(() => {
-    this.performNetworkScan();
-  }, interval); // Default: 5 minutes
-}
-```
-
-**Scan Lifecycle:**
-
-1. Set `scanInProgress = true`
-2. Run ARP discovery
-3. Update database (insert new, update existing, mark missing as 'asleep')
-4. Emit events: `host-discovered`, `host-updated`, `scan-complete`
-5. Set `scanInProgress = false`, update `lastScanTime`
-
-**Database Update Strategy:**
-
-- **New hosts:** INSERT with `discovered = 1`
-- **Existing hosts:** UPDATE status, lastSeen timestamp
-- **Missing hosts:** Status unchanged (may be temporarily offline)
-- Manual cleanup required for permanently removed devices
-
-## Development Workflow
-
-### Build & Run Commands
+**Test preflight:** Both apps run `scripts/test-preflight.js` before Jest to verify runtime prerequisites.
 
 ```bash
-npm start              # Development: ts-node direct execution (no build)
-npm run dev            # Development with auto-reload (nodemon + ts-node)
-npm run build          # Compile TypeScript → dist/
-npm run prod           # Production: build + node execution
-
-# Testing
-npm test               # All tests (unit + integration)
-npm run test:unit      # Unit tests only (*.unit.test.ts)
-npm run test:integration  # Integration tests only (*.integration.test.ts)
-npm run test:coverage  # Coverage report (enforces thresholds)
-npm run test:watch     # Watch mode for development
-npm run test:ci        # CI mode (coverage to Codecov)
+# Rebuild better-sqlite3 if switching Node versions
+npm rebuild better-sqlite3 --build-from-source
 ```
 
-**Common Gotcha:** Unlike C&C backend, `npm start` uses `ts-node` directly (no build required). Use `npm run prod` for compiled production build.
+## API Patterns
 
-### Testing Strategy (195 Tests, 90% Coverage)
+### Node Agent API (port 8082)
 
-**Coverage Thresholds (Enforced in CI):**
-
-- Statements: 80%
-- Lines: 80%
-- Branches: 70%
-- Functions: 85%
-
-**Test Organization:**
-
-- **Unit tests:** `__tests__/` directories alongside source files
-  - Services: `services/__tests__/*.unit.test.ts`
-  - Controllers: `controllers/__tests__/*.unit.test.ts`
-  - Middleware: `middleware/__tests__/*.unit.test.ts`
-- **Integration tests:** `__tests__/` at project root
-  - Full API testing with supertest
-  - Example: `__tests__/api.integration.test.ts`
-
-**Key Testing Patterns:**
-
-**Database Mocking (Unit Tests):**
-
-```typescript
-// Mock better-sqlite3 database (synchronous API)
-jest.mock('better-sqlite3', () => {
-  return jest.fn().mockImplementation(() => ({
-    prepare: jest.fn().mockReturnValue({
-      run: jest.fn().mockReturnValue({ changes: 1, lastInsertRowid: 1 }),
-      get: jest.fn().mockReturnValue(mockHost),
-      all: jest.fn().mockReturnValue([mockHost]),
-    }),
-    exec: jest.fn(),
-    close: jest.fn(),
-  }));
-});
-
-// Or use in-memory database for real behavior
-import Database from 'better-sqlite3';
-const db = new Database(':memory:');
-db.exec(fs.readFileSync('db/schema.sql', 'utf8'));
+```
+GET  /health                     Health check
+GET  /hosts                      All hosts + scan status
+GET  /hosts/:name                Single host
+POST /hosts                      Add host manually
+POST /hosts/wakeup/:name         Wake-on-LAN
+POST /hosts/scan                 Trigger network scan
+GET  /hosts/mac-vendor/:mac      MAC vendor lookup
+GET  /api-docs                   Swagger UI
 ```
 
-**WebSocket Mocking (Agent Mode Tests):**
+### C&C API (port 8080)
 
-```typescript
-import WebSocket from 'ws';
-import { cncClient } from '../services/cncClient';
-
-// Mock WebSocket connection
-jest.mock('ws');
-const mockWs = {
-  send: jest.fn(),
-  on: jest.fn(),
-  close: jest.fn(),
-  readyState: WebSocket.OPEN,
-};
-
-// Test message sending
-test('should forward host discovery to C&C', () => {
-  cncClient.send({ type: 'host-discovered', data: mockHost });
-  expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('host-discovered'));
-});
+```
+GET    /health                   Health check
+POST   /api/auth/token           Exchange operator token for JWT
+GET    /api/nodes                List nodes
+GET    /api/nodes/:id            Node details
+GET    /api/nodes/:id/health     Node health
+GET    /api/hosts                All hosts (JWT required)
+GET    /api/hosts/:fqn           Single host
+POST   /api/hosts/wakeup/:fqn    Wake-on-LAN via C&C
+PUT    /api/hosts/:fqn           Update host
+DELETE /api/hosts/:fqn           Delete host
+DELETE /api/admin/nodes/:id      Deregister node (admin)
+GET    /api/admin/stats          System stats (admin)
+ws://  /ws/node                  WebSocket for node connections
 ```
 
-**EventEmitter Testing (Service Communication):**
+## Conventions
 
-```typescript
-// HostDatabase emits events, AgentService listens
-const hostDb = new HostDatabase(':memory:');
-const eventSpy = jest.fn();
-hostDb.on('host-discovered', eventSpy);
+- TypeScript strict mode everywhere (extends `tsconfig.base.json`)
+- Express 5 — `req.params` values are `string | string[]`, cast with `as string`
+- Unused params prefixed with `_` (e.g., `_req`, `_res`)
+- Structured Winston logging with object context, not string interpolation
+- Joi validation (node-agent), Zod validation (protocol/cnc)
+- Standardized error responses via `middleware/errorHandler.ts`
+- Rate limiting via `express-rate-limit`
+- Docker: node-agent requires `--net host` for ARP scanning
 
-await hostDb.performNetworkScan();
-expect(eventSpy).toHaveBeenCalledWith(
-  expect.objectContaining({ name: 'TEST-HOST', status: 'awake' })
-);
-```
+## Configuration
 
-**Integration Tests with Supertest:**
+Each app has `.env.example` with all available options. Key differences:
 
-```typescript
-import request from 'supertest';
-import app from '../app';
+| Variable | Node Agent | C&C |
+|---|---|---|
+| Port | `PORT=8082` | `PORT=8080` |
+| Database | `DB_PATH=./db/woly.db` (SQLite) | `DB_TYPE=sqlite\|postgres`, `DATABASE_URL` |
+| Auth | `NODE_AUTH_TOKEN` (for agent mode) | `NODE_AUTH_TOKENS`, `JWT_SECRET` |
+| Network | `SCAN_INTERVAL`, `PING_TIMEOUT` | `NODE_HEARTBEAT_INTERVAL`, `NODE_TIMEOUT` |
 
-// Test full request/response cycle
-test('GET /hosts returns host list', async () => {
-  const response = await request(app).get('/hosts').expect(200).expect('Content-Type', /json/);
+## Docker
 
-  expect(response.body).toHaveProperty('hosts');
-  expect(response.body).toHaveProperty('scanInProgress');
-});
-
-// Test error handling
-test('POST /hosts/wakeup/:name with invalid name returns 404', async () => {
-  await request(app)
-    .post('/hosts/wakeup/NONEXISTENT')
-    .expect(404)
-    .expect((res) => {
-      expect(res.body.error.code).toBe('NOT_FOUND');
-    });
-});
-
-// Test rate limiting
-test('POST /hosts/scan respects rate limit', async () => {
-  // First 5 requests succeed
-  for (let i = 0; i < 5; i++) {
-    await request(app).post('/hosts/scan').expect(200);
-  }
-  // 6th request fails with 429
-  await request(app).post('/hosts/scan').expect(429);
-});
-```
-
-**Network Discovery Mocking:**
-
-```typescript
-import * as networkDiscovery from '../services/networkDiscovery';
-
-jest.mock('../services/networkDiscovery', () => ({
-  discoverHosts: jest
-    .fn()
-    .mockResolvedValue([{ ip: '192.168.1.100', mac: 'AA:BB:CC:DD:EE:FF', hostname: 'TEST-HOST' }]),
-  pingHost: jest.fn().mockResolvedValue(true),
-}));
-```
-
-**When adding features:**
-
-1. Add unit tests for business logic (controllers, services, utils)
-2. Add integration tests for new API endpoints
-3. Mock external dependencies (network, database, WebSocket)
-4. Test error paths and edge cases
-5. Run `npm run test:coverage` to verify thresholds
-6. CI fails if coverage drops below 80%
-
-**Test File Naming Convention:**
-
-- Unit tests: `*.unit.test.ts` - Fast, isolated, no external dependencies
-- Integration tests: `*.integration.test.ts` - Full stack, real database (SQLite in-memory)
-
-See `jest.config.js` for configuration and `jest.setup.ts` for global test setup.
-
-## Configuration Management
-
-**Environment Variables** (`.env`):
-
-```env
-# Server
-PORT=8082
-HOST=0.0.0.0
-NODE_ENV=development
-
-# Database
-DB_PATH=./db/woly.db
-
-# Network Discovery
-SCAN_INTERVAL=300000          # 5 minutes
-SCAN_DELAY=5000               # 5 seconds initial delay
-PING_TIMEOUT=2000             # 2 seconds
-USE_PING_VALIDATION=false     # Optional ping validation (ARP is sufficient)
-
-# Caching
-MAC_VENDOR_TTL=86400000       # 24 hours
-MAC_VENDOR_RATE_LIMIT=1000    # 1 second between API calls
-
-# CORS
-CORS_ORIGINS=http://localhost:19000,http://192.168.1.228:8082
-
-# Logging
-LOG_LEVEL=info                # error, warn, info, http, debug
-
-# AGENT MODE ONLY (set NODE_MODE=agent to enable)
-NODE_MODE=standalone          # standalone or agent
-CNC_URL=ws://localhost:8080   # C&C backend WebSocket URL
-NODE_ID=node-1                # Unique node identifier
-NODE_LOCATION=Home Office     # Human-readable location
-NODE_AUTH_TOKEN=secret-token  # Authentication token
-HEARTBEAT_INTERVAL=30000      # 30 seconds
-RECONNECT_INTERVAL=5000       # 5 seconds
-MAX_RECONNECT_ATTEMPTS=0      # 0 = infinite
-```
-
-**Config loaded via** `config/index.ts` and `config/agent.ts` with dotenv. Access via `import { config } from './config'` or `import { agentConfig } from './config/agent'`.
-
-**Validation:** `validateAgentConfig()` throws error if agent mode enabled without required fields.
-
-## API Patterns & Conventions
-
-### Rate Limiting (express-rate-limit)
-
-- **General API:** 100 requests per 15 minutes per IP
-- **Network scans:** 5 requests per minute per IP (resource-intensive)
-- **Wake requests:** 20 requests per minute per IP
-- Headers: `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`
-
-See `middleware/rateLimiter.ts` for configuration.
-
-### Input Validation (Joi)
-
-All endpoints validate input via `middleware/validateRequest.ts` using schemas from `validators/hostValidator.ts`:
-
-- MAC format: `XX:XX:XX:XX:XX:XX` or `XX-XX-XX-XX-XX-XX`
-- IP format: Valid IPv4/IPv6
-- Hostname: 1-255 characters
-
-### Error Handling (Standardized Format)
-
-Global error handler in `middleware/errorHandler.ts` returns consistent structure:
-
-```typescript
-{
-  error: {
-    code: "VALIDATION_ERROR",
-    message: "MAC address must be in format XX:XX:XX:XX:XX:XX",
-    statusCode: 400,
-    timestamp: "2025-11-19T09:35:06.541Z",
-    path: "/hosts/mac-vendor/INVALID"
-  }
-}
-```
-
-**Common codes:** `VALIDATION_ERROR` (400), `NOT_FOUND` (404), `INTERNAL_ERROR` (500)
-
-### API Documentation (Swagger/OpenAPI)
-
-Interactive docs at `/api-docs` endpoint. Configuration in `swagger.ts` using `swagger-jsdoc` and `swagger-ui-express`.
-
-## Type System & Protocol
-
-**Central Types** (`types.ts`):
-
-- `Host` - Basic host data (used in both standalone and agent modes)
-- `HostsResponse`, `ScanResponse`, `WakeUpResponse` - API responses
-- **Agent Protocol Types:**
-  - `NodeMessage` - Union type for node→C&C messages (register, heartbeat, host-discovered, etc.)
-  - `CncCommand` - Union type for C&C→node commands (wake, scan, update-host, etc.)
-  - `NodeRegistration` - Registration payload with metadata
-
-**Shared Protocol Package (@kaonis/woly-protocol):**
-
-Protocol types are being migrated to shared package for consistency between node and C&C:
-
-- Lives in `packages/protocol/` within this repo
-- Published to npm as `@kaonis/woly-protocol`
-- Exports runtime validation schemas (Zod) + TypeScript types
-- Version synchronization required across repos (see `ADR-0002`)
-
-**Publishing Protocol:**
+Build from monorepo root (Dockerfiles reference root package.json and protocol):
 
 ```bash
-npm run protocol:pack     # Create tarball for local testing
-npm run protocol:publish  # Publish to npm (requires credentials)
-# Or use GitHub Action: "Publish Protocol Package"
+docker build -f apps/node-agent/Dockerfile -t woly-node-agent .
+docker build -f apps/cnc/Dockerfile -t woly-cnc .
 ```
 
-**Union types enable exhaustive TypeScript checking:**
-
-```typescript
-switch (message.type) {
-  case 'register':
-    return await handleRegistration(message.data);
-  case 'heartbeat':
-    return await handleHeartbeat(message.data);
-  // TypeScript ensures all cases covered
-}
-```
-
-### WebSocket Message Handling Patterns
-
-**Node → C&C Message Flow** (`agentService.ts`):
-
-```typescript
-// Host discovery forwarding
-private sendHostDiscovered(host: Host): void {
-  const message: NodeMessage = {
-    type: 'host-discovered',
-    data: { nodeId: agentConfig.nodeId, ...host }
-  };
-  cncClient.send(message);
-}
-
-// Registration with metadata
-private async sendRegistration(): Promise<void> {
-  const registration: NodeRegistration = {
-    nodeId: agentConfig.nodeId,
-    name: os.hostname(),
-    location: agentConfig.location,
-    authToken: agentConfig.authToken,
-    metadata: {
-      version: '1.0.0',
-      platform: os.platform(),
-      networkInfo: { subnet: '192.168.1.0/24', gateway: '192.168.1.1' }
-    }
-  };
-  cncClient.send({ type: 'register', data: registration });
-}
-```
-
-**C&C → Node Command Handling** (`agentService.ts:120-240`):
-
-```typescript
-// Wake command with result reporting
-private async handleWakeCommand(command: CncCommand): Promise<void> {
-  const { commandId, data } = command;
-  try {
-    const result = await this.hostDb.wakeHost(data.hostName);
-    this.sendCommandResult(commandId, true, 'Wake packet sent');
-  } catch (error) {
-    this.sendCommandResult(commandId, false, error.message);
-  }
-}
-
-// Scan command with immediate flag
-private async handleScanCommand(command: CncCommand): Promise<void> {
-  const { commandId, data } = command;
-  if (data.immediate) {
-    await this.hostDb.performNetworkScan();
-  } else {
-    this.hostDb.startPeriodicSync(config.network.scanInterval, true);
-  }
-  this.sendCommandResult(commandId, true, 'Scan initiated');
-}
-```
-
-**Connection Lifecycle** (`cncClient.ts:100-150`):
-
-```typescript
-// Heartbeat keeps connection alive
-private startHeartbeat(): void {
-  this.heartbeatTimer = setInterval(() => {
-    this.send({
-      type: 'heartbeat',
-      data: { nodeId: agentConfig.nodeId, timestamp: new Date() }
-    });
-  }, agentConfig.heartbeatInterval);
-}
-
-// Automatic reconnection with backoff
-private scheduleReconnect(): void {
-  if (this.reconnectAttempts >= agentConfig.maxReconnectAttempts &&
-      agentConfig.maxReconnectAttempts !== 0) {
-    this.emit('reconnect-failed');
-    return;
-  }
-
-  const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 30000);
-  this.reconnectTimer = setTimeout(() => this.connect(), delay);
-  this.reconnectAttempts++;
-}
-```
-
-## Logging Convention
-
-Winston logger (`utils/logger.ts`) with structured logging:
-
-```typescript
-logger.info('Network scan completed', { hostsFound: 5, duration: 1234 });
-logger.error('Failed to connect to C&C', { error: error.message, nodeId });
-```
-
-**Log Levels:** `error` → `logs/error.log`, all levels → `logs/combined.log`, console (colored in dev)
-
-**Use object format for context,** not string interpolation - enables structured log parsing.
-
-## Security Features
-
-### Helmet.js Security Headers
-
-- Content Security Policy
-- X-Frame-Options
-- X-Content-Type-Options
-- Referrer-Policy
-
-### CORS Configuration (`app.ts:19-57`)
-
-Dynamic origin validation:
-
-- Whitelist from `CORS_ORIGINS` env var
-- Auto-allow ngrok URLs: `https://*.ngrok-free.app`
-- Auto-allow Netlify URLs: `https://*.netlify.app`
-- Auto-allow custom domains: `helios.kaonis.com`
-
-**Pattern:** Use callback-based CORS to log accepted/rejected origins for debugging.
-
-## Docker Deployment
-
-**CRITICAL:** Host networking mode required for ARP scanning to work.
-
-```bash
-docker run -d \
-  --name woly-backend \
-  --net host \
-  -v $(pwd)/db:/app/db \
-  -v $(pwd)/logs:/app/logs \
-  -e NODE_ENV=production \
-  woly-backend:latest
-```
-
-**Why `--net host`:** ARP scanning requires low-level network access. Bridge networking breaks discovery.
-
-Multi-stage Dockerfile optimizes image size (see Dockerfile for implementation).
-
-## Common Pitfalls & Debugging
-
-### Configuration Issues
-
-1. **Agent mode without config** - Set all 4 required env vars or get validation error:
-
-   ```bash
-   # Required for agent mode
-   NODE_MODE=agent
-   CNC_URL=ws://localhost:8080
-   NODE_ID=node-1
-   NODE_LOCATION=Home Office
-   NODE_AUTH_TOKEN=secret-token
-   ```
-
-   **Error:** `Agent mode enabled but missing required configuration: CNC_URL, NODE_ID`
-   **Fix:** Check `.env` file exists and all variables set
-
-2. **CORS errors from mobile app** - Origin not in whitelist
-   ```typescript
-   // app.ts - Check logs for rejected origins
-   logger.error(`CORS: Rejected origin: ${origin}`);
-   ```
-   **Fix:** Add origin to `CORS_ORIGINS` in `.env` or use dynamic patterns (ngrok, Netlify)
-
-### Service Initialization Errors
-
-3. **Database not initialized** - Always `await hostDb.initialize()` before starting services
-
-   ```typescript
-   // ❌ WRONG - services won't have database instance
-   const hostDb = new HostDatabase();
-   hostsController.setHostDatabase(hostDb);
-   await hostDb.initialize();
-
-   // ✅ CORRECT - initialize before passing to services
-   const hostDb = new HostDatabase();
-   await hostDb.initialize();
-   hostsController.setHostDatabase(hostDb);
-   ```
-
-4. **AgentService timing** - Must call `setHostDatabase()` before `start()` to connect events
-   ```typescript
-   // Event listeners registered in setHostDatabase()
-   agentService.setHostDatabase(hostDb); // Connect events first
-   await agentService.start(); // Then start (triggers initial scan)
-   ```
-   **Symptom:** Host discoveries not forwarded to C&C
-   **Debug:** Check `agentService.ts:25-38` event listener setup
-
-### Network & Docker Issues
-
-5. **Docker networking** - Must use `--net host` for ARP scanning to work
-
-   ```bash
-   # ❌ WRONG - Bridge mode breaks ARP
-   docker run -p 8082:8082 woly-backend
-
-   # ✅ CORRECT - Host networking required
-   docker run --net host woly-backend
-   ```
-
-   **Why:** ARP packets require direct network interface access
-   **Symptom:** Zero hosts discovered, even on populated network
-
-6. **Hostname resolution timeouts** - NetBIOS queries can be slow
-   ```typescript
-   // Increase timeout if network is slow
-   SCAN_DELAY = 10000; // 10 seconds instead of 5
-   ```
-   **Symptom:** Many hosts show auto-generated names (`device-192-168-1-100`)
-   **Debug:** Check logs for "NetBIOS lookup failed" warnings
-
-### Status & Discovery Issues
-
-7. **Ping vs ARP confusion** - Use `status` field (awake/asleep) as primary indicator
-
-   ```typescript
-   // ❌ WRONG - pingResponsive unreliable due to firewalls
-   if (host.pingResponsive === 0) {
-     // Host might be awake but blocking ping!
-   }
-
-   // ✅ CORRECT - status is definitive
-   if (host.status === 'awake') {
-     // Host is definitely on network (ARP response)
-   }
-   ```
-
-   **Symptom:** Mobile app shows device as "offline" but it's actually awake
-   **Debug:** Check both `status` AND `pingResponsive` fields in response
-
-8. **MAC vendor rate limit** - API calls throttled to 1/sec, cache expires after 24h
-   ```typescript
-   // Increase cache TTL for less frequent lookups
-   MAC_VENDOR_TTL = 604800000; // 7 days
-   ```
-   **Symptom:** Slow initial scans with many new devices
-   **Debug:** Check `macVendorCache` size in logs
-
-### Testing Issues
-
-9. **Test coverage thresholds** - CI fails if any threshold drops below configured value
-
-   ```bash
-   # Check coverage before commit
-   npm run test:coverage
-   # Look for lines below threshold
-   ```
-
-   **Common cause:** New files without tests
-   **Fix:** Add `__tests__/*.unit.test.ts` alongside new service/controller files
-
-10. **Mock timer interference** - Jest fake timers affect heartbeat/scan intervals
-    ```typescript
-    // Use real timers for integration tests
-    beforeEach(() => {
-      jest.useRealTimers();
-    });
-    ```
-
-### WebSocket Connection Issues (Agent Mode)
-
-11. **C&C connection refused** - Check C&C backend is running and URL correct
-
-    ```bash
-    # Test WebSocket connection manually
-    wscat -c "ws://localhost:8080/ws/node?token=test-token"
-    ```
-
-    **Symptom:** `Failed to connect to C&C backend` in logs
-    **Debug:** Check `CNC_URL`, ensure C&C server started, verify firewall rules
-
-12. **Authentication failures** - Token mismatch between node and C&C
-
-    ```typescript
-    // C&C logs show: Invalid authentication token
-    ```
-
-    **Fix:** Ensure `NODE_AUTH_TOKEN` matches one of C&C's `NODE_AUTH_TOKENS`
-
-13. **Heartbeat timeout** - Node marked offline despite active connection
-    ```typescript
-    // Increase timeout if network latency high
-    HEARTBEAT_INTERVAL = 60000; // 1 minute
-    // C&C must have matching or higher NODE_TIMEOUT
-    ```
-
-### Performance Issues
-
-14. **Slow network scans** - Large networks (200+ devices) take 10-30s
-    **Optimization:** Increase `SCAN_INTERVAL` to reduce frequency
-
-    ```bash
-    SCAN_INTERVAL=600000  # 10 minutes instead of 5
-    ```
-
-15. **Database lock errors** - Concurrent writes to SQLite
-    **Symptom:** `SQLITE_BUSY: database is locked`
-    **Fix:** SQLite has automatic retry logic, but consider PostgreSQL for high-write workloads
-
-### Debugging Commands
-
-```bash
-# Check database contents
-sqlite3 db/woly.db "SELECT name, status, lastSeen FROM hosts;"
-
-# Monitor logs in real-time
-tail -f logs/combined.log | grep -i error
-
-# Test ARP scanning manually
-node -e "require('./services/networkDiscovery').discoverHosts().then(console.log)"
-
-# Verify WebSocket connection (agent mode)
-wscat -c "ws://localhost:8080/ws/node?token=test-token"
-```
-
-## Key Files Reference
-
-- `app.ts` - Express app, service initialization, mode detection
-- `types.ts` - Shared protocol types (Host, NodeMessage, CncCommand)
-- `packages/protocol/` - Shared protocol package (@kaonis/woly-protocol)
-- `config/index.ts` - Server configuration
-- `config/agent.ts` - Agent mode configuration and validation
-- `services/hostDatabase.ts` - better-sqlite3 operations, event emitter
-- `services/networkDiscovery.ts` - ARP scanning, hostname resolution
-- `services/agentService.ts` - Agent mode orchestration
-- `services/cncClient.ts` - WebSocket connection to C&C
-- `controllers/hosts.ts` - Request handlers
-- `middleware/rateLimiter.ts` - Rate limiting configuration
-- `middleware/errorHandler.ts` - Global error handling
-- `jest.config.js` - Test configuration with coverage thresholds
-- `docs/SECURITY_REMEDIATION_2026-02-07.md` - Database migration details
-- `docs/adr/0002-shared-protocol-package.md` - Protocol package adoption
-
-## Integration with Other Projects
-
-**Mobile App** (`woly` repo) - REST client for standalone mode, connects to `/hosts` endpoints
-
-**C&C Backend** (`woly-cnc-backend` repo) - WebSocket server for agent mode, aggregates multiple node agents
-
-**Switch between modes:** Change `NODE_MODE=agent` and configure C&C connection. No code changes needed.
+Node agent requires `--net host` for ARP scanning.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing
+
+## Setup
+
+```bash
+git clone https://github.com/kaonis/woly-server.git
+cd woly-server
+nvm use          # Node.js 24
+npm install      # All workspaces
+npm run build    # Protocol first, then apps
+npm run test     # Verify everything works
+```
+
+Copy environment files before running dev servers:
+
+```bash
+cp apps/node-agent/.env.example apps/node-agent/.env
+cp apps/cnc/.env.example apps/cnc/.env
+```
+
+## Development Workflow
+
+1. Create a branch from `master`
+2. Make changes
+3. Run `npm run build && npm run typecheck && npm run test` to verify
+4. Push and open a PR against `master`
+
+## Working With Workspaces
+
+This is an npm workspaces monorepo with Turborepo for task orchestration.
+
+**Run a command in a specific workspace:**
+
+```bash
+npm run test -w apps/node-agent
+npm run build -w packages/protocol
+```
+
+**Build order matters.** `packages/protocol` must build before either app. Turborepo handles this automatically via `turbo.json`, but if running `tsc` directly in an app, build protocol first.
+
+**Adding a dependency to a workspace:**
+
+```bash
+npm install axios -w apps/node-agent        # Runtime dep
+npm install @types/ws -w apps/cnc --save-dev # Dev dep
+```
+
+Shared dev dependencies (typescript, eslint, prettier) live in the root `package.json`.
+
+## Protocol Changes
+
+When modifying `packages/protocol/src/index.ts`:
+
+1. Make the change
+2. Run `npm run build -w packages/protocol` to regenerate `dist/`
+3. Run `npm run typecheck` to verify both apps still compile
+4. Run `npm run test` to verify no runtime regressions
+5. If the mobile app needs the update, bump version and publish to npm
+
+## TypeScript
+
+All workspaces extend `tsconfig.base.json` which enables strict mode. Key settings:
+
+- `noUnusedLocals: true` / `noUnusedParameters: true` — prefix unused params with `_`
+- `strict: true` — no implicit any, strict null checks, etc.
+- Express 5 types: `req.params` values are `string | string[]`, cast with `as string`
+
+Test files use `tsconfig.test.json` which relaxes unused variable checks.
+
+## Testing
+
+```bash
+npm run test              # All workspaces
+npm run test:ci           # CI mode with coverage
+npm run test -w apps/cnc  # Single workspace
+```
+
+**If `better-sqlite3` fails after switching Node versions:**
+
+```bash
+npm rebuild better-sqlite3 --build-from-source
+```
+
+## Docker
+
+Build images from the repo root (Dockerfiles copy root workspace files):
+
+```bash
+docker build -f apps/node-agent/Dockerfile -t woly-node-agent .
+docker build -f apps/cnc/Dockerfile -t woly-cnc .
+```
+
+The node agent requires `--net host` for ARP scanning to discover devices on the local network.
+
+## Code Style
+
+- Formatting: Prettier (run `npm run format`)
+- Linting: ESLint with TypeScript plugin (run `npm run lint`)
+- Logging: Winston with structured object context, not string interpolation
+- Error handling: Throw `AppError` instances, caught by global error handler middleware

--- a/README.md
+++ b/README.md
@@ -1,0 +1,182 @@
+# WoLy Server
+
+Distributed Wake-on-LAN management system. A monorepo containing two backend services and a shared protocol package that together enable waking up devices across multiple LANs from a single mobile app.
+
+## Architecture
+
+```
+┌──────────┐       REST/JWT        ┌───────────┐      WebSocket       ┌──────────────┐
+│ Mobile   │ ──────────────────▶  │    C&C    │ ◀──────────────────▶ │  Node Agent  │
+│ App      │                      │  Backend  │                      │  (per LAN)   │
+│ (Expo)   │                      │  :8080    │                      │  :8082       │
+└──────────┘                      └───────────┘                      └──────┬───────┘
+                                        │                                   │
+                                   PostgreSQL                          ARP / WoL
+                                   or SQLite                          Magic Packets
+                                                                          │
+                                                                    ┌─────▼─────┐
+                                                                    │ Local LAN │
+                                                                    │  Devices  │
+                                                                    └───────────┘
+```
+
+**Node Agent** discovers hosts on its local network via ARP scanning and can wake them with Wake-on-LAN magic packets. It operates standalone or connects to the C&C backend as an agent.
+
+**C&C Backend** aggregates multiple node agents, providing a unified API for the mobile app to manage hosts across all locations.
+
+**Protocol Package** defines the shared TypeScript types and Zod validation schemas used for WebSocket communication between the two services.
+
+## Workspace Layout
+
+```
+woly-server/
+├── apps/
+│   ├── node-agent/          Per-LAN WoL agent (Express 5, SQLite, :8082)
+│   └── cnc/                 C&C aggregator (Express 5, PostgreSQL/SQLite, :8080)
+├── packages/
+│   └── protocol/            Shared types & Zod schemas (@kaonis/woly-protocol)
+├── turbo.json               Turborepo task orchestration
+├── tsconfig.base.json       Shared TypeScript config
+└── CLAUDE.md                AI agent instructions
+```
+
+## Prerequisites
+
+- **Node.js 24+** (see `.nvmrc`)
+- **npm 10+**
+- PostgreSQL 16+ (optional, cnc supports SQLite for dev)
+
+```bash
+nvm use
+```
+
+## Getting Started
+
+```bash
+# Install all workspaces
+npm install
+
+# Copy environment files
+cp apps/node-agent/.env.example apps/node-agent/.env
+cp apps/cnc/.env.example apps/cnc/.env
+
+# Build everything (protocol first, then apps)
+npm run build
+
+# Run tests
+npm run test
+```
+
+### Development
+
+```bash
+# Start node agent with hot reload
+npm run dev:node-agent
+
+# Start C&C backend with hot reload
+npm run dev:cnc
+
+# Run a single workspace command
+npm run test -w apps/node-agent
+npm run build -w packages/protocol
+```
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `npm run build` | Build all workspaces (protocol → apps) |
+| `npm run test` | Run all tests |
+| `npm run test:ci` | CI mode with coverage |
+| `npm run typecheck` | Type-check all workspaces |
+| `npm run lint` | Lint all workspaces |
+| `npm run dev:node-agent` | Start node agent in dev mode |
+| `npm run dev:cnc` | Start C&C backend in dev mode |
+| `npm run format` | Format all files with Prettier |
+
+## Node Agent
+
+The node agent is deployed on each LAN where you want to discover and wake devices. Key features:
+
+- **ARP network discovery** with DNS/NetBIOS hostname resolution
+- **Wake-on-LAN** magic packet sending
+- **Dual status tracking** — ARP-based `status` (reliable) + ICMP `pingResponsive` (diagnostic)
+- **MAC vendor lookup** with LRU caching
+- **Standalone or agent mode** — works independently or connects to C&C
+- **Swagger API docs** at `/api-docs`
+
+Runs on port 8082 by default. See [apps/node-agent/README.md](apps/node-agent/README.md) for full API reference and configuration.
+
+## C&C Backend
+
+The command-and-control backend aggregates multiple node agents into a single API surface. Key features:
+
+- **Node management** — registration, health monitoring, heartbeat tracking
+- **Host aggregation** — unified view across all locations
+- **Command routing** — WoL, scan, update, and delete commands forwarded to the right node
+- **WebSocket protocol** — real-time bidirectional messaging with nodes
+- **JWT authentication** — role-based access (operator, admin)
+- **Dual database** — PostgreSQL for production, SQLite for development
+
+Runs on port 8080 by default. See [apps/cnc/README.md](apps/cnc/README.md) for full API reference and configuration.
+
+## Protocol Package
+
+`@kaonis/woly-protocol` defines the contract between node agents and the C&C backend:
+
+- **TypeScript types** — `NodeMessage`, `CncCommand`, `HostPayload`, `NodeRegistration`
+- **Zod schemas** — `outboundNodeMessageSchema`, `inboundCncCommandSchema` for runtime validation
+- **Protocol versioning** — `PROTOCOL_VERSION`, `SUPPORTED_PROTOCOL_VERSIONS`
+
+Both apps consume it via npm workspace link. It's also published to npm for the mobile app. See [packages/protocol/README.md](packages/protocol/README.md).
+
+## Docker
+
+Each app has its own Dockerfile optimized for the monorepo structure. Build from the repo root:
+
+```bash
+# Node agent
+docker build -f apps/node-agent/Dockerfile -t woly-node-agent .
+
+# C&C backend
+docker build -f apps/cnc/Dockerfile -t woly-cnc .
+```
+
+**Important:** The node agent requires `--net host` for ARP scanning to work:
+
+```bash
+docker run -d --net host \
+  -v $(pwd)/db:/app/apps/node-agent/db \
+  -e NODE_ENV=production \
+  woly-node-agent
+```
+
+## CI
+
+GitHub Actions runs on every push and PR to `master`:
+
+1. Install dependencies (`npm ci`)
+2. Build, lint, typecheck, and test all workspaces via Turborepo
+3. Upload coverage reports as artifacts
+
+See [.github/workflows/ci.yml](.github/workflows/ci.yml).
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Runtime | Node.js 24, TypeScript 5.9 |
+| Framework | Express 5 |
+| Databases | SQLite (better-sqlite3), PostgreSQL |
+| Testing | Jest 30, Supertest |
+| Validation | Zod, Joi |
+| Build | Turborepo, tsc |
+| CI | GitHub Actions |
+
+## Related
+
+- [WoLy Mobile App](https://github.com/kaonis/woly) — React Native / Expo client
+
+## License
+
+MIT

--- a/apps/cnc/README.md
+++ b/apps/cnc/README.md
@@ -1,6 +1,6 @@
 # WoLy C&C Backend
 
-Command & Control backend for distributed WoLy Wake-on-LAN management system. Aggregates data from multiple LAN-based node agents, enabling multi-site host management from a single mobile app.
+> Part of the [woly-server](../../README.md) monorepo. Command & Control backend that aggregates multiple node agents.
 
 ## Architecture
 
@@ -9,23 +9,20 @@ Mobile App → C&C Backend → Multiple Node Agents → LANs
 ```
 
 The C&C backend provides:
+
 - **Node Management**: Registration, health monitoring, heartbeat tracking
 - **Host Aggregation**: Unified view of hosts across all locations
 - **Command Routing**: Routes WoL commands to appropriate nodes
 - **WebSocket Communication**: Real-time bidirectional messaging with nodes
-- **Dual Database Support**: PostgreSQL for production, SQLite for development/VS Code tunnel
+- **Dual Database Support**: PostgreSQL for production, SQLite for development
 
 ## Quick Start
 
-## Contribution Workflow
-
-Use branch + PR flow for all changes. See `DEVELOPMENT_WORKFLOW.md`.
-
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 24+ (see root `.nvmrc`)
 - npm 10+
-- **PostgreSQL 16+** (optional - SQLite supported)
+- **PostgreSQL 16+** (optional — SQLite supported for dev)
 
 Use the baseline runtime for consistency:
 
@@ -33,17 +30,21 @@ Use the baseline runtime for consistency:
 nvm use
 ```
 
-### Installation
+### From monorepo root
 
 ```bash
-# Install dependencies
-npm install --legacy-peer-deps
+npm install
+cp apps/cnc/.env.example apps/cnc/.env
+npm run dev:cnc
+```
 
-# Copy environment configuration
+### Standalone
+
+```bash
+cd apps/cnc
 cp .env.example .env
-
 # Edit .env with your settings
-# Set DB_TYPE, DATABASE_URL, NODE_AUTH_TOKENS, and JWT settings
+npm run dev
 ```
 
 ### Database Setup
@@ -131,7 +132,7 @@ npm run test:coverage
 npm rebuild better-sqlite3 --build-from-source
 ```
 
-- Node.js v20+ is supported. `.nvmrc` provides a baseline local version.
+- Node.js v24+ is required. See root `.nvmrc`.
 
 ## API Endpoints
 
@@ -313,27 +314,6 @@ docker-compose down
 docker-compose up -d --build
 ```
 
-## Phase 1 Deliverables ✅
-
-- [x] Project setup with TypeScript + Express
-- [x] PostgreSQL database with schema
-- [x] Node registration endpoint
-- [x] Node authentication via tokens
-- [x] WebSocket server for node connections
-- [x] Heartbeat mechanism
-- [x] Node status tracking (online/offline)
-- [x] Admin API endpoints
-- [x] Health check endpoints
-- [x] Docker Compose setup
-- [x] Logging infrastructure
-
-## Next Steps (Phase 2)
-
-- [ ] Modify woly-backend to add agent mode
-- [ ] Implement C&C client in node agent
-- [ ] Bidirectional command execution
-- [ ] Test with 2 nodes connected
-
 ## Troubleshooting
 
 ### Database Connection Failed
@@ -362,11 +342,6 @@ pg_isready
 - Node marked offline after 90s of missed heartbeats
 - Check node agent logs for connection issues
 - Verify network connectivity between node and C&C
-
-## Documentation
-
-- [Architecture Specification](../woly/docs/DISTRIBUTED_ARCHITECTURE_SPEC.md)
-- [Implementation Roadmap](../woly/docs/DISTRIBUTED_IMPLEMENTATION_ROADMAP.md)
 
 ## License
 

--- a/apps/node-agent/README.md
+++ b/apps/node-agent/README.md
@@ -1,103 +1,58 @@
-# woly-backend
+# WoLy Node Agent
 
-[![Tests](https://github.com/kaonis/woly-backend/actions/workflows/test.yml/badge.svg)](https://github.com/kaonis/woly-backend/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/kaonis/woly-backend/branch/master/graph/badge.svg)](https://codecov.io/gh/kaonis/woly-backend)
-
-Node.js backend for [WoLy](https://github.com/kaonis/woly) - A Wake-on-LAN application with automatic network discovery.
+> Part of the [woly-server](../../README.md) monorepo. Per-LAN Wake-on-LAN agent with automatic network discovery.
 
 ## Features
 
-- 🔍 **Automatic Network Discovery** - ARP scanning with DNS/NetBIOS hostname resolution
-- 💤 **Wake-on-LAN** - Remote host wake-up via magic packets
-- 📡 **Dual Status Tracking** - Separate `status` (awake/asleep via ARP) and `pingResponsive` (ICMP) fields
-- 🔐 **Security** - Rate limiting, input validation, CORS, Helmet headers
-- 📊 **Health Monitoring** - Enhanced health checks with database status
-- 📝 **API Documentation** - Interactive Swagger UI
-- 🪵 **Structured Logging** - Winston-based logging with file rotation
-- ⚙️ **Configuration Management** - Environment-based configuration with `.env`
-- 🐳 **Docker Support** - Containerized deployment ready
-- ✅ **Testing** - 195 tests with 90% coverage (Jest + Supertest)
+- Automatic network discovery via ARP scanning with DNS/NetBIOS hostname resolution
+- Wake-on-LAN magic packet sending
+- Dual status tracking — `status` (ARP-based, reliable) and `pingResponsive` (ICMP, diagnostic)
+- Standalone or agent mode (connects to C&C backend via WebSocket)
+- Rate limiting, input validation, CORS, Helmet security headers
+- Interactive Swagger API docs at `/api-docs`
+- Structured Winston logging with file rotation
+- 240+ tests with 90%+ coverage
 
 ## Quick Start
 
 ### Prerequisites
 
-- Node.js 22+
-- npm or yarn
-- SQLite3
+- Node.js 24+ (see root `.nvmrc`)
+- npm 10+
 
-### Installation
+### From monorepo root
 
 ```bash
-# Clone the repository
-git clone https://github.com/kaonis/woly-backend.git
-cd woly-backend
-
-# Install dependencies
 npm install
-
-# Create environment file
-cp .env.example .env
-
-# Build
-npm run build
-
-# Start server
-npm start
+cp apps/node-agent/.env.example apps/node-agent/.env
+npm run dev:node-agent
 ```
 
-### Development
+### Standalone development
 
 ```bash
-# Run in development mode with auto-reload
+cd apps/node-agent
 npm run dev
 ```
 
 ## Testing
 
-This project has comprehensive test coverage with enforced thresholds:
-
-- **195 tests** across unit and integration test suites
-- **90%** statement coverage (threshold: 80%)
-- **89.5%** line coverage (threshold: 80%)
-- **76.9%** branch coverage (threshold: 70%)
-- **94.2%** function coverage (threshold: 85%)
-
-### Running Tests
+240+ tests with enforced coverage thresholds (50% branches/functions/lines/statements).
 
 ```bash
-npm test                # Run all tests
-npm run test:coverage   # Run tests with coverage report
-npm run test:watch      # Run tests in watch mode
-npm run test:unit       # Run only unit tests
-npm run test:integration # Run only integration tests
-npm run test:ci         # Run tests in CI mode
-npm run typecheck       # TypeScript checks without emitting build output
+npm test                 # All tests
+npm run test:coverage    # With coverage report
+npm run test:watch       # Watch mode
+npm run test:unit        # Unit tests only
+npm run test:integration # Integration tests only
+npm run test:ci          # CI mode
+npm run typecheck        # Type-check without emitting
 ```
 
-### Test Organization
+**Test organization:**
 
-- **Unit Tests**: Located in `__tests__/` directories alongside source files
-  - Controllers, services, middleware, validators, utilities
-- **Integration Tests**: Located in `__tests__/` at project root
-  - End-to-end API testing with supertest
-
-### Coverage Enforcement
-
-Jest is configured to enforce coverage thresholds in `jest.config.js`:
-
-- CI pipeline fails if coverage drops below thresholds
-- Coverage reports uploaded to Codecov automatically
-- HTML coverage reports available in `coverage/` directory
-
-### Writing Tests
-
-When adding new features:
-
-1. Add unit tests for business logic and utilities
-2. Add integration tests for new API endpoints
-3. Run `npm run test:coverage` to verify coverage
-4. Ensure all thresholds are met before committing
+- Unit tests: `src/**/__tests__/*.unit.test.ts` (alongside source)
+- Integration tests: `src/__tests__/*.integration.test.ts`
 
 ## Host Status Fields
 
@@ -411,92 +366,27 @@ Logs are written to:
 - `logs/combined.log` (all levels)
 - `logs/error.log` (errors only)
 
-## Development
-
-### Project Structure
+## Project Structure
 
 ```
-woly-backend/
-├── app.ts                 # Application entry point
-├── config/
-│   └── index.ts          # Configuration management
-├── controllers/
-│   └── hosts.ts          # Request handlers
-├── middleware/
-│   ├── errorHandler.ts   # Error handling
-│   ├── rateLimiter.ts    # Rate limiting
-│   └── validateRequest.ts # Input validation
-├── routes/
-│   └── hosts.ts          # Route definitions
-├── services/
-│   ├── hostDatabase.ts   # Database operations
-│   └── networkDiscovery.ts # Network scanning
-├── utils/
-│   └── logger.ts         # Logging configuration
-├── validators/
-│   └── hostValidator.ts  # Joi schemas
-├── swagger.ts            # API documentation config
-└── types.ts              # TypeScript types
+apps/node-agent/
+├── src/
+│   ├── app.ts                 # Express app + initialization
+│   ├── types.ts               # Local TypeScript types
+│   ├── swagger.ts             # OpenAPI/Swagger config
+│   ├── config/                # Environment configuration
+│   ├── controllers/           # Request handlers
+│   ├── middleware/            # Error handling, rate limiting, validation
+│   ├── routes/                # Route definitions
+│   ├── services/              # Business logic (hostDatabase, networkDiscovery, agent)
+│   ├── utils/                 # Logger
+│   └── validators/            # Joi schemas
+├── types/                     # Ambient .d.ts for untyped packages
+├── jest.config.js
+├── tsconfig.json              # Extends ../../tsconfig.base.json
+└── Dockerfile
 ```
-
-### Code Quality
-
-The project uses:
-
-- **TypeScript** for type safety
-- **ESLint** for code linting
-- **Prettier** for code formatting
-- **Husky** for pre-commit hooks
-- **lint-staged** for staged file linting
-
-### Pre-commit Hooks
-
-Before each commit:
-
-1. ESLint automatically fixes issues
-2. Prettier formats code
-3. Commit fails if linting errors remain
-
-## Recent Improvements (Phase 1-4)
-
-### ✅ Phase 1: Foundation
-
-- Environment-based configuration management
-- Winston structured logging
-- Global error handling middleware
-- CORS and Helmet security
-- Enhanced health checks
-- Docker support
-
-### ✅ Phase 2: Security & Reliability
-
-- Rate limiting on all endpoints
-- Joi input validation
-- Standardized error responses
-- Database connection retry logic
-
-### ✅ Phase 4: Documentation & DX
-
-- OpenAPI/Swagger documentation
-- Modernized ESLint configuration
-- Pre-commit hooks with Husky
-- Enhanced README
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run `npm run build` to verify
-5. Commit (pre-commit hooks will run)
-6. Push and create a pull request
 
 ## License
 
 MIT
-
-## Links
-
-- **Frontend**: https://github.com/kaonis/woly
-- **API Docs**: http://localhost:8082/api-docs (when running)
-- **Issues**: https://github.com/kaonis/woly-backend/issues

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -1,29 +1,78 @@
 # @kaonis/woly-protocol
 
-Shared protocol types and runtime schemas for communication between `woly-backend` (node agent) and `woly-cnc-backend` (C&C).
+> Part of the [woly-server](../../README.md) monorepo. Shared protocol types and Zod schemas for node agent ↔ C&C communication.
 
 ## Exports
 
-- `PROTOCOL_VERSION`
-- `SUPPORTED_PROTOCOL_VERSIONS`
-- `outboundNodeMessageSchema`
-- `inboundCncCommandSchema`
-- Type exports from `index.d.ts` (`NodeMessage`, `CncCommand`, `NodeRegistration`, etc.)
+### Types
 
-## Publish
+- `HostStatus` — `'awake' | 'asleep'`
+- `HostPayload` — Host data transmitted over the wire
+- `NodeMetadata` — Agent platform/version/network info
+- `NodeRegistration` — Registration payload sent by nodes
+- `NodeMessage` — Discriminated union of all node → C&C messages
+- `CncCommand` — Discriminated union of all C&C → node commands
+- `CommandResultPayload` — Result data for command acknowledgements
+- `RegisteredCommandData` — Server response after successful registration
 
-From the `woly-backend` repo root:
+### Zod Schemas
 
-```bash
-npm run protocol:pack
-npm run protocol:publish
+- `outboundNodeMessageSchema` — Validates `NodeMessage` at runtime
+- `inboundCncCommandSchema` — Validates `CncCommand` at runtime
+
+### Constants
+
+- `PROTOCOL_VERSION` — Current protocol version (`'1.0.0'`)
+- `SUPPORTED_PROTOCOL_VERSIONS` — Array of supported versions
+
+## Usage
+
+Both apps consume this package via npm workspace link:
+
+```json
+{
+  "dependencies": {
+    "@kaonis/woly-protocol": "*"
+  }
+}
 ```
 
-Or use the GitHub workflow: `Publish Protocol Package`.
+```typescript
+import {
+  NodeMessage,
+  CncCommand,
+  outboundNodeMessageSchema,
+  inboundCncCommandSchema,
+  PROTOCOL_VERSION,
+} from '@kaonis/woly-protocol';
 
-## Versioning
+// Validate incoming message
+const result = inboundCncCommandSchema.safeParse(JSON.parse(rawMessage));
+if (result.success) {
+  handleCommand(result.data);
+}
+```
 
-1. Bump `packages/protocol/package.json` version.
-2. Publish package.
-3. Update both repos to consume the new semver version.
-4. Run protocol contract tests in both repos before merge.
+## Building
+
+```bash
+# From monorepo root
+npm run build -w packages/protocol
+
+# Or directly
+cd packages/protocol && npx tsc
+```
+
+Output goes to `dist/`. Both `main` and `types` in package.json point there.
+
+## Publishing to npm
+
+This package is also published to npm for the mobile app to consume:
+
+```bash
+cd packages/protocol
+npm version patch
+npm publish --access public
+```
+
+The monorepo apps always use the workspace-linked source, so publishing is only needed when the mobile app needs updated types.


### PR DESCRIPTION
## Summary

- Adds root `README.md` with architecture diagram, workspace layout, commands reference, and per-app summaries
- Adds `CONTRIBUTING.md` with setup, development workflow, workspace usage, and conventions
- Rewrites `.github/copilot-instructions.md` for full monorepo context (both apps, protocol, API reference)
- Updates `apps/node-agent/README.md` — fixes stale repo URLs/badges, Node version (24+), project structure
- Updates `apps/cnc/README.md` — fixes Node version, install instructions, removes stale phase checklist
- Rewrites `packages/protocol/README.md` with exports reference, usage examples, and publishing instructions

## Test plan

- [ ] Verify all internal markdown links resolve correctly
- [ ] Confirm no stale references to old repo URLs remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)