### PR TITLE
fix(turbo): auto-build protocol before dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -181,7 +181,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1325,7 +1324,6 @@
       "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/expect": "30.2.0",
@@ -2156,7 +2154,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2613,7 +2610,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3032,7 +3028,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3855,7 +3850,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4125,7 +4119,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5203,7 +5196,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -6711,7 +6703,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test:ci": "turbo run test:ci",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
-    "dev:node-agent": "npm run dev -w apps/node-agent",
-    "dev:cnc": "npm run dev -w apps/cnc",
+    "dev:node-agent": "turbo run dev --filter=@woly-server/node-agent",
+    "dev:cnc": "turbo run dev --filter=@woly-server/cnc",
     "format": "prettier --write ."
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,7 @@
       "dependsOn": ["^build"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
## Summary
- Add `"dependsOn": ["^build"]` to the `dev` task in `turbo.json` so upstream workspace packages are built before dev starts
- Route `dev:cnc` and `dev:node-agent` through `turbo run dev --filter=...` instead of bare `npm run dev -w`, so the Turbo dependency graph is actually used
- Fixes `Cannot find module '@kaonis/woly-protocol'` errors when running `npm run dev:cnc` on a fresh clone or after cleaning `dist/`

## Test plan
- [ ] `npm run dev:cnc` on a fresh clone (without running `npm run build` first) — should auto-build protocol then start the server
- [ ] `npm run dev:node-agent` — same behavior
- [ ] Subsequent `npm run dev:cnc` runs skip the protocol build (Turbo cache hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)