### PR TITLE
test: add mobile API compatibility smoke suite (#112)

### DIFF
--- a/apps/cnc/src/routes/__tests__/mobileCompatibility.smoke.test.ts
+++ b/apps/cnc/src/routes/__tests__/mobileCompatibility.smoke.test.ts
@@ -1,0 +1,203 @@
+import express, { Express } from 'express';
+import request from 'supertest';
+import { createRoutes } from '../index';
+import { NodeManager } from '../../services/nodeManager';
+import { HostAggregator } from '../../services/hostAggregator';
+import { CommandRouter } from '../../services/commandRouter';
+import { createToken } from './testUtils';
+import { NodeModel } from '../../models/Node';
+
+jest.mock('../../config', () => ({
+  __esModule: true,
+  default: {
+    jwtSecret: 'test-secret',
+    jwtIssuer: 'test-issuer',
+    jwtAudience: 'test-audience',
+    port: 8080,
+    dbType: 'sqlite',
+    dbPath: ':memory:',
+    nodeAuthTokens: ['test-node-token'],
+    nodeHeartbeatInterval: 30000,
+    nodeTimeout: 60000,
+    jwtTtlSeconds: 3600,
+    operatorAuthTokens: ['operator-token-123'],
+    adminAuthTokens: ['admin-token-456'],
+  },
+}));
+
+jest.mock('../../models/Node', () => ({
+  NodeModel: {
+    findAll: jest.fn(),
+    findById: jest.fn(),
+  },
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  authLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+  strictAuthLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+  apiLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+describe('Mobile API compatibility smoke checks', () => {
+  let app: Express;
+  const now = Math.floor(Date.now() / 1000);
+  const mockedNodeModel = NodeModel as jest.Mocked<typeof NodeModel>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedNodeModel.findAll.mockResolvedValue([
+      {
+        id: 'node-1',
+        name: 'Home Node',
+        location: 'Home',
+        status: 'online',
+        lastHeartbeat: new Date('2026-02-15T00:00:00.000Z'),
+        capabilities: [],
+        metadata: {
+          version: '1.0.0',
+          platform: 'darwin',
+          protocolVersion: '1.1.1',
+          networkInfo: {
+            subnet: '192.168.1.0/24',
+            gateway: '192.168.1.1',
+          },
+        },
+        createdAt: new Date('2026-02-14T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-15T00:00:00.000Z'),
+      },
+    ]);
+    mockedNodeModel.findById.mockResolvedValue(null);
+
+    const nodeManager = {
+      isNodeConnected: jest.fn().mockReturnValue(true),
+    } as unknown as NodeManager;
+
+    const hostAggregator = {
+      getAllHosts: jest.fn().mockResolvedValue([
+        {
+          name: 'Office-Mac',
+          ip: '192.168.1.10',
+          mac: '00:11:22:33:44:55',
+          status: 'awake',
+          lastSeen: '2026-02-15T00:00:00.000Z',
+          nodeId: 'node-1',
+          location: 'Home',
+          fullyQualifiedName: 'Office-Mac@Home',
+        },
+      ]),
+      getHostsByNode: jest.fn().mockResolvedValue([]),
+      getStats: jest.fn().mockResolvedValue({ total: 1, awake: 1, asleep: 0 }),
+    } as unknown as HostAggregator;
+
+    const commandRouter = {} as unknown as CommandRouter;
+
+    app = express();
+    app.use(express.json());
+    app.use('/api', createRoutes(nodeManager, hostAggregator, commandRouter));
+  });
+
+  describe('POST /api/auth/token', () => {
+    it('returns token payload compatible with woly client parser', async () => {
+      const response = await request(app)
+        .post('/api/auth/token')
+        .set('Authorization', 'Bearer operator-token-123')
+        .send({ role: 'operator' });
+
+      expect(response.status).toBe(200);
+      expect(typeof response.body.token).toBe('string');
+      expect(typeof response.body.expiresAt).toBe('string');
+      expect(new Date(response.body.expiresAt).toString()).not.toBe('Invalid Date');
+    });
+
+    it('returns auth error envelope for invalid credentials', async () => {
+      const response = await request(app)
+        .post('/api/auth/token')
+        .set('Authorization', 'Bearer invalid-token')
+        .send({ role: 'operator' });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+      expect(typeof response.body.message).toBe('string');
+    });
+  });
+
+  describe('GET /api/hosts', () => {
+    const operatorJwt = createToken({
+      sub: 'mobile-client',
+      role: 'operator',
+      iss: 'test-issuer',
+      aud: 'test-audience',
+      exp: now + 3600,
+      nbf: now - 10,
+    });
+
+    it('returns hosts payload compatible with woly HostsResponse type', async () => {
+      const response = await request(app)
+        .get('/api/hosts')
+        .set('Authorization', `Bearer ${operatorJwt}`);
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body.hosts)).toBe(true);
+      expect(response.body.hosts[0]).toMatchObject({
+        name: 'Office-Mac',
+        ip: '192.168.1.10',
+        mac: '00:11:22:33:44:55',
+        status: 'awake',
+        fullyQualifiedName: 'Office-Mac@Home',
+      });
+    });
+
+    it('returns auth error envelope when JWT is missing', async () => {
+      const response = await request(app).get('/api/hosts');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+  });
+
+  describe('GET /api/nodes', () => {
+    const operatorJwt = createToken({
+      sub: 'mobile-client',
+      role: 'operator',
+      iss: 'test-issuer',
+      aud: 'test-audience',
+      exp: now + 3600,
+      nbf: now - 10,
+    });
+
+    it('returns nodes payload compatible with woly NodesResponse type', async () => {
+      const response = await request(app)
+        .get('/api/nodes')
+        .set('Authorization', `Bearer ${operatorJwt}`);
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body.nodes)).toBe(true);
+      expect(response.body.nodes[0]).toMatchObject({
+        id: 'node-1',
+        name: 'Home Node',
+        location: 'Home',
+        status: 'online',
+        connected: true,
+      });
+    });
+
+    it('returns auth error envelope for malformed authorization header', async () => {
+      const response = await request(app)
+        .get('/api/nodes')
+        .set('Authorization', 'InvalidHeader');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+  });
+});

--- a/docs/PROTOCOL_COMPATIBILITY.md
+++ b/docs/PROTOCOL_COMPATIBILITY.md
@@ -229,6 +229,20 @@ export const SUPPORTED_PROTOCOL_VERSIONS = ['2.0.0'];
 3. Update app code to use new protocol API
 4. If breaking change is intentional, follow breaking change workflow
 
+### Cross-repo mobile API compatibility check
+
+When changing C&C auth or response payloads used by `kaonis/woly`, run the dedicated smoke suite:
+
+```bash
+npm run test -w apps/cnc -- mobileCompatibility.smoke
+```
+
+This verifies:
+- `POST /api/auth/token` response shape used by `cnc-auth-service`
+- `GET /api/hosts` response shape used by `woly-service`
+- `GET /api/nodes` response shape used by `woly-service`
+- auth failure envelopes expected by the mobile client
+
 ### Runtime: "Unsupported protocol version"
 
 **Cause**: Node agent protocol version not in C&C's `SUPPORTED_PROTOCOL_VERSIONS`

--- a/docs/ROADMAP_V1.md
+++ b/docs/ROADMAP_V1.md
@@ -61,7 +61,7 @@ Acceptance criteria:
 - Coverage threshold raised to 60% in node-agent.
 - Preflight scripts aligned with Node 24+ requirement.
 
-Status: `In Progress`
+Status: `Completed` (2026-02-15 via PR #114)
 
 ### Phase 3: Cross-repo compatibility guardrails
 Issue: #112  
@@ -72,7 +72,7 @@ Acceptance criteria:
 - Validate auth and error envelope compatibility with `kaonis/woly` service layer expectations.
 - Ensure CI fails on breaking API drift.
 
-Status: `Planned`
+Status: `In Progress`
 
 ### Phase 4: Node-agent security and API parity
 Issues:
@@ -108,4 +108,7 @@ For each issue phase:
 - 2026-02-15: Merged PR #113 (`fix: remove unused monorepo dependencies (#86)`).
 - 2026-02-15: Verified post-merge `master` CI and CodeQL runs are green.
 - 2026-02-15: Started Phase 2 implementation on issue #93 (`fix/93-testing-hardening`).
-- Next: Open and merge PR for #93, then continue to #112.
+- 2026-02-15: Merged PR #114 (`test: harden protocol/CORS coverage checks (#93)`).
+- 2026-02-15: Verified post-merge `master` CI and CodeQL runs are green.
+- 2026-02-15: Started Phase 3 implementation on issue #112 (`test/112-mobile-compat-smoke`).
+- Next: Open and merge PR for #112, then continue to Phase 4.


### PR DESCRIPTION
## Summary
- add dedicated CNC smoke checks for `kaonis/woly` compatibility at:
  - `POST /api/auth/token`
  - `GET /api/hosts`
  - `GET /api/nodes`
- validate auth failure envelopes expected by the mobile client
- document the compatibility smoke command in `docs/PROTOCOL_COMPATIBILITY.md`
- update `docs/ROADMAP_V1.md` progress for Phase 3

## Validation
- `npm run test -w apps/cnc -- mobileCompatibility.smoke`
- `npm run build`
- `npm run typecheck`
- `npm run test:ci`

Closes #112
