### PR TITLE
feat(cnc): enforce zero-warning lint gate

### DIFF
--- a/apps/cnc/package.json
+++ b/apps/cnc/package.json
@@ -15,7 +15,7 @@
     "test:ci": "npm run test:preflight && jest --ci --coverage --maxWorkers=2",
     "test:schema-gate": "npm run test:preflight && jest --ci --runInBand src/services/__tests__/nodeManager.test.ts",
     "test:coverage": "npm run test:preflight && jest --coverage",
-    "lint": "eslint src --ext .ts",
+    "lint": "eslint src --ext .ts --max-warnings=0",
     "format": "prettier --write \"src/**/*.ts\"",
     "pm2:start": "pm2 start ecosystem.config.js",
     "pm2:stop": "pm2 stop woly-cnc",

--- a/apps/cnc/src/init-db.ts
+++ b/apps/cnc/src/init-db.ts
@@ -8,6 +8,14 @@ import { join } from 'path';
 import db from './database/connection';
 import logger from './utils/logger';
 
+function getTableName(row: unknown): string | null {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+  const maybeName = (row as Record<string, unknown>).table_name;
+  return typeof maybeName === 'string' ? maybeName : null;
+}
+
 async function initDatabase(): Promise<void> {
   try {
     logger.info('Starting database initialization...');
@@ -36,8 +44,9 @@ async function initDatabase(): Promise<void> {
         WHERE type='table' AND name NOT LIKE 'sqlite_%'
         ORDER BY name
       `);
+      const tables = result.rows.map(getTableName).filter((tableName): tableName is string => Boolean(tableName));
       logger.info('Created tables:', {
-        tables: result.rows.map((r: any) => r.table_name)
+        tables
       });
     } else {
       const result = await db.query(`
@@ -46,8 +55,9 @@ async function initDatabase(): Promise<void> {
         WHERE table_schema = 'public'
         ORDER BY table_name
       `);
+      const tables = result.rows.map(getTableName).filter((tableName): tableName is string => Boolean(tableName));
       logger.info('Created tables:', {
-        tables: result.rows.map((r: any) => r.table_name)
+        tables
       });
     }
 

--- a/apps/cnc/src/websocket/sessionTokens.ts
+++ b/apps/cnc/src/websocket/sessionTokens.ts
@@ -45,6 +45,10 @@ function asNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
 export function mintWsSessionToken(nodeId: string, config: WsSessionTokenConfig): WsMintedSessionToken {
   if (!nodeId || nodeId.trim().length === 0) {
     throw new Error('nodeId is required');
@@ -91,8 +95,10 @@ export function verifyWsSessionToken(token: string, config: WsSessionTokenConfig
 
   const header = decodeBase64UrlJson(encodedHeader);
   const payload = decodeBase64UrlJson(encodedPayload);
+  const headerRecord = asRecord(header);
+  const payloadRecord = asRecord(payload);
 
-  const alg = asString((header as any)?.alg);
+  const alg = asString(headerRecord?.alg);
   if (alg !== 'HS256') {
     throw new Error('Unsupported session token algorithm');
   }
@@ -102,12 +108,12 @@ export function verifyWsSessionToken(token: string, config: WsSessionTokenConfig
     throw new Error('Invalid session token signature');
   }
 
-  const issuer = asString((payload as any)?.iss);
-  const audience = asString((payload as any)?.aud);
-  const subject = asString((payload as any)?.sub);
-  const issuedAt = asNumber((payload as any)?.iat);
-  const expiresAt = asNumber((payload as any)?.exp);
-  const tokenType = asString((payload as any)?.typ);
+  const issuer = asString(payloadRecord?.iss);
+  const audience = asString(payloadRecord?.aud);
+  const subject = asString(payloadRecord?.sub);
+  const issuedAt = asNumber(payloadRecord?.iat);
+  const expiresAt = asNumber(payloadRecord?.exp);
+  const tokenType = asString(payloadRecord?.typ);
 
   if (!issuer || issuer !== config.issuer) {
     throw new Error('Invalid session token issuer');

--- a/docs/ROADMAP_V3.md
+++ b/docs/ROADMAP_V3.md
@@ -6,15 +6,17 @@ Scope: Continue autonomous delivery after V2 Phase 5 completion (#47 + #51).
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `25ccf05` (PR #131).
-- Active execution branch: `feat/127-node-agent-security-remediation`.
+- `master` synced at merge commit `742a801` (PR #132).
+- Active execution branch: `feat/133-cnc-zero-warning-lint`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
-- #127 `[Security] Node-agent dependency vulnerability remediation plan`
 - #4 `Dependency Dashboard`
+- #133 `[C&C] Eliminate lint warnings and enforce zero-warning gate`
+- #134 `[C&C] Complete auth 401/403 integration coverage`
+- #135 `[Protocol] Define external publish readiness workflow`
 
 ### CI snapshot
-- Post-merge checks for `25ccf05` are green (CI + CodeQL).
+- Post-merge checks for `742a801` are green (CI + CodeQL).
 
 ## 2. Iterative Phases
 
@@ -50,7 +52,7 @@ Acceptance criteria:
 - Select and document remediation/acceptance strategy with owner and expiry.
 - Implement mitigation and CI policy updates.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #132)
 
 ## 3. Execution Loop Rules
 
@@ -75,3 +77,6 @@ For each phase:
 - 2026-02-15: Merged #128 via PR #131.
 - 2026-02-15: Verified post-merge `master` checks green for #131 (CI + CodeQL).
 - 2026-02-15: Started Phase 3 issue #127 on branch `feat/127-node-agent-security-remediation`.
+- 2026-02-15: Merged #127 via PR #132.
+- 2026-02-15: Verified post-merge `master` checks green for #132 (CI + CodeQL).
+- 2026-02-15: Closed lingering issue #129 manually after verifying PR #130 delivery.

--- a/docs/ROADMAP_V4.md
+++ b/docs/ROADMAP_V4.md
@@ -1,0 +1,75 @@
+# Woly-Server Roadmap V4
+
+Date: 2026-02-15
+Scope: New autonomous cycle after V3 completion.
+
+## 1. Status Audit
+
+### Repository and branch status
+- `master` synced at merge commit `742a801` (PR #132).
+- Active execution branch: `feat/133-cnc-zero-warning-lint`.
+
+### Open issue snapshot (`kaonis/woly-server`)
+- #133 `[C&C] Eliminate lint warnings and enforce zero-warning gate`
+- #134 `[C&C] Complete auth 401/403 integration coverage`
+- #135 `[Protocol] Define external publish readiness workflow`
+- #4 `Dependency Dashboard`
+
+### CI snapshot
+- Post-merge checks for `742a801` are green (CI + CodeQL).
+- New node-agent dependency audit gate is active in CI validate job.
+
+## 2. Iterative Phases
+
+### Phase 1: C&C zero-warning lint enforcement
+Issue: #133  
+Labels: `priority:low`, `technical-debt`, `cnc`
+
+Acceptance criteria:
+- Remove current C&C `no-explicit-any` warnings.
+- Enforce zero-warning lint gate for C&C.
+- Keep all local gates green after typing refactors.
+
+Status: `In Progress` (2026-02-15)
+
+### Phase 2: C&C auth integration coverage completion
+Issue: #134  
+Labels: `priority:low`, `testing`, `cnc`
+
+Acceptance criteria:
+- Add/verify 401 and 403 integration coverage for protected endpoints.
+- Cover missing token, malformed token, invalid signature, expired token, and role mismatch.
+- Update checklist status to reflect delivered coverage.
+
+Status: `Pending`
+
+### Phase 3: Protocol external publish readiness
+Issue: #135  
+Labels: `priority:low`, `protocol`, `technical-debt`
+
+Acceptance criteria:
+- Document concrete publish readiness criteria.
+- Document external release + rollback workflow.
+- Align checklist/docs state with publish decision.
+
+Status: `Pending`
+
+## 3. Execution Loop Rules
+
+For each phase:
+1. Create branch `feat/<issue>-<slug>` or `fix/<issue>-<slug>`.
+2. Implement smallest complete change meeting acceptance criteria.
+3. Add/update tests.
+4. Run local gate:
+   - `npm run typecheck`
+   - `npm run test:ci`
+5. Open PR (`Closes #<issue>`) and merge after green CI.
+6. Verify post-merge `master` CI.
+7. Update roadmap progress and continue.
+
+## 4. Progress Log
+
+- 2026-02-15: Created ROADMAP_V4 after V3 phase set completion.
+- 2026-02-15: Started Phase 1 issue #133 on branch `feat/133-cnc-zero-warning-lint`.
+- 2026-02-15: Implemented #133 lint warning removals in C&C and enforced `--max-warnings=0` for `apps/cnc`.
+- 2026-02-15: Ran local gates for #133 (`npm run lint -w apps/cnc`, `npm run typecheck -w apps/cnc`, `npm run test:ci -w apps/cnc`) successfully.


### PR DESCRIPTION
## Summary
- remove explicit `any` usage in C&C DB init table-name logging
- replace JWT payload/header `any` casts in WS session token verification with typed record narrowing
- enforce zero-warning lint gate for C&C via `eslint --max-warnings=0`
- roll roadmap state forward into ROADMAP_V4 for current autonomous cycle

## Validation
- npm run lint -w apps/cnc
- npm run typecheck -w apps/cnc
- npm run test:ci -w apps/cnc

Closes #133
