### PR TITLE
docs(protocol): add external publish readiness and rollback workflow

### DIFF
--- a/apps/node-agent/IMPLEMENTATION_CHECKLIST.md
+++ b/apps/node-agent/IMPLEMENTATION_CHECKLIST.md
@@ -61,7 +61,8 @@ Definition of done:
 - [x] Add protocol version negotiation at connect.
 - [x] Add cross-repo contract tests.
 - [x] Add CI workflow to enforce protocol compatibility checks.
-- [ ] Publish `@kaonis/woly-protocol` to shared registry (monorepo uses workspace links; publishing only needed for external consumers like mobile app).
+- [x] Define external publish readiness + rollback workflow for `@kaonis/woly-protocol` in `docs/PROTOCOL_PUBLISH_WORKFLOW.md`.
+- [~] Publish `@kaonis/woly-protocol` when an external consumer release requires it (follow `docs/PROTOCOL_PUBLISH_WORKFLOW.md`).
 
 Definition of done:
 

--- a/docs/PROTOCOL_COMPATIBILITY.md
+++ b/docs/PROTOCOL_COMPATIBILITY.md
@@ -141,6 +141,9 @@ npm run protocol:publish:next
 
 **Note**: Monorepo apps continue using workspace links. Publishing is only required for external consumers.
 
+For publish readiness criteria, release steps, and rollback actions, use:
+- [`docs/PROTOCOL_PUBLISH_WORKFLOW.md`](./PROTOCOL_PUBLISH_WORKFLOW.md)
+
 ## Breaking Change Workflow
 
 When introducing breaking changes to the protocol:
@@ -278,4 +281,5 @@ This verifies:
 - [Architecture Plan Phase 3](../apps/node-agent/ARCHITECTURE_PLAN.md)
 - [Implementation Checklist](../apps/node-agent/IMPLEMENTATION_CHECKLIST.md)
 - [Protocol Package README](../packages/protocol/README.md)
+- [Protocol Publish Workflow](./PROTOCOL_PUBLISH_WORKFLOW.md)
 - [CI Workflow](../.github/workflows/ci.yml)

--- a/docs/PROTOCOL_PUBLISH_WORKFLOW.md
+++ b/docs/PROTOCOL_PUBLISH_WORKFLOW.md
@@ -1,0 +1,69 @@
+# Protocol External Publish Workflow
+
+Date: 2026-02-15
+Owner: Platform Team
+Package: `@kaonis/woly-protocol`
+
+## 1. Decision State
+
+- Monorepo services (`apps/node-agent`, `apps/cnc`) use workspace-linked protocol code.
+- npm publishing is **on-demand** and only required for external consumers (for example, the mobile app).
+- Do not publish protocol versions that are not tied to an external consumer release need.
+
+## 2. Publish Readiness Criteria
+
+All items must be true before running `npm run protocol:publish` or `npm run protocol:publish:next`:
+
+1. Version bump is correct for change type (`patch`/`minor`/`major`).
+2. Compatibility docs are updated:
+   - `docs/PROTOCOL_COMPATIBILITY.md`
+   - `docs/compatibility.md` (if rollout guidance changed)
+3. Local verification passes:
+   - `npm run protocol:build`
+   - `npm test -w packages/protocol`
+   - `npm run test -w apps/node-agent -- protocol.contract`
+   - `npm run test -w apps/cnc -- protocol.contract`
+4. CI protocol gates are green on the PR branch.
+5. Release notes/changelog entry exists in the PR description and includes:
+   - protocol version
+   - compatibility impact
+   - required consumer action
+
+## 3. Release Workflow
+
+1. Create branch: `feat/protocol-release-<version>`.
+2. Bump version from monorepo root:
+   - `npm run protocol:version:patch` or
+   - `npm run protocol:version:minor` or
+   - `npm run protocol:version:major`
+3. Run readiness verification commands from Section 2.
+4. Merge PR after CI is green.
+5. Publish from `master`:
+   - stable: `npm run protocol:publish`
+   - prerelease/canary: `npm run protocol:publish:next`
+6. Create release communication entry (issue/PR comment) with:
+   - published package version
+   - npm dist-tag (`latest` or `next`)
+   - external consumer rollout owner
+
+## 4. Rollback Workflow
+
+If a bad package version is published:
+
+1. Immediately stop new consumer rollouts.
+2. Deprecate the bad version on npm:
+   - `npm deprecate @kaonis/woly-protocol@<bad_version> \"Deprecated due to regression; use <fixed_version_or_previous_version>\"`
+3. Publish a fixed version:
+   - patch bump for non-breaking fix
+   - major bump plus compatibility guidance for breaking correction
+4. Update compatibility docs and communicate rollback status to consumer owners.
+5. Open a post-incident issue with:
+   - root cause
+   - affected versions
+   - preventive actions
+
+## 5. Operational Guardrails
+
+- Never rely on npm unpublish as the primary rollback path.
+- For breaking protocol changes, keep dual-version compatibility (`SUPPORTED_PROTOCOL_VERSIONS`) during migration windows.
+- If rollback requires schema compatibility restoration, prioritize server-side dual support before forcing consumer upgrades.

--- a/docs/ROADMAP_V4.md
+++ b/docs/ROADMAP_V4.md
@@ -41,7 +41,7 @@ Acceptance criteria:
 - Cover missing token, malformed token, invalid signature, expired token, and role mismatch.
 - Update checklist status to reflect delivered coverage.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #137)
 
 ### Phase 3: Protocol external publish readiness
 Issue: #135  
@@ -52,7 +52,7 @@ Acceptance criteria:
 - Document external release + rollback workflow.
 - Align checklist/docs state with publish decision.
 
-Status: `Pending`
+Status: `In Progress` (2026-02-15)
 
 ## 3. Execution Loop Rules
 
@@ -75,3 +75,7 @@ For each phase:
 - 2026-02-15: Ran local gates for #133 (`npm run lint -w apps/cnc`, `npm run typecheck -w apps/cnc`, `npm run test:ci -w apps/cnc`) successfully.
 - 2026-02-15: Merged #133 via PR #136 and verified post-merge `master` checks green (CI + CodeQL).
 - 2026-02-15: Started Phase 2 issue #134 on branch `feat/134-cnc-auth-integration-coverage`.
+- 2026-02-15: Merged #134 via PR #137 and verified post-merge `master` checks green (CI + CodeQL).
+- 2026-02-15: Started Phase 3 issue #135 on branch `feat/135-protocol-publish-readiness-workflow`.
+- 2026-02-15: Added protocol external publish readiness + rollback workflow documentation and linked checklist/docs for decision-state clarity.
+- 2026-02-15: Ran local protocol gates for #135 (`npm run typecheck -w packages/protocol`, `npm run test:ci -w packages/protocol`) successfully.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,6 +7,7 @@ This guide defines the required steps to roll protocol or auth changes safely ac
 - Node-agent matrix: `apps/node-agent/docs/compatibility.md`
 - C&C matrix: `apps/cnc/docs/compatibility.md`
 - Protocol contract policy: `docs/PROTOCOL_COMPATIBILITY.md`
+- Protocol external publish workflow: `docs/PROTOCOL_PUBLISH_WORKFLOW.md`
 
 ## Required Upgrade Flow
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -99,7 +99,10 @@ The package includes schema validation tests in `src/__tests__/schemas.test.ts`.
 
 ## Publishing to npm
 
-This package is also published to npm for the mobile app to consume.
+This package is published to npm only when external consumers (for example, mobile app releases) require updated protocol contracts.
+
+Before publishing, follow the readiness and rollback runbook:
+- [`docs/PROTOCOL_PUBLISH_WORKFLOW.md`](../../docs/PROTOCOL_PUBLISH_WORKFLOW.md)
 
 ### Quick Start (Recommended)
 


### PR DESCRIPTION
## Summary
- add `docs/PROTOCOL_PUBLISH_WORKFLOW.md` with explicit publish readiness criteria, release process, rollback flow, and operational guardrails for `@kaonis/woly-protocol`
- align protocol docs (`docs/PROTOCOL_COMPATIBILITY.md`, `docs/compatibility.md`, `packages/protocol/README.md`) to reference the external publish runbook
- update node-agent checklist to reflect the explicit publish decision state (workflow defined; publish executed on-demand for external consumers)
- update `docs/ROADMAP_V4.md` progress for completed #134 and active #135 work

## Validation
- npm run typecheck -w packages/protocol
- npm run test:ci -w packages/protocol

Closes #135
