### PR TITLE
security(node-agent): enforce dependency audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Node-agent dependency security gate
+        run: npm run security:audit -w apps/node-agent
+
       - name: Build, lint, typecheck, test
         run: npx turbo run lint typecheck test:ci build
 

--- a/apps/node-agent/IMPLEMENTATION_CHECKLIST.md
+++ b/apps/node-agent/IMPLEMENTATION_CHECKLIST.md
@@ -10,15 +10,13 @@ Owner: Platform Team
 - [x] Ran `npm audit` + `npm audit fix` on branch `feat/phase2-runtime-validation-v2`; safe lockfile updates applied.
 - [~] Phase 3 implementation started on branch `feat/phase3-shared-protocol-adoption`.
 
-## Dependency Security Follow-up (2026-02-07)
+## Dependency Security Follow-up (2026-02-15)
 
-- [x] Apply non-breaking dependency remediations via `npm audit fix`.
-- [ ] Resolve remaining high vulnerabilities tied to `local-devices` -> `get-ip-range` -> `ip` (no upstream fix currently available).
-- [ ] Resolve remaining high vulnerabilities tied to `sqlite3` transitive `node-gyp`/`tar` chain (current npm-proposed fix requires `npm audit fix --force` and a semver-major package change).
-- [ ] Decide remediation strategy:
-- [ ] Option A: replace/remove `local-devices` usage and migrate from `sqlite3` to a maintained storage path.
-- [ ] Option B: accept residual risk temporarily with documented compensating controls and tracked owner/date.
-- [ ] Add a CI/security gate decision for audit behavior (fail on high vs. allowlisted exceptions with expiry).
+- [x] Re-assess dependency risk with fresh `npm audit --json`.
+- [x] Apply non-breaking lockfile remediation (`npm audit fix --package-lock-only`).
+- [x] Confirm current audit state has no high/critical findings.
+- [x] Document remediation strategy, ownership, and exception process in `docs/security/dependency-remediation-plan.md`.
+- [x] Add CI security gate (`npm run security:audit`) to fail on high/critical vulnerabilities.
 
 ## Phase 0 - Baseline and Safety Rails
 
@@ -71,14 +69,14 @@ Definition of done:
 
 ## Phase 4 - Command Execution Reliability
 
-- [ ] Add idempotency guard for duplicate command delivery.
-- [ ] Track local command lifecycle for diagnostics.
-- [ ] Add timeout and bounded retry policies.
-- [ ] Ensure acknowledgment retry semantics are safe.
+- [x] Add idempotency guard for duplicate command delivery.
+- [x] Track local command lifecycle for diagnostics.
+- [x] Add timeout and bounded retry policies.
+- [x] Ensure acknowledgment retry semantics are safe.
 
 Definition of done:
 
-- [ ] Duplicate deliveries do not cause duplicate side effects.
+- [x] Duplicate deliveries do not cause duplicate side effects.
 
 ## Phase 5 - Host Data and Backpressure
 

--- a/apps/node-agent/README.md
+++ b/apps/node-agent/README.md
@@ -453,6 +453,7 @@ apps/node-agent/
 - [Architecture Plan](ARCHITECTURE_PLAN.md) — Multi-phase evolution roadmap
 - [Implementation Checklist](IMPLEMENTATION_CHECKLIST.md) — Progress tracking
 - [Security](SECURITY.md) — Security considerations and practices
+- [Dependency Remediation Plan](docs/security/dependency-remediation-plan.md) — Dependency audit policy and exceptions
 - [Testing](TESTING.md) — Testing strategy and guidelines
 - [Runbook: Reconnect/Auth Loop](docs/runbooks/reconnect-auth-loop.md)
 - [Runbook: Protocol Validation Failures](docs/runbooks/protocol-validation-failures.md)

--- a/apps/node-agent/docs/security/dependency-remediation-plan.md
+++ b/apps/node-agent/docs/security/dependency-remediation-plan.md
@@ -1,0 +1,49 @@
+# Node-Agent Dependency Remediation Plan
+
+Date: 2026-02-15  
+Owner: Platform Team  
+Issue: #127
+
+## Current Audit State
+
+Command run:
+
+```bash
+npm audit --json
+```
+
+Result (2026-02-15):
+
+- High: `0`
+- Critical: `0`
+- Total vulnerabilities: `0`
+
+The previous low-severity `qs` advisory was removed after lockfile remediation via:
+
+```bash
+npm audit fix --package-lock-only
+```
+
+## Remediation Strategy
+
+1. Prefer non-breaking dependency updates (`npm audit fix`) first.
+2. Avoid semver-major or risky forced updates unless a high/critical advisory requires it.
+3. If a high/critical finding cannot be patched immediately, document a time-bound exception with:
+   - owner
+   - risk description
+   - compensating controls
+   - expiry date
+
+## CI Security Policy
+
+Node-agent now enforces a dependency audit gate in CI:
+
+```bash
+npm run security:audit -w apps/node-agent
+```
+
+This runs `npm audit --audit-level=high` and fails CI on any high or critical vulnerability.
+
+## Exception Register
+
+No active high/critical exceptions as of 2026-02-15.

--- a/apps/node-agent/package.json
+++ b/apps/node-agent/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint src --max-warnings=0",
     "lint-fix": "eslint --fix src --max-warnings=0",
     "format": "prettier --write src",
+    "security:audit": "npm audit --audit-level=high",
     "pm2:start": "pm2 start ecosystem.config.js",
     "pm2:stop": "pm2 stop woly-node",
     "pm2:restart": "pm2 restart woly-node",

--- a/docs/ROADMAP_V3.md
+++ b/docs/ROADMAP_V3.md
@@ -6,16 +6,15 @@ Scope: Continue autonomous delivery after V2 Phase 5 completion (#47 + #51).
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `8fd58b9` (PR #130).
-- Active execution branch: `feat/128-protocol-schema-ci-gates`.
+- `master` synced at merge commit `25ccf05` (PR #131).
+- Active execution branch: `feat/127-node-agent-security-remediation`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
-- #128 `[CI/Protocol] Close remaining protocol compatibility and schema gates`
 - #127 `[Security] Node-agent dependency vulnerability remediation plan`
 - #4 `Dependency Dashboard`
 
 ### CI snapshot
-- Post-merge checks for `8fd58b9` are green (CI + CodeQL).
+- Post-merge checks for `25ccf05` are green (CI + CodeQL).
 
 ## 2. Iterative Phases
 
@@ -40,7 +39,7 @@ Acceptance criteria:
 - Add cross-repo contract tests for node-agent and C&C in CI.
 - Publish/update compatibility upgrade guide.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #131)
 
 ### Phase 3: Security dependency remediation plan
 Issue: #127  
@@ -51,7 +50,7 @@ Acceptance criteria:
 - Select and document remediation/acceptance strategy with owner and expiry.
 - Implement mitigation and CI policy updates.
 
-Status: `Pending`
+Status: `In Progress` (2026-02-15)
 
 ## 3. Execution Loop Rules
 
@@ -73,3 +72,6 @@ For each phase:
 - 2026-02-15: Merged #129 via PR #130.
 - 2026-02-15: Verified post-merge `master` checks green for #130 (CI + CodeQL).
 - 2026-02-15: Started Phase 2 issue #128 on branch `feat/128-protocol-schema-ci-gates`.
+- 2026-02-15: Merged #128 via PR #131.
+- 2026-02-15: Verified post-merge `master` checks green for #131 (CI + CodeQL).
+- 2026-02-15: Started Phase 3 issue #127 on branch `feat/127-node-agent-security-remediation`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6974,9 +6974,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Summary
- remediate node-agent dependency audit findings (lockfile update removes remaining advisory)
- add enforceable node-agent dependency security gate (`npm run security:audit`) to CI
- document remediation strategy, ownership, and exception handling in `apps/node-agent/docs/security/dependency-remediation-plan.md`
- update node-agent implementation checklist and docs links to reflect completed security follow-up

## Validation
- `npm audit --json` (apps/node-agent) -> 0 vulnerabilities
- `npm run security:audit -w apps/node-agent`
- `npm run typecheck -w apps/node-agent`
- `npm run lint -w apps/node-agent`
- `npm run test:ci -w apps/node-agent`

Closes #127
