### PR TITLE
docs(deps): operationalize dependency dashboard triage workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ All checks must pass for a PR to be merged. The workflow runs:
 
 See [.github/workflows/ci.yml](.github/workflows/ci.yml).
 
+Dependency update review cadence and decision rules are documented in:
+- [docs/DEPENDENCY_TRIAGE_WORKFLOW.md](docs/DEPENDENCY_TRIAGE_WORKFLOW.md)
+
 **Note:** To enforce PR blocking, configure branch protection rules in GitHub repository settings to require the `validate` status check to pass before merging.
 
 ## Tech Stack

--- a/apps/node-agent/IMPLEMENTATION_CHECKLIST.md
+++ b/apps/node-agent/IMPLEMENTATION_CHECKLIST.md
@@ -17,6 +17,7 @@ Owner: Platform Team
 - [x] Confirm current audit state has no high/critical findings.
 - [x] Document remediation strategy, ownership, and exception process in `docs/security/dependency-remediation-plan.md`.
 - [x] Add CI security gate (`npm run security:audit`) to fail on high/critical vulnerabilities.
+- [x] Link dependency triage ownership/cadence policy in `docs/DEPENDENCY_TRIAGE_WORKFLOW.md`.
 
 ## Phase 0 - Baseline and Safety Rails
 

--- a/docs/DEPENDENCY_TRIAGE_WORKFLOW.md
+++ b/docs/DEPENDENCY_TRIAGE_WORKFLOW.md
@@ -1,0 +1,71 @@
+# Dependency Dashboard Triage Workflow
+
+Date: 2026-02-15
+Owner: Platform Team (rotating on-call maintainer)
+Primary source: GitHub issue `#4` (Dependency Dashboard)
+
+## 1. Purpose
+
+Define a repeatable dependency triage process so update decisions are explicit, auditable, and tied to follow-up work.
+
+## 2. Cadence and Ownership
+
+1. Primary triage cadence: weekly.
+2. Event-driven triage: immediately after new Renovate/Mend dependency PR bursts.
+3. Owner: current platform on-call maintainer.
+4. Backup owner: repository maintainer with merge rights.
+
+## 3. Input Sources
+
+- Issue `#4` Dependency Dashboard state.
+- Open dependency update PRs.
+- CI/security signals (`npm audit`, CodeQL, failing dependency-related CI).
+
+## 4. Decision Categories
+
+For each dependency PR/update, choose one category:
+
+### A. Auto-merge safe
+
+Use when all conditions are true:
+- patch/minor change with no runtime contract impact.
+- CI and tests pass without source changes.
+- no security or licensing concerns detected.
+
+Action:
+- merge dependency PR after checks pass.
+
+### B. Manual validation required
+
+Use when any condition is true:
+- major version update.
+- runtime-critical package (`express`, `ws`, `zod`, `pg`, `better-sqlite3`, auth/security middleware).
+- schema/typing behavior changes likely to affect protocol or API contracts.
+
+Action:
+- open/attach a scoped validation issue.
+- run targeted test matrix before merge.
+
+### C. Deferred with rationale
+
+Use when update is blocked by compatibility risk, tooling limits, or upstream instability.
+
+Action:
+- document defer reason in issue `#4` comment.
+- include re-evaluation date or trigger.
+- create follow-up issue if work is required to unblock.
+
+## 5. Required Triage Output
+
+For each triage pass, post a short issue `#4` comment containing:
+
+1. Date and owner.
+2. Updates merged.
+3. Updates requiring manual validation.
+4. Deferred updates with rationale and follow-up links.
+
+## 6. Operational Rules
+
+1. Do not defer without rationale.
+2. Do not merge major dependency changes without explicit validation notes.
+3. Keep dependency triage outcomes reflected in the active roadmap phase when non-trivial work is required.

--- a/docs/ROADMAP_V5.md
+++ b/docs/ROADMAP_V5.md
@@ -41,7 +41,7 @@ Acceptance criteria:
 - Configure tests/CI to fail when coverage regresses below baseline.
 - Publish phased plan for threshold increases.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #143)
 
 ### Phase 3: Dependency dashboard triage workflow
 Issue: #141  
@@ -52,7 +52,7 @@ Acceptance criteria:
 - Document decision categories and defer/acceptance policy.
 - Link triage process from roadmap/checklist docs.
 
-Status: `Pending`
+Status: `In Progress` (2026-02-15)
 
 ## 3. Execution Loop Rules
 
@@ -77,3 +77,9 @@ For each phase:
 - 2026-02-15: Started Phase 2 issue #140 on branch `feat/140-cnc-coverage-ratchet-policy`.
 - 2026-02-15: Added C&C coverage-ratchet policy doc and raised Jest global coverage thresholds to a non-regression baseline gate.
 - 2026-02-15: Ran local C&C gates for #140 (`npm run typecheck -w apps/cnc`, `npm run test:ci -w apps/cnc`) successfully.
+- 2026-02-15: Merged #140 via PR #143 and verified post-merge `master` checks green (CI + CodeQL).
+- 2026-02-15: Started Phase 3 issue #141 on branch `feat/141-dependency-dashboard-triage-workflow`.
+- 2026-02-15: Added dependency dashboard triage workflow with ownership, cadence, decision categories, and defer/follow-up policy.
+- 2026-02-15: Linked dependency triage workflow from README and node-agent checklist.
+- 2026-02-15: Ran local node-agent gates for #141 (`npm run typecheck -w apps/node-agent`, `npm run test:ci -w apps/node-agent`) successfully.
+- 2026-02-15: Added triage output comment on issue #4 and created follow-up issue #144 for deferred major dependency upgrades.


### PR DESCRIPTION
## Summary
- add `docs/DEPENDENCY_TRIAGE_WORKFLOW.md` with explicit ownership, cadence, triage categories, and defer/follow-up requirements for Dependency Dashboard handling
- link dependency triage workflow from root README and node-agent implementation checklist
- update ROADMAP_V5 progress (Phase 2 completed via #143, Phase 3 in progress)
- perform initial triage output on issue #4 and create #144 to track deferred major upgrade wave

## Validation
- npm run typecheck -w apps/node-agent
- npm run test:ci -w apps/node-agent

Closes #141
