### PR TITLE
test(cnc): enforce coverage ratchet baseline and staged policy

### DIFF
--- a/apps/cnc/IMPLEMENTATION_CHECKLIST.md
+++ b/apps/cnc/IMPLEMENTATION_CHECKLIST.md
@@ -13,6 +13,7 @@ Owner: Platform Team
 ## Checklist Reconciliation (2026-02-15)
 
 - [x] Phase 0 Definition-of-Done references audited for ADR/doc/CI discoverability.
+- [x] Coverage ratchet baseline policy documented and enforced (`apps/cnc/docs/coverage-ratchet-policy.md`, `apps/cnc/jest.config.js`).
 
 ## Phase 0 - Baseline and Safety Rails
 

--- a/apps/cnc/docs/coverage-ratchet-policy.md
+++ b/apps/cnc/docs/coverage-ratchet-policy.md
@@ -1,0 +1,45 @@
+# C&C Coverage Ratchet Policy
+
+Date: 2026-02-15
+Owner: Platform Team
+Scope: `apps/cnc`
+
+## 1. Purpose
+
+This policy prevents test coverage regression while raising thresholds in staged increments toward long-term targets.
+
+## 2. Current Baseline Gate
+
+As of 2026-02-15, Jest global coverage thresholds are enforced in `apps/cnc/jest.config.js`:
+
+- statements: `68`
+- lines: `68`
+- functions: `72`
+- branches: `58`
+
+These values match current delivered coverage and are a non-regression floor.
+
+## 3. Ratchet Plan
+
+Threshold increases are staged and must be raised only in PRs that add/expand tests.
+
+| Phase | Statements | Lines | Functions | Branches | Trigger |
+|---|---:|---:|---:|---:|---|
+| Baseline (current) | 68 | 68 | 72 | 58 | Established in #140 |
+| Stage A | 72 | 72 | 74 | 60 | After command/router and runtime error-path additions |
+| Stage B | 76 | 76 | 78 | 64 | After service/model branch coverage expansions |
+| Target | 80 | 80 | 80 | 70 | Stable sustained coverage and no active coverage debt |
+
+## 4. Enforcement Rules
+
+1. `npm run test:ci -w apps/cnc` must fail if coverage drops below the configured baseline gate.
+2. Thresholds may only move upward in normal operation.
+3. Any temporary threshold reduction requires a time-bound follow-up issue and explicit approval in PR notes.
+4. Coverage summaries should be captured in PR validation notes when thresholds are changed.
+
+## 5. Update Procedure
+
+1. Add tests for targeted low-coverage areas.
+2. Run `npm run test:ci -w apps/cnc` and capture resulting global coverage.
+3. Raise `coverageThreshold.global` in `apps/cnc/jest.config.js` to the new floor.
+4. Update this document to reflect the new phase and rationale.

--- a/apps/cnc/jest.config.js
+++ b/apps/cnc/jest.config.js
@@ -18,10 +18,11 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 50,
-      functions: 50,
-      lines: 50,
-      statements: 50
+      // Baseline ratchet gate (2026-02-15): prevent coverage regression.
+      branches: 58,
+      functions: 72,
+      lines: 68,
+      statements: 68
     }
   },
   coverageDirectory: 'coverage',

--- a/docs/ROADMAP_V5.md
+++ b/docs/ROADMAP_V5.md
@@ -30,7 +30,7 @@ Acceptance criteria:
 - Update checklist statuses to match verifiable repository state.
 - Add references to concrete docs/workflows for completed DoD items.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #142)
 
 ### Phase 2: Coverage ratchet policy and gate
 Issue: #140  
@@ -41,7 +41,7 @@ Acceptance criteria:
 - Configure tests/CI to fail when coverage regresses below baseline.
 - Publish phased plan for threshold increases.
 
-Status: `Pending`
+Status: `In Progress` (2026-02-15)
 
 ### Phase 3: Dependency dashboard triage workflow
 Issue: #141  
@@ -73,3 +73,7 @@ For each phase:
 - 2026-02-15: Started Phase 1 issue #139 on branch `feat/139-cnc-checklist-dod-reconciliation`.
 - 2026-02-15: Reconciled C&C Phase 0 Definition-of-Done checklist items with explicit ADR/docs/CI workflow references.
 - 2026-02-15: Ran local C&C gates for #139 (`npm run typecheck -w apps/cnc`, `npm run test:ci -w apps/cnc`) successfully.
+- 2026-02-15: Merged #139 via PR #142 and verified post-merge `master` checks green (CodeQL; CI not triggered for docs-only change).
+- 2026-02-15: Started Phase 2 issue #140 on branch `feat/140-cnc-coverage-ratchet-policy`.
+- 2026-02-15: Added C&C coverage-ratchet policy doc and raised Jest global coverage thresholds to a non-regression baseline gate.
+- 2026-02-15: Ran local C&C gates for #140 (`npm run typecheck -w apps/cnc`, `npm run test:ci -w apps/cnc`) successfully.


### PR DESCRIPTION
## Summary
- add `apps/cnc/docs/coverage-ratchet-policy.md` defining the baseline coverage gate and staged threshold plan toward higher targets
- raise C&C Jest global coverage thresholds to a non-regression baseline (`statements/lines 68`, `functions 72`, `branches 58`)
- record coverage-ratchet policy enforcement in the C&C implementation checklist
- roll ROADMAP_V5 forward (Phase 1 complete via #142, Phase 2 in progress)

## Validation
- npm run typecheck -w apps/cnc
- npm run test:ci -w apps/cnc

Closes #140
