### PR TITLE
[Security] Add WebSocket connection limits per IP

### DIFF
--- a/apps/cnc/.env.example
+++ b/apps/cnc/.env.example
@@ -28,6 +28,8 @@ WS_REQUIRE_TLS=false
 WS_ALLOW_QUERY_TOKEN_AUTH=true
 # Maximum inbound WebSocket messages accepted per connection per second
 WS_MESSAGE_RATE_LIMIT_PER_SECOND=100
+# Maximum concurrent upgraded WebSocket connections allowed per source IP
+WS_MAX_CONNECTIONS_PER_IP=10
 
 # Rate Limiting
 # Auth endpoint rate limiting (prevent brute-force attacks)

--- a/apps/cnc/src/config/index.ts
+++ b/apps/cnc/src/config/index.ts
@@ -79,6 +79,7 @@ export const config: ServerConfig = {
   wsSessionTokenAudience: getEnvVar('WS_SESSION_TOKEN_AUDIENCE', 'woly-ws-node'),
   wsSessionTokenTtlSeconds: getEnvNumber('WS_SESSION_TOKEN_TTL_SECONDS', 300),
   wsMessageRateLimitPerSecond: getEnvNumber('WS_MESSAGE_RATE_LIMIT_PER_SECOND', 100),
+  wsMaxConnectionsPerIp: getEnvNumber('WS_MAX_CONNECTIONS_PER_IP', 10),
   nodeHeartbeatInterval: getEnvNumber('NODE_HEARTBEAT_INTERVAL', 30000),
   nodeTimeout: getEnvNumber('NODE_TIMEOUT', 90000),
   commandTimeout: getEnvNumber('COMMAND_TIMEOUT', 30000),
@@ -111,6 +112,10 @@ if (!Number.isFinite(config.wsSessionTokenTtlSeconds) || config.wsSessionTokenTt
 
 if (!Number.isFinite(config.wsMessageRateLimitPerSecond) || config.wsMessageRateLimitPerSecond <= 0) {
   throw new Error('WS_MESSAGE_RATE_LIMIT_PER_SECOND must be a finite number > 0');
+}
+
+if (!Number.isFinite(config.wsMaxConnectionsPerIp) || config.wsMaxConnectionsPerIp <= 0) {
+  throw new Error('WS_MAX_CONNECTIONS_PER_IP must be a finite number > 0');
 }
 
 if (!Number.isFinite(config.jwtTtlSeconds) || config.jwtTtlSeconds <= 0) {

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -108,6 +108,7 @@ export interface ServerConfig {
   wsSessionTokenAudience: string;
   wsSessionTokenTtlSeconds: number;
   wsMessageRateLimitPerSecond: number;
+  wsMaxConnectionsPerIp: number;
   nodeHeartbeatInterval: number;
   nodeTimeout: number;
   commandTimeout: number;

--- a/apps/cnc/src/websocket/__tests__/server.test.ts
+++ b/apps/cnc/src/websocket/__tests__/server.test.ts
@@ -1,0 +1,116 @@
+import { EventEmitter } from 'events';
+import type { IncomingMessage, Server as HTTPServer } from 'http';
+import type WebSocket from 'ws';
+import config from '../../config';
+import type { NodeManager } from '../../services/nodeManager';
+import { createWebSocketServer } from '../server';
+import { authenticateWsUpgrade } from '../upgradeAuth';
+
+jest.mock('../upgradeAuth', () => ({
+  authenticateWsUpgrade: jest.fn(),
+}));
+
+type MockSocket = {
+  write: jest.Mock;
+  destroy: jest.Mock;
+};
+
+type MockNodeManager = Pick<NodeManager, 'handleConnection'>;
+
+function createUpgradeRequest(ip: string, forwardedFor?: string): IncomingMessage {
+  return {
+    url: '/ws/node',
+    headers: forwardedFor ? { 'x-forwarded-for': forwardedFor } : {},
+    socket: { remoteAddress: ip },
+  } as unknown as IncomingMessage;
+}
+
+function createMockSocket(): MockSocket {
+  return {
+    write: jest.fn(),
+    destroy: jest.fn(),
+  };
+}
+
+describe('createWebSocketServer', () => {
+  const originalMaxConnectionsPerIp = config.wsMaxConnectionsPerIp;
+  const originalRequireTls = config.wsRequireTls;
+  const mockAuthenticateWsUpgrade = authenticateWsUpgrade as jest.MockedFunction<
+    typeof authenticateWsUpgrade
+  >;
+
+  let httpServer: HTTPServer;
+  let nodeManager: MockNodeManager;
+  let upgradedSocketsQueue: WebSocket[];
+
+  beforeEach(() => {
+    (config as any).wsMaxConnectionsPerIp = 1;
+    (config as any).wsRequireTls = false;
+    mockAuthenticateWsUpgrade.mockReturnValue({ kind: 'static-token', token: 'dev-token-home' });
+    httpServer = new EventEmitter() as unknown as HTTPServer;
+    nodeManager = {
+      handleConnection: jest.fn().mockResolvedValue(undefined),
+    };
+    upgradedSocketsQueue = [];
+  });
+
+  afterEach(() => {
+    (config as any).wsMaxConnectionsPerIp = originalMaxConnectionsPerIp;
+    (config as any).wsRequireTls = originalRequireTls;
+  });
+
+  function setupWss() {
+    const wss = createWebSocketServer(httpServer, nodeManager as NodeManager);
+    const handleUpgradeSpy = jest.spyOn(wss, 'handleUpgrade').mockImplementation(
+      (request, _socket, _head, callback) => {
+        const upgradedSocket = upgradedSocketsQueue.shift();
+        if (!upgradedSocket) {
+          throw new Error('No upgraded WebSocket prepared for handleUpgrade callback');
+        }
+        callback(upgradedSocket, request);
+      }
+    );
+    return { wss, handleUpgradeSpy };
+  }
+
+  it('rejects websocket upgrades when per-IP connection limit is exceeded', () => {
+    const { handleUpgradeSpy } = setupWss();
+    const firstWs = new EventEmitter() as unknown as WebSocket;
+    upgradedSocketsQueue.push(firstWs);
+
+    const firstSocket = createMockSocket();
+    httpServer.emit('upgrade', createUpgradeRequest('10.0.0.5'), firstSocket, Buffer.alloc(0));
+
+    const secondSocket = createMockSocket();
+    httpServer.emit('upgrade', createUpgradeRequest('10.0.0.5'), secondSocket, Buffer.alloc(0));
+
+    expect(handleUpgradeSpy).toHaveBeenCalledTimes(1);
+    expect(nodeManager.handleConnection).toHaveBeenCalledTimes(1);
+    expect(secondSocket.write).toHaveBeenCalledWith('HTTP/1.1 429 Too Many Requests\r\n\r\n');
+    expect(secondSocket.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases per-IP connection slots after websocket close', () => {
+    const { handleUpgradeSpy } = setupWss();
+    const firstWs = new EventEmitter() as unknown as WebSocket;
+    const secondWs = new EventEmitter() as unknown as WebSocket;
+    upgradedSocketsQueue.push(firstWs, secondWs);
+
+    const firstSocket = createMockSocket();
+    httpServer.emit(
+      'upgrade',
+      createUpgradeRequest('10.0.0.8', '203.0.113.1, 198.51.100.2'),
+      firstSocket,
+      Buffer.alloc(0)
+    );
+    firstWs.emit('close');
+
+    const secondSocket = createMockSocket();
+    httpServer.emit('upgrade', createUpgradeRequest('10.0.0.99', '203.0.113.1'), secondSocket, Buffer.alloc(0));
+
+    expect(handleUpgradeSpy).toHaveBeenCalledTimes(2);
+    expect(nodeManager.handleConnection).toHaveBeenCalledTimes(2);
+    expect(secondSocket.write).not.toHaveBeenCalled();
+    expect(secondSocket.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cnc/src/websocket/server.ts
+++ b/apps/cnc/src/websocket/server.ts
@@ -3,7 +3,7 @@
  */
 
 import WebSocket from 'ws';
-import { Server as HTTPServer } from 'http';
+import { IncomingMessage, Server as HTTPServer } from 'http';
 import { NodeManager } from '../services/nodeManager';
 import config from '../config';
 import logger from '../utils/logger';
@@ -15,12 +15,41 @@ export function createWebSocketServer(
   nodeManager: NodeManager
 ): WebSocket.Server {
   const wss = new WebSocket.Server({ noServer: true, maxPayload: 256 * 1024 });
+  const wsMaxConnectionsPerIp = Math.max(config.wsMaxConnectionsPerIp, 1);
+  const connectionsPerIp = new Map<string, number>();
+
+  const decrementConnectionCount = (ip: string): void => {
+    const count = connectionsPerIp.get(ip);
+    if (!count) {
+      return;
+    }
+
+    if (count <= 1) {
+      connectionsPerIp.delete(ip);
+      return;
+    }
+
+    connectionsPerIp.set(ip, count - 1);
+  };
 
   // Handle upgrade requests
   httpServer.on('upgrade', (request, socket, head) => {
     const pathname = request.url?.split('?')[0];
 
     if (pathname === '/ws/node') {
+      const clientIp = getClientIp(request);
+      const activeConnectionsForIp = connectionsPerIp.get(clientIp) ?? 0;
+      if (activeConnectionsForIp >= wsMaxConnectionsPerIp) {
+        logger.warn('WebSocket connection rejected: per-IP connection limit exceeded', {
+          clientIp,
+          activeConnectionsForIp,
+          wsMaxConnectionsPerIp,
+        });
+        socket.write('HTTP/1.1 429 Too Many Requests\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
       if (config.wsRequireTls && !isRequestTls(request)) {
         socket.write('HTTP/1.1 426 Upgrade Required\r\n\r\n');
         socket.destroy();
@@ -35,10 +64,15 @@ export function createWebSocketServer(
       }
 
       wss.handleUpgrade(request, socket, head, (ws) => {
+        connectionsPerIp.set(clientIp, activeConnectionsForIp + 1);
+        ws.once('close', () => {
+          decrementConnectionCount(clientIp);
+        });
+
         // Emit the standard connection event for any listeners, but handle node auth here
         // so we can keep authContext strongly typed without relying on extra event args.
         wss.emit('connection', ws, request);
-        logger.info('New WebSocket connection attempt');
+        logger.info('New WebSocket connection attempt', { clientIp });
         void nodeManager.handleConnection(ws, authContext);
       });
     } else {
@@ -52,6 +86,22 @@ export function createWebSocketServer(
 
   logger.info('WebSocket server initialized');
   return wss;
+}
+
+function getClientIp(request: IncomingMessage): string {
+  const forwardedFor = request.headers['x-forwarded-for'];
+  if (typeof forwardedFor === 'string' && forwardedFor.trim().length > 0) {
+    return forwardedFor.split(',')[0].trim();
+  }
+
+  if (Array.isArray(forwardedFor) && forwardedFor.length > 0) {
+    const first = forwardedFor[0]?.trim();
+    if (first) {
+      return first;
+    }
+  }
+
+  return request.socket.remoteAddress || 'unknown';
 }
 
 export default createWebSocketServer;

--- a/docs/ROADMAP_V2.md
+++ b/docs/ROADMAP_V2.md
@@ -6,8 +6,8 @@ Scope: Continue autonomous delivery on `kaonis/woly-server` after V1 completion.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `woly-server` synced with `origin/master` at merge commit `6e05237` (PR #121).
-- Active execution branch for next phase: `feat/55-websocket-message-rate-limit`.
+- `woly-server` synced with `origin/master` at merge commit `4584ae0` (PR #122).
+- Active execution branch for next phase: `feat/56-websocket-connection-limit-per-ip`.
 
 ### GitHub issues snapshot (`kaonis/woly-server`)
 - Open issues reviewed on 2026-02-15.
@@ -21,8 +21,8 @@ Scope: Continue autonomous delivery on `kaonis/woly-server` after V1 completion.
   - #51 `[C&C] Phase 6: Observability and operations`
 
 ### CI snapshot
-- Recent merged PRs on 2026-02-15: #118, #119, #120, #121.
-- Post-merge checks on `master` for #121 are green (CI + CodeQL).
+- Recent merged PRs on 2026-02-15: #118, #119, #120, #121, #122.
+- Post-merge checks on `master` for #122 are green (CI + CodeQL).
 
 ### Local gate health (`woly-server`)
 - `npm run typecheck`: pass.
@@ -116,4 +116,6 @@ For each issue phase:
 - 2026-02-15: Started Phase 2 branch for #63 (`feat/63-node-agent-lint-type-hygiene`) and added zero-warning lint gate enforcement in `apps/node-agent`.
 - 2026-02-15: Merged #63 via PR #121; verified post-merge `master` checks green.
 - 2026-02-15: Started Phase 3 issue #55 on branch `feat/55-websocket-message-rate-limit`.
-- Next: Open PR for #55, merge after CI, then implement #56.
+- 2026-02-15: Merged #55 via PR #122; verified post-merge `master` checks green.
+- 2026-02-15: Started follow-up Phase 3 issue #56 on branch `feat/56-websocket-connection-limit-per-ip`.
+- Next: Open PR for #56 and complete Phase 3.


### PR DESCRIPTION
## Summary
- add per-IP WebSocket connection caps at the C&C upgrade boundary
- reject excess upgrades with HTTP 429 and release slots on WebSocket close
- support `x-forwarded-for` first-hop extraction for proxy-aware client IP limiting
- add `WS_MAX_CONNECTIONS_PER_IP` config/env support with validation
- add websocket server unit tests for overflow rejection and slot release behavior
- update `docs/ROADMAP_V2.md` progress after #55 merge and #56 execution start

Closes #56

## Validation
- npm run lint --workspace=@woly-server/cnc
- npx tsc --noEmit
- npx jest --ci --coverage --passWithNoTests
