### PR TITLE
fix(cnc): enable ts-node to load Express type augmentation

### DIFF
--- a/apps/cnc/tsconfig.json
+++ b/apps/cnc/tsconfig.json
@@ -5,6 +5,9 @@
     "rootDir": "./src",
     "types": ["node", "jest"]
   },
+  "ts-node": {
+    "files": true
+  },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- `npm run dev:cnc` crashed with `TS2339: Property 'auth' does not exist on type 'Request'` because `ts-node` never loaded the global type augmentation in `src/types/express.d.ts`
- Added `"ts-node": { "files": true }` to `apps/cnc/tsconfig.json` so `ts-node` respects the `include` patterns and loads all project files, matching `tsc` behavior
- `tsc --noEmit` already passed; this fix aligns dev mode with the build

## Test plan
- [x] `npx tsc --noEmit -p apps/cnc/tsconfig.json` passes
- [x] `ts-node` successfully compiles `src/middleware/auth.ts` without errors
- [ ] `npm run dev:cnc` starts without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)