### PR TITLE
docs(deps): publish major dependency upgrade wave plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ See [.github/workflows/ci.yml](.github/workflows/ci.yml).
 
 Dependency update review cadence and decision rules are documented in:
 - [docs/DEPENDENCY_TRIAGE_WORKFLOW.md](docs/DEPENDENCY_TRIAGE_WORKFLOW.md)
+- [docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md](docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md)
 
 **Note:** To enforce PR blocking, configure branch protection rules in GitHub repository settings to require the `validate` status check to pass before merging.
 

--- a/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
+++ b/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
@@ -1,0 +1,70 @@
+# Dependency Major Upgrade Wave Plan
+
+Date: 2026-02-15
+Owner: Platform Team
+Source: Dependency Dashboard (`#4`)
+
+## 1. Scope
+
+This plan covers the currently deferred or high-risk major dependency updates:
+
+- ESLint v10
+- typescript-eslint v8
+- eslint-config-prettier v10
+- Zod v4
+- npm v11
+
+## 2. Risk Profile
+
+### Tooling-only risk (medium)
+
+- ESLint v10
+- typescript-eslint v8
+- eslint-config-prettier v10
+
+Primary impact:
+- lint configuration and rule behavior changes
+- developer/CI lint task stability
+
+### Runtime schema risk (high)
+
+- Zod v4
+
+Primary impact:
+- runtime validation behavior across `packages/protocol`, `apps/cnc`, and `apps/node-agent`
+- potential contract/serialization edge differences
+
+### Package manager/runtime risk (medium)
+
+- npm v11
+
+Primary impact:
+- workspace install/task behavior
+- lockfile and CI reproducibility
+
+## 3. Sequenced Execution Waves
+
+1. Wave A: tooling major upgrades  
+   Tracking issue: #146
+2. Wave B: Zod v4 migration and validation  
+   Tracking issue: #147
+3. Wave C: npm 11 adoption decision  
+   Tracking issue: #148
+
+## 4. Decision Table (2026-02-15)
+
+| Dependency | Decision | Rationale | Tracking |
+|---|---|---|---|
+| ESLint v10 | Merge candidate | Toolchain-only major; manageable with focused lint migration | #146 |
+| typescript-eslint v8 | Merge candidate | Coupled with ESLint upgrade; should be migrated together | #146 |
+| eslint-config-prettier v10 | Merge candidate | Companion lint stack upgrade with low runtime risk | #146 |
+| Zod v4 | Deferred pending validation | Runtime schema behavior can affect protocol/API contract guarantees | #147 |
+| npm v11 | Deferred pending compatibility evaluation | Potential workspace/CI/lockfile behavior changes require explicit validation | #148 |
+
+## 5. Exit Criteria for #144
+
+Issue #144 is complete when:
+
+1. Decision table is documented and linked in roadmap progress.
+2. Execution/defer follow-up issues are in place (#146, #147, #148).
+3. Dependency dashboard comment history references these decisions for auditability.

--- a/docs/DEPENDENCY_TRIAGE_WORKFLOW.md
+++ b/docs/DEPENDENCY_TRIAGE_WORKFLOW.md
@@ -69,3 +69,8 @@ For each triage pass, post a short issue `#4` comment containing:
 1. Do not defer without rationale.
 2. Do not merge major dependency changes without explicit validation notes.
 3. Keep dependency triage outcomes reflected in the active roadmap phase when non-trivial work is required.
+
+## 7. Major Upgrade Planning Reference
+
+For active major dependency wave planning and current merge/defer decisions, see:
+- `docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md`

--- a/docs/ROADMAP_V5.md
+++ b/docs/ROADMAP_V5.md
@@ -52,7 +52,7 @@ Acceptance criteria:
 - Document decision categories and defer/acceptance policy.
 - Link triage process from roadmap/checklist docs.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #145)
 
 ## 3. Execution Loop Rules
 
@@ -83,3 +83,5 @@ For each phase:
 - 2026-02-15: Linked dependency triage workflow from README and node-agent checklist.
 - 2026-02-15: Ran local node-agent gates for #141 (`npm run typecheck -w apps/node-agent`, `npm run test:ci -w apps/node-agent`) successfully.
 - 2026-02-15: Added triage output comment on issue #4 and created follow-up issue #144 for deferred major dependency upgrades.
+- 2026-02-15: Merged #141 via PR #145 and verified post-merge `master` checks green (CI + CodeQL).
+- 2026-02-15: V5 phase set completed; next cycle planned in `docs/ROADMAP_V6.md`.

--- a/docs/ROADMAP_V6.md
+++ b/docs/ROADMAP_V6.md
@@ -1,0 +1,78 @@
+# Woly-Server Roadmap V6
+
+Date: 2026-02-15
+Scope: New autonomous cycle after V5 completion.
+
+## 1. Status Audit
+
+### Repository and branch status
+- `master` synced at merge commit `9b027df` (PR #145).
+- Active execution branch: `master`.
+
+### Open issue snapshot (`kaonis/woly-server`)
+- #4 `Dependency Dashboard`
+- #144 `[Dependencies] Plan major dashboard upgrade wave (ESLint 10, TS-ESLint 8, Zod 4, npm 11)`
+- #146 `[Dependencies] Execute tooling major upgrade set (ESLint 10 + typescript-eslint 8)`
+- #147 `[Dependencies] Evaluate and stage Zod v4 migration across protocol and services`
+- #148 `[Dependencies] Evaluate npm 11 adoption and CI/runtime compatibility`
+
+### CI snapshot
+- Post-merge checks for `9b027df` are green (CI + CodeQL).
+- Dependency triage workflow and audit/security gates are documented and active.
+
+## 2. Iterative Phases
+
+### Phase 1: Major dependency upgrade wave plan
+Issue: #144  
+Labels: `priority:low`, `technical-debt`, `security`
+
+Acceptance criteria:
+- Define migration order and risk profile for major dependency updates.
+- Produce explicit merge/defer decisions with rationale.
+- Link resulting execution issues for approved upgrade tracks.
+
+Status: `In Progress` (2026-02-15)
+
+### Phase 2: Tooling major upgrade execution
+Issue: #146  
+Labels: `priority:low`, `technical-debt`, `testing`
+
+Acceptance criteria:
+- Upgrade lint toolchain majors (ESLint 10 + typescript-eslint 8 family).
+- Keep lint/typecheck/test gates green across workspaces.
+- Document any lint rule/config migration adjustments.
+
+Status: `Pending`
+
+### Phase 3: Zod v4 migration validation
+Issue: #147  
+Labels: `priority:low`, `technical-debt`, `protocol`
+
+Acceptance criteria:
+- Validate Zod v4 migration impact across protocol/C&C/node-agent runtime schemas.
+- Preserve contract compatibility or document deliberate breaking changes.
+- Keep CI and contract/schema suites green.
+
+Status: `Pending`
+
+## 3. Execution Loop Rules
+
+For each phase:
+1. Create branch `feat/<issue>-<slug>` or `fix/<issue>-<slug>`.
+2. Implement smallest complete change meeting acceptance criteria.
+3. Add/update tests.
+4. Run local gate:
+   - `npm run typecheck`
+   - `npm run test:ci`
+5. Open PR (`Closes #<issue>`) and merge after green CI.
+6. Verify post-merge `master` CI.
+7. Update roadmap progress and continue.
+
+## 4. Progress Log
+
+- 2026-02-15: Created ROADMAP_V6 after V5 completion.
+- 2026-02-15: Started Phase 1 issue #144 on branch `feat/144-dependency-upgrade-wave-plan`.
+- 2026-02-15: Added follow-up issue #148 for npm 11 adoption evaluation from dependency dashboard triage.
+- 2026-02-15: Documented major dependency migration order, risk profile, and merge/defer decisions in `docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md`.
+- 2026-02-15: Posted dependency decision summary comment on issue #4 with links to #146, #147, and #148.
+- 2026-02-15: Ran local protocol gates for #144 (`npm run typecheck -w packages/protocol`, `npm run test:ci -w packages/protocol`) successfully.


### PR DESCRIPTION
## Summary
- add `docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md` with major dependency risk profile, migration wave sequencing, and explicit merge/defer decisions
- extend dependency triage workflow with major-upgrade plan reference
- roll roadmap state forward by completing V5 and creating V6 with dependency-focused phased issues
- link major-upgrade plan from README CI/dependency governance section
- post dependency dashboard triage decision update on issue #4 and create follow-up #148 for npm 11 evaluation

## Validation
- npm run typecheck -w packages/protocol
- npm run test:ci -w packages/protocol

Closes #144
