### PR TITLE
fix: restrict default CORS and rate-limit health endpoint (#83)

### DIFF
--- a/apps/node-agent/src/config/__tests__/corsConfig.unit.test.ts
+++ b/apps/node-agent/src/config/__tests__/corsConfig.unit.test.ts
@@ -1,0 +1,42 @@
+describe('CORS config defaults', () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.resetModules();
+  });
+
+  it('defaults to wildcard in non-production when CORS_ORIGINS is unset', () => {
+    process.env = { ...originalEnv, NODE_ENV: 'development', CORS_ORIGINS: '' };
+
+    jest.isolateModules(() => {
+      const { config } = require('../index');
+      expect(config.cors.origins).toEqual(['*']);
+    });
+  });
+
+  it('defaults to empty list in production when CORS_ORIGINS is unset', () => {
+    process.env = { ...originalEnv, NODE_ENV: 'production', CORS_ORIGINS: '' };
+
+    jest.isolateModules(() => {
+      const { config } = require('../index');
+      expect(config.cors.origins).toEqual([]);
+    });
+  });
+
+  it('parses configured origins in production', () => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'production',
+      CORS_ORIGINS: 'https://app.example.com, https://ops.example.com ',
+    };
+
+    jest.isolateModules(() => {
+      const { config } = require('../index');
+      expect(config.cors.origins).toEqual([
+        'https://app.example.com',
+        'https://ops.example.com',
+      ]);
+    });
+  });
+});

--- a/apps/node-agent/src/config/index.ts
+++ b/apps/node-agent/src/config/index.ts
@@ -3,6 +3,13 @@ import dotenv from 'dotenv';
 // Load environment variables from .env file
 dotenv.config();
 
+const parsedCorsOrigins = process.env.CORS_ORIGINS
+  ?.split(',')
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+
+const defaultCorsOrigins = process.env.NODE_ENV === 'production' ? [] : ['*'];
+
 export const config = {
   server: {
     port: parseInt(process.env.PORT || '8082', 10),
@@ -26,7 +33,9 @@ export const config = {
     macVendorRateLimit: parseInt(process.env.MAC_VENDOR_RATE_LIMIT || '1000', 10), // 1 second
   },
   cors: {
-    origins: process.env.CORS_ORIGINS?.split(',') || ['*'],
+    origins: parsedCorsOrigins && parsedCorsOrigins.length > 0
+      ? parsedCorsOrigins
+      : defaultCorsOrigins,
   },
   logging: {
     level: process.env.LOG_LEVEL || 'info',

--- a/apps/node-agent/src/middleware/__tests__/rateLimiter.unit.test.ts
+++ b/apps/node-agent/src/middleware/__tests__/rateLimiter.unit.test.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { apiLimiter, scanLimiter, wakeLimiter } from '../rateLimiter';
+import { apiLimiter, healthLimiter, scanLimiter, wakeLimiter } from '../rateLimiter';
 
 // Mock logger
 jest.mock('../../utils/logger', () => ({
@@ -64,6 +64,17 @@ describe('rateLimiter middleware', () => {
     it('should be a middleware function', () => {
       // Rate limiters from express-rate-limit are middleware functions
       expect(wakeLimiter.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('healthLimiter', () => {
+    it('should be defined', () => {
+      expect(healthLimiter).toBeDefined();
+      expect(typeof healthLimiter).toBe('function');
+    });
+
+    it('should be a middleware function', () => {
+      expect(healthLimiter.length).toBeGreaterThanOrEqual(2);
     });
   });
 });

--- a/apps/node-agent/src/middleware/rateLimiter.ts
+++ b/apps/node-agent/src/middleware/rateLimiter.ts
@@ -70,3 +70,25 @@ export const wakeLimiter = rateLimit({
     });
   },
 });
+
+/**
+ * Health check rate limiter
+ * Generous limit to reduce accidental DoS while keeping monitoring friendly
+ */
+export const healthLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60,
+  message: {
+    error: 'Too many health check requests. Please try again later.',
+    retryAfter: '1 minute',
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logger.warn(`Health endpoint rate limit exceeded for IP: ${req.ip}`);
+    res.status(429).json({
+      error: 'Too many health check requests. Please try again later.',
+      retryAfter: '1 minute',
+    });
+  },
+});

--- a/docs/ROADMAP_V1.md
+++ b/docs/ROADMAP_V1.md
@@ -72,7 +72,7 @@ Acceptance criteria:
 - Validate auth and error envelope compatibility with `kaonis/woly` service layer expectations.
 - Ensure CI fails on breaking API drift.
 
-Status: `In Progress`
+Status: `Completed` (2026-02-15 via PR #115)
 
 ### Phase 4: Node-agent security and API parity
 Issues:
@@ -83,7 +83,7 @@ Acceptance criteria:
 - Restrictive default CORS in production and health endpoint rate limiting (#83).
 - Standalone REST `PUT /hosts/:name` and `DELETE /hosts/:name` with tests/docs (#89).
 
-Status: `Planned`
+Status: `In Progress` (starting with #83)
 
 ## 3. Execution Loop Rules for V1
 
@@ -111,4 +111,7 @@ For each issue phase:
 - 2026-02-15: Merged PR #114 (`test: harden protocol/CORS coverage checks (#93)`).
 - 2026-02-15: Verified post-merge `master` CI and CodeQL runs are green.
 - 2026-02-15: Started Phase 3 implementation on issue #112 (`test/112-mobile-compat-smoke`).
-- Next: Open and merge PR for #112, then continue to Phase 4.
+- 2026-02-15: Merged PR #115 (`test: add mobile API compatibility smoke suite (#112)`).
+- 2026-02-15: Verified post-merge `master` CI and CodeQL runs are green.
+- 2026-02-15: Started Phase 4 implementation on issue #83 (`fix/83-node-agent-cors-health-hardening`).
+- Next: Open and merge PR for #83, then continue to #89.


### PR DESCRIPTION
## Summary
- default `config.cors.origins` to `[]` in production when `CORS_ORIGINS` is not configured
- keep development default as `['*']`
- add startup warning when production runs without configured `CORS_ORIGINS`
- add `healthLimiter` middleware (60 req/min) and apply it to `GET /health`
- add/extend unit coverage for CORS config defaults and rate limiter exports
- update `docs/ROADMAP_V1.md` Phase 4 progress

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run test:ci`

Closes #83
