### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/apps/cnc/package.json
+++ b/apps/cnc/package.json
@@ -42,7 +42,8 @@
     "uuid": "^9.0.1",
     "winston": "^3.17.0",
     "ws": "^8.18.3",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",


### PR DESCRIPTION
Potential fix for [https://github.com/kaonis/woly-server/security/code-scanning/1](https://github.com/kaonis/woly-server/security/code-scanning/1)

In general, the fix is to introduce rate-limiting middleware for routes that perform authentication/authorization and likely trigger expensive operations. In an Express setup, this is commonly done with a library like `express-rate-limit`, configuring a limiter and applying it via `router.use` or per-route as needed.

In this file, the best targeted fix without changing existing semantics is:

- Import `express-rate-limit`.
- Define at least one limiter instance near the top of `createRoutes` (or module-scope) with reasonable defaults (e.g., a window and maximum allowed requests).
- Apply a limiter to the protected route groups (`/hosts` and `/admin`) at the same place where `authenticateJwt` and `authorizeRoles` are applied, so that all these sensitive operations are rate-limited.
- Optionally use a slightly stricter limiter for `/admin` if desired, but to keep behavior simple we can use a single limiter for both groups.

Concretely:

- Modify `apps/cnc/src/routes/index.ts` imports to add `rateLimit` from `express-rate-limit`.
- Inside `createRoutes`, after `const router = Router();`, define a limiter, e.g.:

  ```ts
  const apiLimiter = rateLimit({
    windowMs: 15 * 60 * 1000,
    max: 100,
    standardHeaders: true,
    legacyHeaders: false,
  });
  ```

- Update the middleware chains for `/hosts` and `/admin` so they include `apiLimiter`:

  ```ts
  router.use('/hosts', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
  router.use('/admin', apiLimiter, authenticateJwt, authorizeRoles('admin'));
  ```

No other behavior of the handlers changes; they are simply protected by rate limiting before authentication and authorization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
