### PR TITLE
docs(cnc): reconcile checklist DoD status and start roadmap v5

### DIFF
--- a/apps/cnc/IMPLEMENTATION_CHECKLIST.md
+++ b/apps/cnc/IMPLEMENTATION_CHECKLIST.md
@@ -10,6 +10,10 @@ Owner: Platform Team
 - [x] Shared protocol adoption started on branch `feat/phase3-shared-protocol-adoption` to align with `woly-backend` Phase 3 rollout.
 - [x] Auth-path integration coverage now explicitly includes missing token, malformed token, invalid signature, expired token, and role-mismatch scenarios.
 
+## Checklist Reconciliation (2026-02-15)
+
+- [x] Phase 0 Definition-of-Done references audited for ADR/doc/CI discoverability.
+
 ## Phase 0 - Baseline and Safety Rails
 
 - [x] Create and approve ADRs for API auth, shared protocol package, and durable command lifecycle.
@@ -18,8 +22,8 @@ Owner: Platform Team
 - [x] Add schema-validation test gate in CI.
 
 Definition of done:
-- [ ] ADRs and compatibility docs merged and discoverable.
-- [ ] CI consistently blocks regressions.
+- [x] ADRs and compatibility docs merged and discoverable (`apps/cnc/docs/adr/`, `docs/compatibility.md`, `docs/PROTOCOL_COMPATIBILITY.md`, `docs/PROTOCOL_PUBLISH_WORKFLOW.md`).
+- [x] CI consistently blocks regressions (`.github/workflows/ci.yml` validate + protocol compatibility jobs, including schema gate).
 
 ## Phase 1 - API Authentication and Authorization
 

--- a/docs/ROADMAP_V4.md
+++ b/docs/ROADMAP_V4.md
@@ -52,7 +52,7 @@ Acceptance criteria:
 - Document external release + rollback workflow.
 - Align checklist/docs state with publish decision.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #138)
 
 ## 3. Execution Loop Rules
 
@@ -79,3 +79,5 @@ For each phase:
 - 2026-02-15: Started Phase 3 issue #135 on branch `feat/135-protocol-publish-readiness-workflow`.
 - 2026-02-15: Added protocol external publish readiness + rollback workflow documentation and linked checklist/docs for decision-state clarity.
 - 2026-02-15: Ran local protocol gates for #135 (`npm run typecheck -w packages/protocol`, `npm run test:ci -w packages/protocol`) successfully.
+- 2026-02-15: Merged #135 via PR #138 and verified post-merge `master` checks green (CI + CodeQL).
+- 2026-02-15: V4 phase set completed; next cycle planned in `docs/ROADMAP_V5.md`.

--- a/docs/ROADMAP_V5.md
+++ b/docs/ROADMAP_V5.md
@@ -1,0 +1,75 @@
+# Woly-Server Roadmap V5
+
+Date: 2026-02-15
+Scope: New autonomous cycle after V4 completion.
+
+## 1. Status Audit
+
+### Repository and branch status
+- `master` synced at merge commit `1868364` (PR #138).
+- Active execution branch: `master`.
+
+### Open issue snapshot (`kaonis/woly-server`)
+- #4 `Dependency Dashboard`
+- #139 `[C&C] Reconcile implementation checklist Definition-of-Done status`
+- #140 `[Testing] Define and enforce staged coverage-ratchet policy`
+- #141 `[Dependencies] Operationalize Dependency Dashboard triage workflow`
+
+### CI snapshot
+- Post-merge checks for `1868364` are green (CI + CodeQL).
+- Protocol compatibility and C&C schema gates are active in CI.
+
+## 2. Iterative Phases
+
+### Phase 1: C&C checklist DoD reconciliation
+Issue: #139  
+Labels: `priority:low`, `technical-debt`, `cnc`
+
+Acceptance criteria:
+- Audit C&C checklist Definition-of-Done items against current docs/CI implementation.
+- Update checklist statuses to match verifiable repository state.
+- Add references to concrete docs/workflows for completed DoD items.
+
+Status: `In Progress` (2026-02-15)
+
+### Phase 2: Coverage ratchet policy and gate
+Issue: #140  
+Labels: `priority:medium`, `testing`, `technical-debt`
+
+Acceptance criteria:
+- Document baseline coverage and staged thresholds.
+- Configure tests/CI to fail when coverage regresses below baseline.
+- Publish phased plan for threshold increases.
+
+Status: `Pending`
+
+### Phase 3: Dependency dashboard triage workflow
+Issue: #141  
+Labels: `priority:low`, `security`, `technical-debt`
+
+Acceptance criteria:
+- Define dependency triage ownership and cadence.
+- Document decision categories and defer/acceptance policy.
+- Link triage process from roadmap/checklist docs.
+
+Status: `Pending`
+
+## 3. Execution Loop Rules
+
+For each phase:
+1. Create branch `feat/<issue>-<slug>` or `fix/<issue>-<slug>`.
+2. Implement smallest complete change meeting acceptance criteria.
+3. Add/update tests.
+4. Run local gate:
+   - `npm run typecheck`
+   - `npm run test:ci`
+5. Open PR (`Closes #<issue>`) and merge after green CI.
+6. Verify post-merge `master` CI.
+7. Update roadmap progress and continue.
+
+## 4. Progress Log
+
+- 2026-02-15: Created ROADMAP_V5 after V4 completion.
+- 2026-02-15: Started Phase 1 issue #139 on branch `feat/139-cnc-checklist-dod-reconciliation`.
+- 2026-02-15: Reconciled C&C Phase 0 Definition-of-Done checklist items with explicit ADR/docs/CI workflow references.
+- 2026-02-15: Ran local C&C gates for #139 (`npm run typecheck -w apps/cnc`, `npm run test:ci -w apps/cnc`) successfully.


### PR DESCRIPTION
## Summary
- reconcile C&C Phase 0 Definition-of-Done checklist entries against current verifiable repository state
- add explicit references for ADR discoverability, compatibility docs, and CI regression gates
- close out ROADMAP_V4 with final #135 completion status and post-merge verification
- create ROADMAP_V5 with the new issue phase set (#139, #140, #141) and mark #139 in progress

## Validation
- npm run typecheck -w apps/cnc
- npm run test:ci -w apps/cnc

Closes #139
