### PR TITLE
test(cnc): complete auth integration coverage for protected routes

### DIFF
--- a/apps/cnc/IMPLEMENTATION_CHECKLIST.md
+++ b/apps/cnc/IMPLEMENTATION_CHECKLIST.md
@@ -8,6 +8,7 @@ Owner: Platform Team
 - [x] Phase 1 implemented (JWT auth + RBAC).
 - [x] Phase 2 implemented baseline (WebSocket auth hardening).
 - [x] Shared protocol adoption started on branch `feat/phase3-shared-protocol-adoption` to align with `woly-backend` Phase 3 rollout.
+- [x] Auth-path integration coverage now explicitly includes missing token, malformed token, invalid signature, expired token, and role-mismatch scenarios.
 
 ## Phase 0 - Baseline and Safety Rails
 
@@ -25,7 +26,7 @@ Definition of done:
 - [x] Add JWT auth middleware for `/api/hosts/*` and `/api/admin/*`.
 - [x] Add role-based authorization (`operator`, `admin`).
 - [x] Enforce issuer/audience/expiry checks.
-- [ ] Add integration tests for 401 and 403 paths.
+- [x] Add integration tests for 401 and 403 paths.
 
 Definition of done:
 - [x] Protected routes reject unauthorized requests.

--- a/docs/ROADMAP_V4.md
+++ b/docs/ROADMAP_V4.md
@@ -30,7 +30,7 @@ Acceptance criteria:
 - Enforce zero-warning lint gate for C&C.
 - Keep all local gates green after typing refactors.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #136)
 
 ### Phase 2: C&C auth integration coverage completion
 Issue: #134  
@@ -41,7 +41,7 @@ Acceptance criteria:
 - Cover missing token, malformed token, invalid signature, expired token, and role mismatch.
 - Update checklist status to reflect delivered coverage.
 
-Status: `Pending`
+Status: `In Progress` (2026-02-15)
 
 ### Phase 3: Protocol external publish readiness
 Issue: #135  
@@ -73,3 +73,5 @@ For each phase:
 - 2026-02-15: Started Phase 1 issue #133 on branch `feat/133-cnc-zero-warning-lint`.
 - 2026-02-15: Implemented #133 lint warning removals in C&C and enforced `--max-warnings=0` for `apps/cnc`.
 - 2026-02-15: Ran local gates for #133 (`npm run lint -w apps/cnc`, `npm run typecheck -w apps/cnc`, `npm run test:ci -w apps/cnc`) successfully.
+- 2026-02-15: Merged #133 via PR #136 and verified post-merge `master` checks green (CI + CodeQL).
+- 2026-02-15: Started Phase 2 issue #134 on branch `feat/134-cnc-auth-integration-coverage`.


### PR DESCRIPTION
## Summary
- expand Node route auth integration tests to cover malformed headers, expired tokens, invalid signatures, and explicit role mismatches
- expand MAC-vendor protected endpoint auth integration tests to cover malformed/invalid/expired tokens and role mismatch
- mark Phase 1 auth 401/403 integration checklist item complete and record auditable coverage status
- update ROADMAP_V4 progress (Phase 1 complete, Phase 2 in progress)

## Validation
- npm run lint -w apps/cnc
- npm run typecheck -w apps/cnc
- npm run test:ci -w apps/cnc

Closes #134
