### PR TITLE
feat(cnc): observability metrics, correlation tracing, and runbooks (#51)

### DIFF
--- a/apps/cnc/IMPLEMENTATION_CHECKLIST.md
+++ b/apps/cnc/IMPLEMENTATION_CHECKLIST.md
@@ -73,10 +73,10 @@ Definition of done:
 
 ## Phase 6 - Observability and Operations
 
-- [ ] Emit node count, command latency, timeout rate, and invalid payload rate metrics.
-- [ ] Propagate correlation IDs from API call to node response.
-- [ ] Add dashboards and alerts.
-- [ ] Publish incident runbooks.
+- [x] Emit node count, command latency, timeout rate, and invalid payload rate metrics.
+- [x] Propagate correlation IDs from API call to node response.
+- [x] Add dashboards and alerts.
+- [x] Publish incident runbooks.
 
 Definition of done:
-- [ ] Incident response can trace failures end-to-end quickly.
+- [x] Incident response can trace failures end-to-end quickly.

--- a/apps/cnc/README.md
+++ b/apps/cnc/README.md
@@ -9,6 +9,7 @@
 - **[Architecture Plan](ARCHITECTURE_PLAN.md)** — Phased implementation roadmap
 - **[Implementation Checklist](IMPLEMENTATION_CHECKLIST.md)** — Progress tracking
 - **[Runbooks](docs/runbooks/)** — Operational procedures
+- **[Observability Dashboard/Alerts](docs/observability-dashboard-alerts.md)** — SLO metrics and alert thresholds
 
 ## Architecture
 

--- a/apps/cnc/docs/observability-dashboard-alerts.md
+++ b/apps/cnc/docs/observability-dashboard-alerts.md
@@ -1,0 +1,56 @@
+# C&C Observability Dashboard and Alerts
+
+This document defines the baseline Phase 6 dashboard and alert thresholds for the WoLy C&C backend.
+
+## Metrics Sources
+
+- `GET /health` -> `metrics`
+- `GET /api/admin/stats` -> `observability`
+
+Core metrics:
+- connected node count (`nodes.connected`, `nodes.peakConnected`)
+- command latency (`commands.avgLatencyMs`, `commands.byType.*.avgLatencyMs`)
+- timeout rate (`commands.timeoutRate`)
+- invalid payload rate (`protocol.invalidPayloadRatePerMinute`)
+
+## Dashboard Panels
+
+1. Node Connectivity
+- Current connected nodes
+- Peak connected nodes since process start
+
+2. Command Reliability
+- Dispatched / acknowledged / failed / timed out counts
+- Timeout rate trend
+
+3. Command Latency
+- Global average latency
+- Per-command-type average latency (wake/scan/update-host/delete-host)
+
+4. Protocol Health
+- Invalid payload total
+- Invalid payload rate per minute
+- Top failing protocol keys (`inbound:<type>`, `outbound:<type>`)
+
+5. Correlation Traceability
+- Recent resolved correlations (`commandId` <-> `correlationId`)
+- Active correlated command count
+
+## Initial Alert Thresholds
+
+- `commands.timeoutRate > 0.10` for 5 minutes
+- `protocol.invalidPayloadRatePerMinute > 3` for 5 minutes
+- `nodes.connected` drops below expected baseline for 10 minutes
+- `commands.avgLatencyMs` above SLO baseline for 10 minutes
+
+## Response Workflow
+
+1. Confirm signal in `/api/admin/stats` and `/health`.
+2. Determine failure domain:
+- auth/protocol: invalid payload spikes
+- network/node stability: node count drop or flapping
+- command pipeline: latency or timeout rate increase
+3. Follow runbook:
+- `docs/runbooks/node-flapping.md`
+- `docs/runbooks/command-backlog.md`
+- `docs/runbooks/auth-failures.md`

--- a/apps/cnc/docs/runbooks/auth-failures.md
+++ b/apps/cnc/docs/runbooks/auth-failures.md
@@ -1,0 +1,27 @@
+# C&C Runbook: Authentication and Protocol Failure Spikes
+
+Use when invalid payload or auth-related failures increase.
+
+## Signals
+
+- `protocol.invalidPayloadRatePerMinute` spike.
+- Frequent registration failures from nodes.
+- Increased auth rejection logs during WS upgrade/registration.
+
+## Triage
+
+1. Inspect `protocol.invalidPayloadByKey` for dominant failing message types.
+2. Confirm node and C&C protocol versions are compatible.
+3. Validate auth secrets, issuer, audience, and token TTL config.
+
+## Mitigation
+
+1. Restore compatible protocol pair (node-agent/C&C) if mismatch exists.
+2. Rotate/restore auth secrets if drift or compromise is suspected.
+3. Pause rollout and hold at canary cohort while investigating.
+
+## Verification
+
+- Invalid payload rate normalizes.
+- Node registration succeeds consistently.
+- Command pipeline resumes normal success rate.

--- a/apps/cnc/docs/runbooks/command-backlog.md
+++ b/apps/cnc/docs/runbooks/command-backlog.md
@@ -1,0 +1,28 @@
+# C&C Runbook: Command Backlog and Timeouts
+
+Use when command latency or timeout rate rises above baseline.
+
+## Signals
+
+- Elevated `commands.timeoutRate`.
+- Increasing `commands.active` without matching acknowledgements.
+- `commands.avgLatencyMs` sustained above expected threshold.
+
+## Triage
+
+1. Check `/api/admin/stats` observability snapshot.
+2. Identify impacted command types from `commands.byType`.
+3. Correlate affected commands via `correlationId` and API logs.
+
+## Mitigation
+
+1. Verify target nodes are connected and healthy.
+2. Reduce command load temporarily (throttle non-critical operations).
+3. Validate command timeout/retry config and recent deploy changes.
+4. Roll back if regression introduced by latest release.
+
+## Verification
+
+- Timeout rate returns below alert threshold.
+- Command latency trend returns to baseline.
+- Backlog (`commands.active`) drains.

--- a/apps/cnc/docs/runbooks/node-flapping.md
+++ b/apps/cnc/docs/runbooks/node-flapping.md
@@ -1,0 +1,26 @@
+# C&C Runbook: Node Flapping
+
+Use when nodes repeatedly transition online/offline in short intervals.
+
+## Signals
+
+- `nodes.connected` oscillates rapidly.
+- Hosts for affected nodes frequently flip to unreachable.
+- Increased reconnect/auth noise in node-agent telemetry.
+
+## Triage
+
+1. Identify affected node IDs and locations.
+2. Compare C&C and node-agent health snapshots.
+3. Check token/auth failures and protocol mismatches.
+
+## Mitigation
+
+1. Verify network path and TLS termination between nodes and C&C.
+2. Validate token/session configuration parity.
+3. Roll back recent incompatible node or C&C deploy if flapping started after rollout.
+
+## Verification
+
+- Node remains connected for at least one heartbeat timeout window.
+- Host state transitions stabilize.

--- a/apps/cnc/src/middleware/__tests__/correlationId.test.ts
+++ b/apps/cnc/src/middleware/__tests__/correlationId.test.ts
@@ -1,0 +1,43 @@
+import { NextFunction, Request, Response } from 'express';
+import { assignCorrelationId } from '../correlationId';
+
+describe('assignCorrelationId middleware', () => {
+  const next = jest.fn() as NextFunction;
+
+  function createMockResponse(): Response {
+    const res = {} as Response;
+    res.setHeader = jest.fn();
+    return res;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses incoming x-correlation-id header when provided', () => {
+    const req = {
+      header: jest.fn().mockImplementation((name: string) =>
+        name.toLowerCase() === 'x-correlation-id' ? 'corr-client-123' : undefined
+      ),
+    } as unknown as Request;
+    const res = createMockResponse();
+
+    assignCorrelationId(req, res, next);
+
+    expect(req.correlationId).toBe('corr-client-123');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-Id', 'corr-client-123');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('generates correlation id when header is missing', () => {
+    const req = {
+      header: jest.fn().mockReturnValue(undefined),
+    } as unknown as Request;
+    const res = createMockResponse();
+
+    assignCorrelationId(req, res, next);
+
+    expect(req.correlationId).toMatch(/^corr_/);
+    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-Id', req.correlationId);
+  });
+});

--- a/apps/cnc/src/middleware/correlationId.ts
+++ b/apps/cnc/src/middleware/correlationId.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from 'crypto';
+import { NextFunction, Request, Response } from 'express';
+
+const CORRELATION_ID_HEADER = 'x-correlation-id';
+const GENERATED_PREFIX = 'corr_';
+const MAX_LENGTH = 128;
+
+function sanitizeCorrelationId(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_LENGTH) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+export function assignCorrelationId(req: Request, res: Response, next: NextFunction): void {
+  const incomingHeader = req.header(CORRELATION_ID_HEADER);
+  const correlationId = sanitizeCorrelationId(incomingHeader) ?? `${GENERATED_PREFIX}${randomUUID()}`;
+
+  req.correlationId = correlationId;
+  res.setHeader('X-Correlation-Id', correlationId);
+  next();
+}

--- a/apps/cnc/src/services/__tests__/nodeManager.test.ts
+++ b/apps/cnc/src/services/__tests__/nodeManager.test.ts
@@ -10,6 +10,7 @@ import db from '../../database/connection';
 import { PROTOCOL_VERSION } from '@kaonis/woly-protocol';
 import config from '../../config';
 import { mintWsSessionToken } from '../../websocket/sessionTokens';
+import { runtimeMetrics } from '../runtimeMetrics';
 
 // Mock WebSocket
 jest.mock('ws');
@@ -26,6 +27,7 @@ describe('NodeManager', () => {
 
   beforeEach(async () => {
     (config as any).wsMessageRateLimitPerSecond = defaultWsMessageRateLimitPerSecond;
+    runtimeMetrics.reset(0);
     hostAggregator = new HostAggregator();
     nodeManager = new NodeManager(hostAggregator);
 
@@ -418,6 +420,7 @@ describe('NodeManager', () => {
       // Verify hosts were marked unreachable
       const hosts = await hostAggregator.getHostsByNode('test-ws-node-3');
       expect(hosts.every(h => h.status === 'asleep')).toBe(true);
+      expect(runtimeMetrics.snapshot().nodes.connected).toBe(0);
     });
   });
 
@@ -501,6 +504,7 @@ describe('NodeManager', () => {
 
       const connectedNodes = nodeManager.getConnectedNodes();
       expect(connectedNodes).toContain('test-ws-node-5');
+      expect(runtimeMetrics.snapshot().nodes.connected).toBe(1);
     });
   });
 

--- a/apps/cnc/src/services/__tests__/runtimeMetrics.test.ts
+++ b/apps/cnc/src/services/__tests__/runtimeMetrics.test.ts
@@ -1,0 +1,61 @@
+import { RuntimeMetrics } from '../runtimeMetrics';
+
+describe('RuntimeMetrics', () => {
+  it('tracks connected node counts and peak', () => {
+    const metrics = new RuntimeMetrics();
+    metrics.reset(1000);
+
+    metrics.setConnectedNodeCount(1);
+    metrics.setConnectedNodeCount(3);
+    metrics.setConnectedNodeCount(2);
+
+    const snapshot = metrics.snapshot(2000);
+    expect(snapshot.nodes).toEqual({
+      connected: 2,
+      peakConnected: 3,
+    });
+  });
+
+  it('tracks invalid payload totals and rates', () => {
+    const metrics = new RuntimeMetrics();
+    metrics.reset(0);
+
+    metrics.recordInvalidPayload('inbound', 'register');
+    metrics.recordInvalidPayload('inbound', 'register');
+    metrics.recordInvalidPayload('outbound', 'wake');
+
+    const snapshot = metrics.snapshot(60_000);
+    expect(snapshot.protocol.invalidPayloadTotal).toBe(3);
+    expect(snapshot.protocol.invalidPayloadByKey['inbound:register']).toBe(2);
+    expect(snapshot.protocol.invalidPayloadByKey['outbound:wake']).toBe(1);
+    expect(snapshot.protocol.invalidPayloadRatePerMinute).toBe(3);
+  });
+
+  it('tracks command latency, timeout rate, and correlation trail', () => {
+    const metrics = new RuntimeMetrics();
+    metrics.reset(100);
+
+    metrics.recordCommandDispatched('cmd-1', 'wake', 'corr-1', 100);
+    metrics.recordCommandResult('cmd-1', true, 180);
+
+    metrics.recordCommandDispatched('cmd-2', 'scan', 'corr-2', 200);
+    metrics.recordCommandResult('cmd-2', false, 350);
+
+    metrics.recordCommandDispatched('cmd-3', 'delete-host', null, 300);
+    metrics.recordCommandTimeout('cmd-3', 600);
+
+    const snapshot = metrics.snapshot(700);
+    expect(snapshot.commands.dispatched).toBe(3);
+    expect(snapshot.commands.acknowledged).toBe(1);
+    expect(snapshot.commands.failed).toBe(1);
+    expect(snapshot.commands.timedOut).toBe(1);
+    expect(snapshot.commands.timeoutRate).toBeCloseTo(0.3333, 4);
+    expect(snapshot.commands.avgLatencyMs).toBe(177);
+    expect(snapshot.commands.byType.wake.acknowledged).toBe(1);
+    expect(snapshot.commands.byType.scan.failed).toBe(1);
+    expect(snapshot.commands.byType['delete-host'].timedOut).toBe(1);
+    expect(snapshot.correlations.recentResolved).toHaveLength(2);
+    expect(metrics.lookupCorrelationId('cmd-1')).toBe('corr-1');
+    expect(metrics.lookupCorrelationId('cmd-3')).toBeNull();
+  });
+});

--- a/apps/cnc/src/services/runtimeMetrics.ts
+++ b/apps/cnc/src/services/runtimeMetrics.ts
@@ -1,0 +1,325 @@
+type ProtocolDirection = 'inbound' | 'outbound';
+type CommandOutcome = 'acknowledged' | 'failed' | 'timed_out';
+
+type CommandMetricBucket = {
+  dispatched: number;
+  acknowledged: number;
+  failed: number;
+  timedOut: number;
+  completed: number;
+  cumulativeLatencyMs: number;
+  lastLatencyMs: number | null;
+};
+
+type CommandMetricBucketSnapshot = {
+  dispatched: number;
+  acknowledged: number;
+  failed: number;
+  timedOut: number;
+  avgLatencyMs: number;
+  lastLatencyMs: number | null;
+};
+
+type ActiveCommand = {
+  commandType: string;
+  correlationId: string | null;
+  startedAtMs: number;
+};
+
+type ResolvedCorrelation = {
+  commandId: string;
+  correlationId: string;
+  outcome: CommandOutcome;
+  resolvedAtMs: number;
+};
+
+export type RuntimeMetricsSnapshot = {
+  startedAtMs: number;
+  generatedAtMs: number;
+  nodes: {
+    connected: number;
+    peakConnected: number;
+  };
+  protocol: {
+    invalidPayloadTotal: number;
+    invalidPayloadRatePerMinute: number;
+    invalidPayloadByKey: Record<string, number>;
+  };
+  commands: {
+    active: number;
+    dispatched: number;
+    acknowledged: number;
+    failed: number;
+    timedOut: number;
+    timeoutRate: number;
+    avgLatencyMs: number;
+    lastLatencyMs: number | null;
+    byType: Record<string, CommandMetricBucketSnapshot>;
+  };
+  correlations: {
+    active: number;
+    recentResolved: ResolvedCorrelation[];
+  };
+};
+
+const MAX_RESOLVED_CORRELATIONS = 200;
+const MAX_RECENT_RESOLVED_IN_SNAPSHOT = 20;
+
+export class RuntimeMetrics {
+  private startedAtMs = Date.now();
+  private connectedNodes = 0;
+  private peakConnectedNodes = 0;
+  private invalidPayloadTotal = 0;
+  private readonly invalidPayloadByKey = new Map<string, number>();
+  private readonly commandTotals: CommandMetricBucket = {
+    dispatched: 0,
+    acknowledged: 0,
+    failed: 0,
+    timedOut: 0,
+    completed: 0,
+    cumulativeLatencyMs: 0,
+    lastLatencyMs: null,
+  };
+  private readonly commandByType = new Map<string, CommandMetricBucket>();
+  private readonly activeCommands = new Map<string, ActiveCommand>();
+  private readonly resolvedCorrelationTrail: ResolvedCorrelation[] = [];
+  private readonly resolvedCorrelationByCommandId = new Map<string, string>();
+
+  public reset(nowMs = Date.now()): void {
+    this.startedAtMs = nowMs;
+    this.connectedNodes = 0;
+    this.peakConnectedNodes = 0;
+    this.invalidPayloadTotal = 0;
+    this.invalidPayloadByKey.clear();
+    this.commandTotals.dispatched = 0;
+    this.commandTotals.acknowledged = 0;
+    this.commandTotals.failed = 0;
+    this.commandTotals.timedOut = 0;
+    this.commandTotals.completed = 0;
+    this.commandTotals.cumulativeLatencyMs = 0;
+    this.commandTotals.lastLatencyMs = null;
+    this.commandByType.clear();
+    this.activeCommands.clear();
+    this.resolvedCorrelationTrail.length = 0;
+    this.resolvedCorrelationByCommandId.clear();
+  }
+
+  public setConnectedNodeCount(count: number): void {
+    const normalizedCount = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+    this.connectedNodes = normalizedCount;
+    if (normalizedCount > this.peakConnectedNodes) {
+      this.peakConnectedNodes = normalizedCount;
+    }
+  }
+
+  public recordInvalidPayload(direction: ProtocolDirection, messageType: string): void {
+    const safeDirection = direction === 'outbound' ? 'outbound' : 'inbound';
+    const normalizedMessageType =
+      typeof messageType === 'string' && messageType.trim().length > 0
+        ? messageType.trim()
+        : 'unknown';
+
+    const key = `${safeDirection}:${normalizedMessageType}`;
+    this.invalidPayloadTotal += 1;
+    this.invalidPayloadByKey.set(key, (this.invalidPayloadByKey.get(key) || 0) + 1);
+  }
+
+  public recordCommandDispatched(
+    commandId: string,
+    commandType: string,
+    correlationId: string | null,
+    nowMs = Date.now()
+  ): void {
+    const normalizedCommandId = this.normalizeCommandId(commandId);
+    const normalizedCommandType = this.normalizeCommandType(commandType);
+    const normalizedCorrelationId = this.normalizeCorrelationId(correlationId);
+    const startedAtMs = Number.isFinite(nowMs) ? Math.floor(nowMs) : Date.now();
+
+    this.commandTotals.dispatched += 1;
+    this.getOrCreateCommandBucket(normalizedCommandType).dispatched += 1;
+    this.activeCommands.set(normalizedCommandId, {
+      commandType: normalizedCommandType,
+      correlationId: normalizedCorrelationId,
+      startedAtMs,
+    });
+  }
+
+  public recordCommandResult(commandId: string, success: boolean, nowMs = Date.now()): void {
+    this.resolveCommand(
+      this.normalizeCommandId(commandId),
+      success ? 'acknowledged' : 'failed',
+      nowMs
+    );
+  }
+
+  public recordCommandTimeout(commandId: string, nowMs = Date.now()): void {
+    this.resolveCommand(this.normalizeCommandId(commandId), 'timed_out', nowMs);
+  }
+
+  public lookupCorrelationId(commandId: string): string | null {
+    const normalizedCommandId = this.normalizeCommandId(commandId);
+    const active = this.activeCommands.get(normalizedCommandId);
+    if (active?.correlationId) {
+      return active.correlationId;
+    }
+
+    return this.resolvedCorrelationByCommandId.get(normalizedCommandId) ?? null;
+  }
+
+  public snapshot(nowMs = Date.now()): RuntimeMetricsSnapshot {
+    const elapsedMs = Math.max(nowMs - this.startedAtMs, 1);
+    const timeoutRate =
+      this.commandTotals.completed > 0
+        ? this.commandTotals.timedOut / this.commandTotals.completed
+        : 0;
+
+    const byType = Object.fromEntries(
+      Array.from(this.commandByType.entries()).map(([commandType, bucket]) => [
+        commandType,
+        this.toBucketSnapshot(bucket),
+      ])
+    );
+
+    return {
+      startedAtMs: this.startedAtMs,
+      generatedAtMs: nowMs,
+      nodes: {
+        connected: this.connectedNodes,
+        peakConnected: this.peakConnectedNodes,
+      },
+      protocol: {
+        invalidPayloadTotal: this.invalidPayloadTotal,
+        invalidPayloadRatePerMinute: Number(
+          ((this.invalidPayloadTotal * 60_000) / elapsedMs).toFixed(2)
+        ),
+        invalidPayloadByKey: Object.fromEntries(this.invalidPayloadByKey.entries()),
+      },
+      commands: {
+        active: this.activeCommands.size,
+        dispatched: this.commandTotals.dispatched,
+        acknowledged: this.commandTotals.acknowledged,
+        failed: this.commandTotals.failed,
+        timedOut: this.commandTotals.timedOut,
+        timeoutRate: Number(timeoutRate.toFixed(4)),
+        avgLatencyMs:
+          this.commandTotals.completed > 0
+            ? Math.round(this.commandTotals.cumulativeLatencyMs / this.commandTotals.completed)
+            : 0,
+        lastLatencyMs: this.commandTotals.lastLatencyMs,
+        byType,
+      },
+      correlations: {
+        active: this.activeCommands.size,
+        recentResolved: this.resolvedCorrelationTrail.slice(-MAX_RECENT_RESOLVED_IN_SNAPSHOT),
+      },
+    };
+  }
+
+  private resolveCommand(commandId: string, outcome: CommandOutcome, nowMs: number): void {
+    const active = this.activeCommands.get(commandId);
+    const commandType = active?.commandType ?? 'unknown';
+    const startedAtMs = active?.startedAtMs ?? nowMs;
+    const latencyMs = Math.max(0, Math.round(nowMs - startedAtMs));
+
+    this.applyOutcome(this.commandTotals, outcome, latencyMs);
+    this.applyOutcome(this.getOrCreateCommandBucket(commandType), outcome, latencyMs);
+
+    if (active) {
+      this.activeCommands.delete(commandId);
+      if (active.correlationId) {
+        this.pushResolvedCorrelation({
+          commandId,
+          correlationId: active.correlationId,
+          outcome,
+          resolvedAtMs: nowMs,
+        });
+      }
+    }
+  }
+
+  private pushResolvedCorrelation(entry: ResolvedCorrelation): void {
+    this.resolvedCorrelationTrail.push(entry);
+    this.resolvedCorrelationByCommandId.set(entry.commandId, entry.correlationId);
+
+    if (this.resolvedCorrelationTrail.length <= MAX_RESOLVED_CORRELATIONS) {
+      return;
+    }
+
+    const removed = this.resolvedCorrelationTrail.shift();
+    if (removed) {
+      this.resolvedCorrelationByCommandId.delete(removed.commandId);
+    }
+  }
+
+  private applyOutcome(
+    bucket: CommandMetricBucket,
+    outcome: CommandOutcome,
+    latencyMs: number
+  ): void {
+    if (outcome === 'acknowledged') {
+      bucket.acknowledged += 1;
+    } else if (outcome === 'failed') {
+      bucket.failed += 1;
+    } else {
+      bucket.timedOut += 1;
+    }
+
+    bucket.completed += 1;
+    bucket.cumulativeLatencyMs += latencyMs;
+    bucket.lastLatencyMs = latencyMs;
+  }
+
+  private getOrCreateCommandBucket(commandType: string): CommandMetricBucket {
+    const existing = this.commandByType.get(commandType);
+    if (existing) {
+      return existing;
+    }
+
+    const created: CommandMetricBucket = {
+      dispatched: 0,
+      acknowledged: 0,
+      failed: 0,
+      timedOut: 0,
+      completed: 0,
+      cumulativeLatencyMs: 0,
+      lastLatencyMs: null,
+    };
+    this.commandByType.set(commandType, created);
+    return created;
+  }
+
+  private toBucketSnapshot(bucket: CommandMetricBucket): CommandMetricBucketSnapshot {
+    return {
+      dispatched: bucket.dispatched,
+      acknowledged: bucket.acknowledged,
+      failed: bucket.failed,
+      timedOut: bucket.timedOut,
+      avgLatencyMs: bucket.completed > 0 ? Math.round(bucket.cumulativeLatencyMs / bucket.completed) : 0,
+      lastLatencyMs: bucket.lastLatencyMs,
+    };
+  }
+
+  private normalizeCommandId(commandId: string): string {
+    if (typeof commandId !== 'string' || commandId.trim().length === 0) {
+      return 'unknown-command-id';
+    }
+    return commandId.trim();
+  }
+
+  private normalizeCommandType(commandType: string): string {
+    if (typeof commandType !== 'string' || commandType.trim().length === 0) {
+      return 'unknown';
+    }
+    return commandType.trim();
+  }
+
+  private normalizeCorrelationId(correlationId: string | null): string | null {
+    if (typeof correlationId !== 'string') {
+      return null;
+    }
+    const trimmed = correlationId.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+}
+
+export const runtimeMetrics = new RuntimeMetrics();

--- a/apps/cnc/src/swagger.ts
+++ b/apps/cnc/src/swagger.ts
@@ -186,6 +186,10 @@ const options: swaggerJsdoc.Options = {
               description: 'API version',
               example: '1.0.0',
             },
+            metrics: {
+              type: 'object',
+              description: 'Runtime observability snapshot (nodes, commands, protocol validation)',
+            },
           },
         },
         TokenRequest: {
@@ -258,6 +262,11 @@ const options: swaggerJsdoc.Options = {
               description: 'Unique command identifier',
               example: '123e4567-e89b-12d3-a456-426614174000',
             },
+            correlationId: {
+              type: 'string',
+              description: 'Request correlation identifier for end-to-end tracing',
+              example: 'corr_2a8f6842-6f8f-4e8f-b6dc-f7dbd9a18e68',
+            },
           },
         },
         SystemStats: {
@@ -297,6 +306,10 @@ const options: swaggerJsdoc.Options = {
                   },
                 },
               },
+            },
+            observability: {
+              type: 'object',
+              description: 'Runtime observability snapshot used by dashboards and alerts',
             },
             timestamp: {
               type: 'string',

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -48,6 +48,7 @@ export interface CommandResult {
   success: boolean;
   error?: string;
   timestamp: Date;
+  correlationId?: string;
 }
 
 // API Response Types
@@ -70,6 +71,7 @@ export interface WakeupResponse {
   message: string;
   nodeId: string;
   location: string;
+  correlationId?: string;
 }
 
 export interface CommandRecord {

--- a/apps/cnc/src/types/express.d.ts
+++ b/apps/cnc/src/types/express.d.ts
@@ -4,6 +4,7 @@ declare global {
   namespace Express {
     interface Request {
       auth?: AuthContext;
+      correlationId?: string;
     }
   }
 }

--- a/docs/ROADMAP_V2.md
+++ b/docs/ROADMAP_V2.md
@@ -6,23 +6,17 @@ Scope: Continue autonomous delivery on `kaonis/woly-server` after V1 completion.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `woly-server` synced with `origin/master` at merge commit `1b00d6c` (PR #124).
-- Active execution branch for next phase: `feat/47-node-agent-observability-rollout`.
+- `woly-server` synced with `origin/master` at merge commit `37d49bf` (PR #125).
+- Active execution branch for next phase: `feat/51-cnc-observability-rollout`.
 
 ### GitHub issues snapshot (`kaonis/woly-server`)
 - Open issues reviewed on 2026-02-15.
 - Existing relevant open issues:
-  - #46 `[Node Agent] Phase 5: Host data quality and backpressure`
-  - #63 `[Node Agent] Clean up lint debt (type safety and hygiene)`
-  - #55 `[Security] Add WebSocket message rate limiting`
-  - #56 `[Security] Add WebSocket connection limits per IP`
-  - #57 `[Security] Tighten CORS configuration on Node Agent for production`
-  - #47 `[Node Agent] Phase 6: Observability and rollout`
   - #51 `[C&C] Phase 6: Observability and operations`
 
 ### CI snapshot
-- Recent merged PRs on 2026-02-15: #118, #119, #120, #121, #122, #123, #124.
-- Post-merge checks on `master` for #124 are green (CI + CodeQL).
+- Recent merged PRs on 2026-02-15: #118, #119, #120, #121, #122, #123, #124, #125.
+- Post-merge checks on `master` for #125 are green (CI + CodeQL).
 
 ### Local gate health (`woly-server`)
 - `npm run typecheck`: pass.
@@ -90,7 +84,7 @@ Acceptance criteria:
 - Add startup diagnostics and incident runbook scaffolding.
 - Define staged rollout/canary and rollback procedure.
 
-Status: `In Progress` (2026-02-15)
+Status: `In Progress` (2026-02-15, #47 complete via PR #125; #51 in active implementation)
 
 ## 3. Execution Loop Rules for V2
 
@@ -124,4 +118,7 @@ For each issue phase:
 - 2026-02-15: Merged #57 via PR #124; verified post-merge `master` checks green.
 - 2026-02-15: Started Phase 5 issue #47 on branch `feat/47-node-agent-observability-rollout`.
 - 2026-02-15: Implemented #47 observability + rollout docs on `feat/47-node-agent-observability-rollout` with local gate green (`npx tsc --noEmit`, `npx jest --ci --coverage --passWithNoTests` in `apps/node-agent`).
-- Next: Open/merge #47 PR, verify post-merge CI, then continue with #51.
+- 2026-02-15: Merged #47 via PR #125; verified post-merge `master` checks green.
+- 2026-02-15: Started #51 implementation branch `feat/51-cnc-observability-rollout`.
+- 2026-02-15: Implemented #51 observability/correlation/runbooks changes with local gate green (`npx tsc --noEmit`, `npx jest --ci --coverage --passWithNoTests`, `npm run lint` in `apps/cnc`).
+- Next: Open/merge #51 PR, verify post-merge CI, then continue roadmap cycle.


### PR DESCRIPTION
## Summary
- add a C&C `runtimeMetrics` service for node connectivity, invalid payload rate, command latency, timeout rate, and correlation snapshots
- wire metrics into `NodeManager` and `CommandRouter`, including dispatch/result/timeout tracking and protocol validation counters
- add correlation ID propagation from API requests (`X-Correlation-Id`) through command routing to command results
- expose observability snapshots in `/health` and `/api/admin/stats`
- publish Phase 6 operations docs: dashboard/alert thresholds and incident runbooks

## Testing
- npx tsc --noEmit
- npx jest --ci --coverage --passWithNoTests
- npm run lint

Closes #51
