### PR TITLE
[Security] Tighten CORS configuration on Node Agent for production

### DIFF
--- a/apps/node-agent/src/app.ts
+++ b/apps/node-agent/src/app.ts
@@ -22,7 +22,9 @@ app.use(helmet());
 app.use(
   cors({
     origin: (origin, callback) => {
-      const decision = evaluateCorsOrigin(origin, config.cors.origins);
+      const decision = evaluateCorsOrigin(origin, config.cors.origins, {
+        allowHostedDevOrigins: config.server.env !== 'production',
+      });
 
       if (decision !== 'rejected') {
         if (decision === 'no-origin') {

--- a/apps/node-agent/src/utils/__tests__/corsOrigin.unit.test.ts
+++ b/apps/node-agent/src/utils/__tests__/corsOrigin.unit.test.ts
@@ -19,6 +19,22 @@ describe('evaluateCorsOrigin', () => {
     expect(evaluateCorsOrigin('https://preview-site.netlify.app', [])).toBe('netlify');
   });
 
+  it('rejects ngrok-free origins when hosted dev origins are disabled', () => {
+    expect(
+      evaluateCorsOrigin('https://demo-123.ngrok-free.app', [], {
+        allowHostedDevOrigins: false,
+      })
+    ).toBe('rejected');
+  });
+
+  it('rejects netlify origins when hosted dev origins are disabled', () => {
+    expect(
+      evaluateCorsOrigin('https://preview-site.netlify.app', [], {
+        allowHostedDevOrigins: false,
+      })
+    ).toBe('rejected');
+  });
+
   it('allows helios.kaonis.com origins over http and https', () => {
     expect(evaluateCorsOrigin('https://helios.kaonis.com', [])).toBe('helios');
     expect(evaluateCorsOrigin('http://api.helios.kaonis.com', [])).toBe('helios');
@@ -30,4 +46,3 @@ describe('evaluateCorsOrigin', () => {
     );
   });
 });
-

--- a/apps/node-agent/src/utils/corsOrigin.ts
+++ b/apps/node-agent/src/utils/corsOrigin.ts
@@ -1,15 +1,23 @@
 export type CorsDecision = 'no-origin' | 'config' | 'ngrok' | 'netlify' | 'helios' | 'rejected';
+type CorsOriginOptions = {
+  allowHostedDevOrigins?: boolean;
+};
 
 const NGROK_ORIGIN_REGEX = /^https:\/\/[a-z0-9-]+\.ngrok-free\.app$/i;
 const NETLIFY_ORIGIN_REGEX = /^https:\/\/[a-z0-9-]+\.netlify\.app$/i;
 const HELIOS_ORIGIN_REGEX = /^https?:\/\/(.*\.)?helios\.kaonis\.com$/i;
 
-export function evaluateCorsOrigin(origin: string | undefined, configuredOrigins: string[]): CorsDecision {
+export function evaluateCorsOrigin(
+  origin: string | undefined,
+  configuredOrigins: string[],
+  options: CorsOriginOptions = {}
+): CorsDecision {
+  const allowHostedDevOrigins = options.allowHostedDevOrigins ?? true;
+
   if (!origin) return 'no-origin';
   if (configuredOrigins.includes(origin)) return 'config';
-  if (NGROK_ORIGIN_REGEX.test(origin)) return 'ngrok';
-  if (NETLIFY_ORIGIN_REGEX.test(origin)) return 'netlify';
+  if (allowHostedDevOrigins && NGROK_ORIGIN_REGEX.test(origin)) return 'ngrok';
+  if (allowHostedDevOrigins && NETLIFY_ORIGIN_REGEX.test(origin)) return 'netlify';
   if (HELIOS_ORIGIN_REGEX.test(origin)) return 'helios';
   return 'rejected';
 }
-

--- a/docs/ROADMAP_V2.md
+++ b/docs/ROADMAP_V2.md
@@ -6,8 +6,8 @@ Scope: Continue autonomous delivery on `kaonis/woly-server` after V1 completion.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `woly-server` synced with `origin/master` at merge commit `4584ae0` (PR #122).
-- Active execution branch for next phase: `feat/56-websocket-connection-limit-per-ip`.
+- `woly-server` synced with `origin/master` at merge commit `c2df1cf` (PR #123).
+- Active execution branch for next phase: `feat/57-node-agent-cors-tightening`.
 
 ### GitHub issues snapshot (`kaonis/woly-server`)
 - Open issues reviewed on 2026-02-15.
@@ -21,8 +21,8 @@ Scope: Continue autonomous delivery on `kaonis/woly-server` after V1 completion.
   - #51 `[C&C] Phase 6: Observability and operations`
 
 ### CI snapshot
-- Recent merged PRs on 2026-02-15: #118, #119, #120, #121, #122.
-- Post-merge checks on `master` for #122 are green (CI + CodeQL).
+- Recent merged PRs on 2026-02-15: #118, #119, #120, #121, #122, #123.
+- Post-merge checks on `master` for #123 are green (CI + CodeQL).
 
 ### Local gate health (`woly-server`)
 - `npm run typecheck`: pass.
@@ -67,7 +67,7 @@ Acceptance criteria:
 - Add per-IP connection limits.
 - Validate behavior under normal traffic and abusive traffic tests.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PRs #122 and #123)
 
 ### Phase 4: Node-agent production CORS tightening
 Issue: #57  
@@ -78,7 +78,7 @@ Acceptance criteria:
 - Implement remaining hardening deltas only (or close as superseded if fully covered).
 - Preserve legitimate mobile/web production use cases.
 
-Status: `Planned`
+Status: `In Progress` (2026-02-15)
 
 ### Phase 5: Observability and rollout ops
 Issues:
@@ -118,4 +118,7 @@ For each issue phase:
 - 2026-02-15: Started Phase 3 issue #55 on branch `feat/55-websocket-message-rate-limit`.
 - 2026-02-15: Merged #55 via PR #122; verified post-merge `master` checks green.
 - 2026-02-15: Started follow-up Phase 3 issue #56 on branch `feat/56-websocket-connection-limit-per-ip`.
-- Next: Open PR for #56 and complete Phase 3.
+- 2026-02-15: Merged #56 via PR #123.
+- 2026-02-15: Verified post-merge `master` checks green for #123.
+- 2026-02-15: Started Phase 4 issue #57 on branch `feat/57-node-agent-cors-tightening`.
+- Next: Open PR for #57, merge after CI, then start Phase 5 (#47/#51).


### PR DESCRIPTION
## Summary
- tighten node-agent CORS behavior in production by disabling automatic ngrok/netlify origin allowlists
- preserve existing dev/test ergonomics by keeping hosted dev origins enabled outside production
- keep explicit `CORS_ORIGINS` and `helios.kaonis.com` handling unchanged
- add unit tests covering disabled hosted-dev origin behavior
- update `docs/ROADMAP_V2.md` with #56 completion and #57 progress

Closes #57

## Validation
- npm run lint --workspace=@woly-server/node-agent
- npx tsc --noEmit
- npx jest --ci --coverage --passWithNoTests
