### PR TITLE
fix: add standalone REST update/delete host endpoints (#89)

### DIFF
--- a/apps/node-agent/src/__tests__/apiKeyAuth.integration.test.ts
+++ b/apps/node-agent/src/__tests__/apiKeyAuth.integration.test.ts
@@ -183,6 +183,17 @@ describe('API Key Authentication Integration Tests', () => {
           .set('Authorization', 'Bearer wrong-key')
           .expect(401);
       });
+
+      it('should reject PUT /hosts/:name without Authorization header', async () => {
+        await request(app)
+          .put('/hosts/TEST-HOST-AUTH2')
+          .send({ ip: '192.168.1.222' })
+          .expect(401);
+      });
+
+      it('should reject DELETE /hosts/:name without Authorization header', async () => {
+        await request(app).delete('/hosts/TEST-HOST-AUTH2').expect(401);
+      });
     });
 
     describe('authorized requests', () => {
@@ -251,6 +262,25 @@ describe('API Key Authentication Integration Tests', () => {
           .expect((res) => {
             // Accept 200 (success), 204 (no content), 429 (rate limit), or 500 (vendor lookup error in test env)
             expect([200, 204, 429, 500]).toContain(res.status);
+          });
+      });
+
+      it('should allow PUT /hosts/:name with valid API key', async () => {
+        await request(app)
+          .put('/hosts/TEST-HOST-AUTH2')
+          .set('Authorization', `Bearer ${validApiKey}`)
+          .send({ ip: '192.168.1.202' })
+          .expect((res) => {
+            expect([200, 404, 409]).toContain(res.status);
+          });
+      });
+
+      it('should allow DELETE /hosts/:name with valid API key', async () => {
+        await request(app)
+          .delete('/hosts/TEST-HOST-AUTH2')
+          .set('Authorization', `Bearer ${validApiKey}`)
+          .expect((res) => {
+            expect([200, 404]).toContain(res.status);
           });
       });
     });

--- a/apps/node-agent/src/middleware/validateRequest.ts
+++ b/apps/node-agent/src/middleware/validateRequest.ts
@@ -14,7 +14,7 @@ export type ValidationTarget = 'body' | 'params' | 'query';
  * @param target - Which part of the request to validate (body, params, or query)
  * @returns Express middleware function
  */
-export const validateRequest = (schema: z.ZodObject<z.ZodRawShape>, target: ValidationTarget = 'body') => {
+export const validateRequest = (schema: z.ZodTypeAny, target: ValidationTarget = 'body') => {
   return (req: Request, _res: Response, next: NextFunction) => {
     const dataToValidate = req[target];
 

--- a/apps/node-agent/src/routes/hosts.ts
+++ b/apps/node-agent/src/routes/hosts.ts
@@ -4,6 +4,8 @@ import { apiLimiter, scanLimiter, wakeLimiter } from '../middleware/rateLimiter'
 import { validateRequest } from '../middleware/validateRequest';
 import { apiKeyAuth } from '../middleware/apiKeyAuth';
 import {
+  addHostSchema,
+  deleteHostSchema,
   hostNameParamSchema,
   macAddressSchema,
   updateHostSchema,
@@ -24,7 +26,7 @@ router.get('/', hostsController.getAllHosts);
 router.post('/scan', scanLimiter, hostsController.scanNetwork);
 
 // Add a new host manually (with validation)
-router.post('/', validateRequest(updateHostSchema, 'body'), hostsController.addHost);
+router.post('/', validateRequest(addHostSchema, 'body'), hostsController.addHost);
 
 // Get MAC address vendor information (with validation)
 router.get(
@@ -42,6 +44,21 @@ router.post(
   wakeLimiter,
   validateRequest(hostNameParamSchema, 'params'),
   hostsController.wakeUpHost
+);
+
+// Update a specific host
+router.put(
+  '/:name',
+  validateRequest(hostNameParamSchema, 'params'),
+  validateRequest(updateHostSchema, 'body'),
+  hostsController.updateHost
+);
+
+// Delete a specific host
+router.delete(
+  '/:name',
+  validateRequest(deleteHostSchema, 'params'),
+  hostsController.deleteHost
 );
 
 export default router;

--- a/apps/node-agent/src/services/__tests__/agentService.unit.test.ts
+++ b/apps/node-agent/src/services/__tests__/agentService.unit.test.ts
@@ -570,6 +570,7 @@ describe('AgentService command handlers', () => {
     service.setHostDatabase((dbEmitter as unknown) as any);
     dbEmitter.emit('host-discovered', sampleHost);
     dbEmitter.emit('host-updated', sampleHost);
+    dbEmitter.emit('host-removed', sampleHost.name);
     dbEmitter.emit('scan-complete', 9);
 
     expect(mockCncClient.send).toHaveBeenCalledWith(
@@ -577,6 +578,12 @@ describe('AgentService command handlers', () => {
     );
     expect(mockCncClient.send).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'host-updated' })
+    );
+    expect(mockCncClient.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'host-removed',
+        data: expect.objectContaining({ name: sampleHost.name }),
+      })
     );
     expect(mockCncClient.send).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/node-agent/src/services/agentService.ts
+++ b/apps/node-agent/src/services/agentService.ts
@@ -50,6 +50,10 @@ export class AgentService extends EventEmitter {
       this.sendHostUpdated(host);
     });
 
+    this.hostDb.on('host-removed', (hostName: string) => {
+      this.sendHostRemoved(hostName);
+    });
+
     this.hostDb.on('scan-complete', (hostCount: number) => {
       this.sendScanComplete(hostCount);
     });

--- a/apps/node-agent/src/validators/__tests__/hostValidator.unit.test.ts
+++ b/apps/node-agent/src/validators/__tests__/hostValidator.unit.test.ts
@@ -1,4 +1,5 @@
 import {
+  addHostSchema,
   deleteHostSchema,
   hostNameParamSchema,
   macAddressSchema,
@@ -7,250 +8,84 @@ import {
 
 describe('hostValidator schemas', () => {
   describe('macAddressSchema', () => {
-    it('should validate correct MAC address with colons', () => {
-      const result = macAddressSchema.safeParse({ mac: 'AA:BB:CC:DD:EE:FF' });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.mac).toBe('AA:BB:CC:DD:EE:FF');
-      }
+    it('accepts valid MAC formats', () => {
+      expect(macAddressSchema.safeParse({ mac: 'AA:BB:CC:DD:EE:FF' }).success).toBe(true);
+      expect(macAddressSchema.safeParse({ mac: 'AA-BB-CC-DD-EE-FF' }).success).toBe(true);
     });
 
-    it('should validate correct MAC address with hyphens', () => {
-      const result = macAddressSchema.safeParse({ mac: 'AA-BB-CC-DD-EE-FF' });
-      expect(result.success).toBe(true);
+    it('rejects invalid MAC', () => {
+      expect(macAddressSchema.safeParse({ mac: 'INVALID' }).success).toBe(false);
     });
+  });
 
-    it('should validate lowercase MAC address', () => {
-      const result = macAddressSchema.safeParse({ mac: 'aa:bb:cc:dd:ee:ff' });
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate mixed case MAC address', () => {
-      const result = macAddressSchema.safeParse({ mac: 'Aa:Bb:Cc:Dd:Ee:Ff' });
+  describe('addHostSchema', () => {
+    it('validates complete host payload', () => {
+      const result = addHostSchema.safeParse({
+        name: 'TestHost',
+        ip: '192.168.1.100',
+        mac: 'AA:BB:CC:DD:EE:FF',
+      });
       expect(result.success).toBe(true);
     });
 
-    it('should reject invalid MAC address format', () => {
-      const result = macAddressSchema.safeParse({ mac: 'INVALID' });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toContain('MAC address must be in format');
-      }
-    });
-
-    it('should reject MAC address with wrong separator', () => {
-      const result = macAddressSchema.safeParse({ mac: 'AA.BB.CC.DD.EE.FF' });
-      expect(result.success).toBe(false);
-    });
-
-    it('should reject MAC address with too few octets', () => {
-      const result = macAddressSchema.safeParse({ mac: 'AA:BB:CC:DD:EE' });
-      expect(result.success).toBe(false);
-    });
-
-    it('should reject MAC address with too many octets', () => {
-      const result = macAddressSchema.safeParse({ mac: 'AA:BB:CC:DD:EE:FF:00' });
-      expect(result.success).toBe(false);
-    });
-
-    it('should reject missing MAC address', () => {
-      const result = macAddressSchema.safeParse({});
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toContain('Required');
-      }
+    it('rejects missing required fields', () => {
+      expect(addHostSchema.safeParse({ name: 'TestHost' }).success).toBe(false);
+      expect(addHostSchema.safeParse({ ip: '192.168.1.100' }).success).toBe(false);
+      expect(addHostSchema.safeParse({ mac: 'AA:BB:CC:DD:EE:FF' }).success).toBe(false);
     });
   });
 
   describe('updateHostSchema', () => {
-    it('should validate complete host data', () => {
-      const result = updateHostSchema.safeParse({
-        name: 'TestHost',
-        ip: '192.168.1.100',
-        mac: 'AA:BB:CC:DD:EE:FF',
-      });
-      expect(result.success).toBe(true);
+    it('accepts partial updates', () => {
+      expect(updateHostSchema.safeParse({ name: 'Renamed' }).success).toBe(true);
+      expect(updateHostSchema.safeParse({ ip: '192.168.1.222' }).success).toBe(true);
+      expect(updateHostSchema.safeParse({ mac: 'AA:BB:CC:DD:EE:11' }).success).toBe(true);
     });
 
-    it('should validate IPv6 address', () => {
+    it('accepts combined updates', () => {
       const result = updateHostSchema.safeParse({
-        name: 'TestHost',
-        ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-        mac: 'AA:BB:CC:DD:EE:FF',
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it('should trim hostname whitespace', () => {
-      const result = updateHostSchema.safeParse({
-        name: '  TestHost  ',
-        ip: '192.168.1.100',
-        mac: 'AA:BB:CC:DD:EE:FF',
+        name: 'Renamed',
+        ip: '192.168.1.222',
+        mac: 'AA:BB:CC:DD:EE:11',
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.name).toBe('TestHost');
+        expect(result.data.name).toBe('Renamed');
       }
     });
 
-    it('should reject empty hostname', () => {
-      const result = updateHostSchema.safeParse({
-        name: '',
-        ip: '192.168.1.100',
-        mac: 'AA:BB:CC:DD:EE:FF',
-      });
+    it('rejects empty update payload', () => {
+      const result = updateHostSchema.safeParse({});
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.errors[0].message).toContain('at least 1 character');
+        expect(result.error.errors[0]?.message).toContain('At least one field is required');
       }
     });
 
-    it('should reject hostname longer than 255 characters', () => {
-      const result = updateHostSchema.safeParse({
-        name: 'a'.repeat(256),
-        ip: '192.168.1.100',
-        mac: 'AA:BB:CC:DD:EE:FF',
-      });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toContain('not exceed 255 characters');
-      }
-    });
-
-    it('should reject invalid IP address', () => {
-      const result = updateHostSchema.safeParse({
-        name: 'TestHost',
-        ip: '999.999.999.999',
-        mac: 'AA:BB:CC:DD:EE:FF',
-      });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toContain('valid IPv4 or IPv6 address');
-      }
-    });
-
-    it('should reject missing name', () => {
-      const result = updateHostSchema.safeParse({
-        ip: '192.168.1.100',
-        mac: 'AA:BB:CC:DD:EE:FF',
-      });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toContain('Required');
-      }
-    });
-
-    it('should reject missing IP', () => {
-      const result = updateHostSchema.safeParse({
-        name: 'TestHost',
-        mac: 'AA:BB:CC:DD:EE:FF',
-      });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toContain('Required');
-      }
-    });
-
-    it('should reject missing MAC', () => {
-      const result = updateHostSchema.safeParse({
-        name: 'TestHost',
-        ip: '192.168.1.100',
-      });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toContain('Required');
-      }
+    it('rejects invalid field values', () => {
+      expect(updateHostSchema.safeParse({ ip: '999.999.999.999' }).success).toBe(false);
+      expect(updateHostSchema.safeParse({ mac: 'INVALID' }).success).toBe(false);
+      expect(updateHostSchema.safeParse({ name: '' }).success).toBe(false);
     });
   });
 
   describe('hostNameParamSchema', () => {
-    it('should validate host name parameter', () => {
-      const result = hostNameParamSchema.safeParse({ name: 'PHANTOM-MBP' });
-      expect(result.success).toBe(true);
-    });
-
-    it('should trim host name parameter', () => {
+    it('validates and trims host name', () => {
       const result = hostNameParamSchema.safeParse({ name: '  PHANTOM-MBP  ' });
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.name).toBe('PHANTOM-MBP');
       }
     });
-
-    it('should reject missing host name', () => {
-      const result = hostNameParamSchema.safeParse({});
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toContain('Required');
-      }
-    });
   });
 
   describe('deleteHostSchema', () => {
-    it('should validate MAC address', () => {
-      const result = deleteHostSchema.safeParse({ macAddress: 'AA:BB:CC:DD:EE:FF' });
-      expect(result.success).toBe(true);
+    it('validates delete params by host name', () => {
+      expect(deleteHostSchema.safeParse({ name: 'PHANTOM-MBP' }).success).toBe(true);
     });
 
-    it('should accept MAC address with hyphens', () => {
-      const result = deleteHostSchema.safeParse({ macAddress: 'AA-BB-CC-DD-EE-FF' });
-      expect(result.success).toBe(true);
-    });
-
-    it('should reject invalid MAC address', () => {
-      const result = deleteHostSchema.safeParse({ macAddress: 'INVALID' });
-      expect(result.success).toBe(false);
-    });
-
-    it('should reject missing MAC address', () => {
-      const result = deleteHostSchema.safeParse({});
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toContain('Required');
-      }
-    });
-  });
-
-  describe('edge cases', () => {
-    it('should handle extra fields with updateHostSchema', () => {
-      const result = updateHostSchema.safeParse({
-        name: 'TestHost',
-        ip: '192.168.1.100',
-        mac: 'AA:BB:CC:DD:EE:FF',
-        extraField: 'should be stripped',
-      });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data).not.toHaveProperty('extraField');
-      }
-    });
-
-    it('should validate MAC address with all zeros', () => {
-      const result = macAddressSchema.safeParse({ mac: '00:00:00:00:00:00' });
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate MAC address with all Fs', () => {
-      const result = macAddressSchema.safeParse({ mac: 'FF:FF:FF:FF:FF:FF' });
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate localhost IP', () => {
-      const result = updateHostSchema.safeParse({
-        name: 'Localhost',
-        ip: '127.0.0.1',
-        mac: 'AA:BB:CC:DD:EE:FF',
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate broadcast IP', () => {
-      const result = updateHostSchema.safeParse({
-        name: 'Broadcast',
-        ip: '255.255.255.255',
-        mac: 'FF:FF:FF:FF:FF:FF',
-      });
-      expect(result.success).toBe(true);
+    it('rejects missing name', () => {
+      expect(deleteHostSchema.safeParse({}).success).toBe(false);
     });
   });
 });

--- a/apps/node-agent/src/validators/hostValidator.ts
+++ b/apps/node-agent/src/validators/hostValidator.ts
@@ -14,13 +14,37 @@ export const macAddressSchema = z.object({
 });
 
 /**
- * Schema for validating host creation/update data
+ * Schema for validating host creation data
  */
-export const updateHostSchema = z.object({
+export const addHostSchema = z.object({
   name: z.string().min(1, 'Hostname must be at least 1 character').max(255, 'Hostname must not exceed 255 characters').trim(),
   ip: z.string().ip('IP address must be a valid IPv4 or IPv6 address'),
   mac: z.string().regex(macAddressPattern, 'MAC address must be in format XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX'),
 });
+
+/**
+ * Schema for validating partial host update data
+ */
+export const updateHostSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, 'Hostname must be at least 1 character')
+      .max(255, 'Hostname must not exceed 255 characters')
+      .trim()
+      .optional(),
+    ip: z.string().ip('IP address must be a valid IPv4 or IPv6 address').optional(),
+    mac: z
+      .string()
+      .regex(
+        macAddressPattern,
+        'MAC address must be in format XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX'
+      )
+      .optional(),
+  })
+  .refine((value) => value.name !== undefined || value.ip !== undefined || value.mac !== undefined, {
+    message: 'At least one field is required: name, ip, or mac',
+  });
 
 /**
  * Schema for validating host name path parameter
@@ -33,5 +57,9 @@ export const hostNameParamSchema = z.object({
  * Schema for validating delete host request
  */
 export const deleteHostSchema = z.object({
-  macAddress: z.string().regex(macAddressPattern, 'MAC address must be in format XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX'),
+  name: z
+    .string()
+    .min(1, 'Hostname must be at least 1 character')
+    .max(255, 'Hostname must not exceed 255 characters')
+    .trim(),
 });

--- a/docs/ROADMAP_V1.md
+++ b/docs/ROADMAP_V1.md
@@ -114,4 +114,7 @@ For each issue phase:
 - 2026-02-15: Merged PR #115 (`test: add mobile API compatibility smoke suite (#112)`).
 - 2026-02-15: Verified post-merge `master` CI and CodeQL runs are green.
 - 2026-02-15: Started Phase 4 implementation on issue #83 (`fix/83-node-agent-cors-health-hardening`).
-- Next: Open and merge PR for #83, then continue to #89.
+- 2026-02-15: Merged PR #116 (`fix: restrict default CORS and rate-limit health endpoint (#83)`).
+- 2026-02-15: Verified post-merge `master` CI and CodeQL runs are green.
+- 2026-02-15: Started remaining Phase 4 implementation on issue #89 (`fix/89-node-agent-rest-update-delete`).
+- Next: Open and merge PR for #89.


### PR DESCRIPTION
## Summary
- add PUT /hosts/:name and DELETE /hosts/:name standalone REST endpoints in node-agent
- update validators and request middleware to support partial update payload validation and delete-name param validation
- forward host-removed events through agent mode and extend unit/integration coverage
- update roadmap progress log for Phase 4 issue #89

Closes #89

## Validation
- npm run typecheck
- npm run test:ci
