### PR TITLE
feat(node-agent): extract scan orchestrator from HostDatabase (#85)

### DIFF
--- a/apps/node-agent/src/__tests__/api.integration.test.ts
+++ b/apps/node-agent/src/__tests__/api.integration.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import express from 'express';
 import HostDatabase from '../services/hostDatabase';
+import ScanOrchestrator from '../services/scanOrchestrator';
 import hosts from '../routes/hosts';
 import * as hostsController from '../controllers/hosts';
 import * as networkDiscovery from '../services/networkDiscovery';
@@ -16,6 +17,7 @@ jest.mock('axios');
 describe('API Integration Tests', () => {
   let app: express.Application;
   let db: HostDatabase;
+  let scanOrchestrator: ScanOrchestrator;
 
   beforeAll(async () => {
     // Setup express app
@@ -25,9 +27,11 @@ describe('API Integration Tests', () => {
     // Setup in-memory database
     db = new HostDatabase(':memory:');
     await db.initialize();
+    scanOrchestrator = new ScanOrchestrator(db);
 
     // Inject database into controller
     hostsController.setHostDatabase(db);
+    hostsController.setScanOrchestrator(scanOrchestrator);
 
     // Setup routes
     app.use('/hosts', hosts);
@@ -43,6 +47,7 @@ describe('API Integration Tests', () => {
   });
 
   afterAll(async () => {
+    scanOrchestrator.stopPeriodicSync();
     await db.close();
   });
 

--- a/apps/node-agent/src/__tests__/app.unit.test.ts
+++ b/apps/node-agent/src/__tests__/app.unit.test.ts
@@ -124,7 +124,7 @@ describe('App initialization and health endpoint', () => {
       const mockDb = new HostDatabase(':memory:');
       expect(mockDb).toBeDefined();
       expect(mockDb.initialize).toBeDefined();
-      expect(mockDb.startPeriodicSync).toBeDefined();
+      expect(mockDb.close).toBeDefined();
     });
   });
 

--- a/apps/node-agent/src/services/__tests__/scanOrchestrator.unit.test.ts
+++ b/apps/node-agent/src/services/__tests__/scanOrchestrator.unit.test.ts
@@ -1,0 +1,95 @@
+import HostDatabase from '../hostDatabase';
+import * as networkDiscovery from '../networkDiscovery';
+import ScanOrchestrator from '../scanOrchestrator';
+import { logger } from '../../utils/logger';
+
+jest.mock('../networkDiscovery');
+jest.mock('../../utils/logger');
+jest.mock('../../config', () => ({
+  config: {
+    server: {
+      env: 'test',
+    },
+    network: {
+      scanInterval: 300000,
+      scanDelay: 5000,
+      pingTimeout: 2000,
+      pingConcurrency: 10,
+      usePingValidation: false,
+    },
+    logging: {
+      level: 'info',
+    },
+  },
+}));
+
+describe('ScanOrchestrator', () => {
+  let db: HostDatabase;
+  let scanOrchestrator: ScanOrchestrator;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    db = new HostDatabase(':memory:');
+    await db.initialize();
+    scanOrchestrator = new ScanOrchestrator(db);
+    (networkDiscovery.formatMAC as jest.Mock).mockImplementation((mac: string) =>
+      mac.toUpperCase().replace(/-/g, ':')
+    );
+  });
+
+  afterEach(async () => {
+    scanOrchestrator.stopPeriodicSync();
+    await db.close();
+  });
+
+  it('tracks scan state and updates last scan timestamp', async () => {
+    let resolveScan: ((hosts: unknown[]) => void) | undefined;
+    (networkDiscovery.scanNetworkARP as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve;
+        })
+    );
+
+    const scanPromise = scanOrchestrator.syncWithNetwork();
+    expect(scanOrchestrator.isScanInProgress()).toBe(true);
+
+    resolveScan?.([]);
+    await scanPromise;
+
+    expect(scanOrchestrator.isScanInProgress()).toBe(false);
+    expect(scanOrchestrator.getLastScanTime()).not.toBeNull();
+  });
+
+  it('skips concurrent scans', async () => {
+    let resolveScan: ((hosts: unknown[]) => void) | undefined;
+    (networkDiscovery.scanNetworkARP as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve;
+        })
+    );
+
+    const firstScan = scanOrchestrator.syncWithNetwork();
+    await scanOrchestrator.syncWithNetwork();
+    resolveScan?.([]);
+    await firstScan;
+
+    expect(networkDiscovery.scanNetworkARP).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('Scan already in progress, skipping...');
+  });
+
+  it('runs and cancels periodic scans', () => {
+    jest.useFakeTimers();
+    (networkDiscovery.scanNetworkARP as jest.Mock).mockResolvedValue([]);
+
+    scanOrchestrator.startPeriodicSync(10000, false);
+    jest.advanceTimersByTime(5000);
+    expect(networkDiscovery.scanNetworkARP).toHaveBeenCalledTimes(1);
+
+    scanOrchestrator.stopPeriodicSync();
+    jest.advanceTimersByTime(20000);
+    expect(networkDiscovery.scanNetworkARP).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+});

--- a/apps/node-agent/src/services/scanOrchestrator.ts
+++ b/apps/node-agent/src/services/scanOrchestrator.ts
@@ -1,0 +1,178 @@
+import { config } from '../config';
+import { Host, DiscoveredHost } from '../types';
+import { logger } from '../utils/logger';
+import HostDatabase from './hostDatabase';
+import * as networkDiscovery from './networkDiscovery';
+
+type NetworkDiscoveryDeps = Pick<
+  typeof networkDiscovery,
+  'scanNetworkARP' | 'isHostAlive' | 'formatMAC'
+>;
+
+/**
+ * Coordinates network scans independently from database CRUD operations.
+ */
+class ScanOrchestrator {
+  private syncInterval?: NodeJS.Timeout;
+  private deferredSyncTimeout?: NodeJS.Timeout;
+  private scanInProgress = false;
+  private lastScanTime: Date | null = null;
+
+  constructor(
+    private readonly hostDb: HostDatabase,
+    private readonly discovery: NetworkDiscoveryDeps = networkDiscovery
+  ) {}
+
+  isScanInProgress(): boolean {
+    return this.scanInProgress;
+  }
+
+  getLastScanTime(): string | null {
+    return this.lastScanTime ? this.lastScanTime.toISOString() : null;
+  }
+
+  async syncWithNetwork(): Promise<void> {
+    if (this.scanInProgress) {
+      logger.info('Scan already in progress, skipping...');
+      return;
+    }
+
+    this.scanInProgress = true;
+
+    try {
+      logger.info('Starting network scan...');
+      const discoveredHosts = await this.discovery.scanNetworkARP();
+
+      if (discoveredHosts.length === 0) {
+        logger.info('No hosts discovered in network scan');
+        return;
+      }
+
+      logger.info(`Discovered ${discoveredHosts.length} hosts on network`);
+
+      let newHostCount = 0;
+      let updatedHostCount = 0;
+      let awakeCount = 0;
+
+      const pingConcurrency = config.network.pingConcurrency;
+      const hostsWithPingResults: Array<{
+        host: DiscoveredHost;
+        pingResponsive: number | null;
+        status: Host['status'];
+      }> = [];
+
+      for (let i = 0; i < discoveredHosts.length; i += pingConcurrency) {
+        const batch = discoveredHosts.slice(i, i + pingConcurrency);
+
+        const batchResults = await Promise.all(
+          batch.map(async (host) => {
+            let isAlive: boolean;
+
+            const pingResult = await this.discovery.isHostAlive(host.ip);
+            const pingResponsive = pingResult ? 1 : 0;
+
+            if (config.network.usePingValidation) {
+              isAlive = pingResult;
+              if (!isAlive) {
+                logger.debug(
+                  `Host ${host.ip} found via ARP but did not respond to ping - marking as asleep`
+                );
+              }
+            } else {
+              isAlive = true;
+            }
+
+            const status: Host['status'] = isAlive ? 'awake' : 'asleep';
+
+            return { host, pingResponsive, status };
+          })
+        );
+
+        hostsWithPingResults.push(...batchResults);
+      }
+
+      for (const { host, pingResponsive, status } of hostsWithPingResults) {
+        const formattedMac = this.discovery.formatMAC(host.mac);
+
+        if (status === 'awake') {
+          awakeCount++;
+        }
+
+        try {
+          await this.hostDb.updateHostSeen(formattedMac, status, pingResponsive);
+          updatedHostCount++;
+
+          const hostByMac = await this.hostDb.getHostByMAC(formattedMac);
+          if (hostByMac) {
+            this.hostDb.emit('host-updated', hostByMac);
+          }
+        } catch {
+          try {
+            const hostName = host.hostname ?? `device-${host.ip.replace(/\./g, '-')}`;
+
+            await this.hostDb.addHost(hostName, formattedMac, host.ip);
+            await this.hostDb.updateHostStatus(hostName, status);
+            await this.hostDb.updateHostSeen(formattedMac, status, pingResponsive);
+            newHostCount++;
+
+            const newHost = await this.hostDb.getHost(hostName);
+            if (newHost) {
+              this.hostDb.emit('host-discovered', newHost);
+            }
+          } catch (addErr) {
+            logger.debug(`Could not add discovered host ${formattedMac}:`, {
+              error: (addErr as Error).message,
+            });
+          }
+        }
+      }
+
+      logger.info(
+        `Network sync complete: ${updatedHostCount} updated, ${newHostCount} new hosts, ${awakeCount} awake`
+      );
+
+      const allHosts = await this.hostDb.getAllHosts();
+      this.hostDb.emit('scan-complete', allHosts.length);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error(`Network sync error: ${message}`);
+    } finally {
+      this.scanInProgress = false;
+      this.lastScanTime = new Date();
+    }
+  }
+
+  startPeriodicSync(intervalMs: number = 5 * 60 * 1000, immediateSync: boolean = false): void {
+    logger.info(`Starting periodic network sync every ${intervalMs / 1000}s`);
+
+    if (immediateSync) {
+      this.syncWithNetwork();
+    } else {
+      logger.info(
+        `Deferring initial network scan to background (${config.network.scanDelay / 1000} seconds)`
+      );
+      this.deferredSyncTimeout = setTimeout(() => {
+        logger.info('Running deferred initial network scan...');
+        this.syncWithNetwork();
+      }, config.network.scanDelay);
+    }
+
+    this.syncInterval = setInterval(() => {
+      this.syncWithNetwork();
+    }, intervalMs);
+  }
+
+  stopPeriodicSync(): void {
+    if (this.deferredSyncTimeout) {
+      clearTimeout(this.deferredSyncTimeout);
+      this.deferredSyncTimeout = undefined;
+    }
+    if (this.syncInterval) {
+      clearInterval(this.syncInterval);
+      this.syncInterval = undefined;
+      logger.info('Stopped periodic network sync');
+    }
+  }
+}
+
+export default ScanOrchestrator;

--- a/docs/ROADMAP_V1.md
+++ b/docs/ROADMAP_V1.md
@@ -12,6 +12,8 @@ Scope: `kaonis/woly-server` primary delivery, with regular compatibility checks 
 ### GitHub issues snapshot (`kaonis/woly-server`)
 - Open issues reviewed on 2026-02-15.
 - Existing relevant issues:
+  - #85 `[Node Agent] Extract scan orchestration from HostDatabase (SRP)`
+  - #88 `[Code Review] Misc code quality: async NBT lookup, SQL dedup, isSqlite, cncClient TODOs`
   - #86 `[Monorepo] Remove unused dependencies`
   - #93 `[Testing] Protocol coverage, CORS tests, raise thresholds, fix preflight version check`
   - #83 `[Node Agent] Restrict default CORS and rate-limit health endpoint`
@@ -83,7 +85,31 @@ Acceptance criteria:
 - Restrictive default CORS in production and health endpoint rate limiting (#83).
 - Standalone REST `PUT /hosts/:name` and `DELETE /hosts/:name` with tests/docs (#89).
 
-Status: `In Progress` (starting with #83)
+Status: `Completed` (2026-02-15 via PR #116 and PR #117)
+
+### Phase 5: Node-agent scan orchestration refactor
+Issue: #85  
+Labels: `priority:medium`, `architecture`, `node-agent`
+
+Acceptance criteria:
+- `HostDatabase` only owns CRUD + host event emission.
+- New `ScanOrchestrator` owns scan scheduling, sync orchestration, and concurrent-scan guardrails.
+- App wiring and agent/controller scan paths use `ScanOrchestrator` without behavior regressions.
+- Unit/integration coverage remains above threshold and green.
+
+Status: `In Progress` (2026-02-15)
+
+### Phase 6: Code review quality debt burn-down
+Issue: #88  
+Labels: `priority:medium`, `technical-debt`
+
+Acceptance criteria:
+- Replace blocking NetBIOS hostname lookup with async execution in node-agent discovery flow.
+- Deduplicate repeated host SELECT column mapping in C&C host aggregation service.
+- Introduce centralized `isSqlite` capability on the DB abstraction and use it in touched call sites.
+- Resolve node-agent `cncClient` registration TODO placeholders for version/subnet/gateway metadata.
+
+Status: `Planned`
 
 ## 3. Execution Loop Rules for V1
 
@@ -117,4 +143,7 @@ For each issue phase:
 - 2026-02-15: Merged PR #116 (`fix: restrict default CORS and rate-limit health endpoint (#83)`).
 - 2026-02-15: Verified post-merge `master` CI and CodeQL runs are green.
 - 2026-02-15: Started remaining Phase 4 implementation on issue #89 (`fix/89-node-agent-rest-update-delete`).
-- Next: Open and merge PR for #89.
+- 2026-02-15: Merged PR #117 (`fix: add standalone REST update/delete host endpoints (#89)`).
+- 2026-02-15: Verified post-merge `master` CI and CodeQL runs are green.
+- 2026-02-15: Started Phase 5 implementation on issue #85 (`feat/85-scan-orchestrator`).
+- Next: Open and merge PR for #85, then continue Phase 6 on #88.


### PR DESCRIPTION
## Summary
- extract network scan scheduling and orchestration from HostDatabase into a new ScanOrchestrator service
- keep HostDatabase focused on persistence and host event emission
- wire ScanOrchestrator through app startup, hosts controller, and agent service
- add dedicated ScanOrchestrator unit tests and update affected integration/unit tests
- update roadmap progress for Phase 5

## Validation
- npm run typecheck
- npm run test:ci --workspace=@woly-server/node-agent
- npm run test:ci

Closes #85
