### PR TITLE
ci(protocol): add explicit schema and compatibility gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Build protocol package
         run: npm run build -w packages/protocol
 
-      - name: Run protocol contract tests
-        run: npm run test -w packages/protocol
+      - name: Run protocol schema tests
+        run: npm run test -w packages/protocol -- schemas.test
+
+      - name: Run protocol cross-repo contract tests
+        run: npm run test -w packages/protocol -- contract.cross-repo
 
       - name: Verify protocol compatibility in apps
         run: |
@@ -41,6 +44,9 @@ jobs:
           echo "Verifying cnc can consume protocol package..."
           # Pattern matches files containing 'protocol.contract' in path
           npm run test -w apps/cnc -- protocol.contract
+
+      - name: Run C&C schema-validation gate
+        run: npm run test:schema-gate -w apps/cnc
 
   validate:
     name: Build, Lint, Typecheck, Test

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Runs on port 8080 by default. See [apps/cnc/README.md](apps/cnc/README.md) for f
 
 Both apps consume it via npm workspace link. It's also published to npm for the mobile app. See [packages/protocol/README.md](packages/protocol/README.md).
 
+Upgrade sequencing and compatibility requirements are documented in:
+- [docs/compatibility.md](docs/compatibility.md)
+- [docs/PROTOCOL_COMPATIBILITY.md](docs/PROTOCOL_COMPATIBILITY.md)
+
 ### Publishing the Protocol Package
 
 To publish `@kaonis/woly-protocol` to npm (for the mobile app):
@@ -175,7 +179,7 @@ docker run -d --net host \
 
 GitHub Actions runs on every push and PR to `master`:
 
-1. Install dependencies (`npm ci`)
+1. Protocol compatibility gate (schema tests, cross-repo contracts, app protocol contracts, C&C schema gate)
 2. Build, lint, typecheck, and test all workspaces via Turborepo
 3. Upload coverage reports as artifacts
 

--- a/apps/cnc/IMPLEMENTATION_CHECKLIST.md
+++ b/apps/cnc/IMPLEMENTATION_CHECKLIST.md
@@ -14,7 +14,7 @@ Owner: Platform Team
 - [x] Create and approve ADRs for API auth, shared protocol package, and durable command lifecycle.
 - [x] Maintain `docs/compatibility.md` with every release.
 - [x] Enforce CI gates for lint, tests, build, and typecheck.
-- [ ] Add schema-validation test gate in CI.
+- [x] Add schema-validation test gate in CI.
 
 Definition of done:
 - [ ] ADRs and compatibility docs merged and discoverable.
@@ -65,11 +65,11 @@ Definition of done:
 - [x] Replace duplicated protocol declarations with `@kaonis/woly-protocol`.
 - [x] Add shared-schema contract tests in C&C test suite.
 - [x] Enforce protocol version compatibility checks during registration.
-- [ ] Add cross-repo contract tests across node and C&C in CI.
-- [ ] Publish compatibility upgrade guide.
+- [x] Add cross-repo contract tests across node and C&C in CI.
+- [x] Publish compatibility upgrade guide.
 
 Definition of done:
-- [ ] Incompatible protocol changes fail CI unless versioned correctly.
+- [x] Incompatible protocol changes fail CI unless versioned correctly.
 
 ## Phase 6 - Observability and Operations
 

--- a/apps/cnc/package.json
+++ b/apps/cnc/package.json
@@ -13,6 +13,7 @@
     "test": "npm run test:preflight && jest",
     "test:watch": "npm run test:preflight && jest --watch",
     "test:ci": "npm run test:preflight && jest --ci --coverage --maxWorkers=2",
+    "test:schema-gate": "npm run test:preflight && jest --ci --runInBand src/services/__tests__/nodeManager.test.ts",
     "test:coverage": "npm run test:preflight && jest --coverage",
     "lint": "eslint src --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/docs/ROADMAP_V3.md
+++ b/docs/ROADMAP_V3.md
@@ -6,17 +6,16 @@ Scope: Continue autonomous delivery after V2 Phase 5 completion (#47 + #51).
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `71f7e03` (PR #126).
-- Active execution branch: `feat/129-node-agent-command-reliability`.
+- `master` synced at merge commit `8fd58b9` (PR #130).
+- Active execution branch: `feat/128-protocol-schema-ci-gates`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
-- #129 `[Node Agent] Phase 4: Command reliability hardening`
 - #128 `[CI/Protocol] Close remaining protocol compatibility and schema gates`
 - #127 `[Security] Node-agent dependency vulnerability remediation plan`
 - #4 `Dependency Dashboard`
 
 ### CI snapshot
-- Post-merge checks for `71f7e03` are green (CI + CodeQL).
+- Post-merge checks for `8fd58b9` are green (CI + CodeQL).
 
 ## 2. Iterative Phases
 
@@ -30,7 +29,7 @@ Acceptance criteria:
 - Add timeout and bounded retry policies per command type.
 - Keep command-result semantics safe under reconnect and retry conditions.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #130)
 
 ### Phase 2: Protocol/schema CI gates closure
 Issue: #128  
@@ -41,7 +40,7 @@ Acceptance criteria:
 - Add cross-repo contract tests for node-agent and C&C in CI.
 - Publish/update compatibility upgrade guide.
 
-Status: `Pending`
+Status: `In Progress` (2026-02-15)
 
 ### Phase 3: Security dependency remediation plan
 Issue: #127  
@@ -71,3 +70,6 @@ For each phase:
 
 - 2026-02-15: Created ROADMAP_V3 after V2 Phase 5 completion.
 - 2026-02-15: Started Phase 1 issue #129 on branch `feat/129-node-agent-command-reliability`.
+- 2026-02-15: Merged #129 via PR #130.
+- 2026-02-15: Verified post-merge `master` checks green for #130 (CI + CodeQL).
+- 2026-02-15: Started Phase 2 issue #128 on branch `feat/128-protocol-schema-ci-gates`.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,41 @@
+# WoLy Compatibility Upgrade Guide
+
+This guide defines the required steps to roll protocol or auth changes safely across `apps/node-agent` and `apps/cnc`.
+
+## Version Matrices
+
+- Node-agent matrix: `apps/node-agent/docs/compatibility.md`
+- C&C matrix: `apps/cnc/docs/compatibility.md`
+- Protocol contract policy: `docs/PROTOCOL_COMPATIBILITY.md`
+
+## Required Upgrade Flow
+
+1. Update protocol/auth code in `packages/protocol`, `apps/node-agent`, and/or `apps/cnc`.
+2. Bump `@kaonis/woly-protocol` version when schema or type contracts change.
+3. Update both compatibility matrices with the new supported pairing.
+4. Run local gates:
+   - `npm run test -w packages/protocol -- schemas.test`
+   - `npm run test -w packages/protocol -- contract.cross-repo`
+   - `npm run test -w apps/node-agent -- protocol.contract`
+   - `npm run test -w apps/cnc -- protocol.contract`
+   - `npm run test:schema-gate -w apps/cnc`
+5. Merge only after CI protocol and schema gates are green.
+
+## CI Enforcement
+
+The `.github/workflows/ci.yml` `protocol-compatibility` job blocks merges unless all of these pass:
+
+1. Protocol schema tests (`packages/protocol`)
+2. Protocol cross-repo contract tests (`packages/protocol`)
+3. Node-agent protocol contract tests
+4. C&C protocol contract tests
+5. C&C schema-validation gate (`nodeManager` runtime validation path)
+
+## Breaking Change Policy
+
+When a protocol change is not backward compatible:
+
+1. Bump protocol major version.
+2. Keep a transition window where C&C accepts both the old and new versions.
+3. Roll out node-agent upgrades in phases (canary -> staged -> full).
+4. Remove old-version compatibility only after all active nodes are upgraded.


### PR DESCRIPTION
## Summary
- add explicit protocol schema + cross-repo contract test steps in CI
- add dedicated C&C schema-validation gate command (`test:schema-gate`) and wire it into CI
- publish top-level compatibility upgrade guide at `docs/compatibility.md` and link it from the root README
- mark corresponding C&C checklist protocol/schema gate items as complete

## Validation
- `npm run test -w packages/protocol -- schemas.test`
- `npm run test -w packages/protocol -- contract.cross-repo`
- `npm run test -w apps/node-agent -- protocol.contract`
- `npm run test -w apps/cnc -- protocol.contract`
- `npm run test:schema-gate -w apps/cnc`
- `npm run typecheck -w apps/cnc`
- `npm run test:ci -w apps/cnc`

Closes #128
