### PR TITLE
chore: adopt turbo 2.8.9 and sync roadmap status (closes #156)

### DIFF
--- a/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
+++ b/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
@@ -13,6 +13,7 @@ This plan covers the currently deferred or high-risk major dependency updates:
 - eslint-config-prettier v10
 - Zod v4
 - npm v11
+- Turbo v2.8.9
 
 ## 2. Risk Profile
 
@@ -54,6 +55,8 @@ Primary impact:
    Tracking issue: #150
 5. Wave E: ESLint flat config migration precondition  
    Tracking issue: #154
+6. Wave F: Turbo workspace runner update  
+   Tracking issue: #156
 
 ## 4. Decision Table (2026-02-15)
 
@@ -65,7 +68,8 @@ Primary impact:
 | eslint-config-prettier v10 | Merged | Upgraded with ESLint v9 toolchain migration via PR #151 | #146 |
 | Zod v4 | Merged | Runtime schema compatibility validated across protocol/C&C/node-agent and merged via PR #152 | #147 |
 | npm v11 | Merged | Workspace tooling and CI remained stable; adopted via PR #17 | #148 |
-| ESLint flat config mode | In progress | Removes legacy `.eslintrc`/`ESLINT_USE_FLAT_CONFIG=false` dependency to clear ESLint 10 precondition | #154 |
+| ESLint flat config mode | Merged | Migrated to root `eslint.config.js` and removed legacy `.eslintrc` mode via PR #155 | #154 |
+| Turbo v2.8.9 | In progress | Renovate PR #75 is green; adoption tracked as the next execution phase | #156 |
 
 ## 5. Exit Criteria for #144
 

--- a/docs/ROADMAP_V6.md
+++ b/docs/ROADMAP_V6.md
@@ -6,16 +6,16 @@ Scope: New autonomous cycle after V5 completion.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `9182401` (PR #153).
+- `master` synced at merge commit `e8e7aa8` (PR #155).
 - Active execution branch: `master`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
-- #154 `[Lint] Migrate to ESLint flat config before ESLint 10 adoption`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
+- #156 `[Dependencies] Adopt Turbo 2.8.9 workspace runner update`
 
 ### CI snapshot
-- Post-merge checks for `9182401` are green (CI + CodeQL).
+- Post-merge checks for `e8e7aa8` are green (CI + CodeQL).
 - Dependency triage workflow and audit/security gates are documented and active.
 
 ## 2. Iterative Phases
@@ -84,6 +84,17 @@ Acceptance criteria:
 - Remove legacy `.eslintrc` dependency and `ESLINT_USE_FLAT_CONFIG=false` usage.
 - Keep lint/typecheck/test/build gates green.
 
+Status: `Completed` (2026-02-15, PR #155)
+
+### Phase 7: Turbo workspace runner update
+Issue: #156  
+Labels: `priority:low`, `technical-debt`, `testing`
+
+Acceptance criteria:
+- Adopt Turbo `2.8.9` update from dependency dashboard track.
+- Keep lint/typecheck/test/build gates green after the update.
+- Verify PR and post-merge `master` CI + CodeQL are green.
+
 Status: `In Progress` (2026-02-15)
 
 ## 3. Execution Loop Rules
@@ -126,3 +137,9 @@ For each phase:
 - 2026-02-15: Started Phase 6 issue #154 on branch `feat/154-eslint-flat-config`.
 - 2026-02-15: Migrated lint configuration to root `eslint.config.js`, removed legacy `.eslintrc.json`, and switched app lint scripts to flat-config mode without `ESLINT_USE_FLAT_CONFIG=false`.
 - 2026-02-15: Ran local gates for #154 (`npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`) successfully.
+- 2026-02-15: Merged #154 via PR #155 and verified post-merge `master` checks green (CI + CodeQL, commit `e8e7aa8`).
+- 2026-02-15: Re-validated ESLint 10 compatibility for #150: `eslint@10.0.0` is available but latest `@typescript-eslint/*@8.55.0` still peers `eslint ^8.57.0 || ^9.0.0`; phase remains blocked.
+- 2026-02-15: Added follow-up issue #156 for Turbo `2.8.9` adoption and started Phase 7 on branch `feat/156-turbo-runner-update`.
+- 2026-02-15: Applied Turbo `2.8.9` lockfile update on #156 (`npm update turbo --save-dev --package-lock-only`) matching dependency dashboard PR #75 scope.
+- 2026-02-15: Ran local gates for #156 (`npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`) successfully.
+- 2026-02-15: Re-installed workspace dependencies with `npm ci`, confirmed `npx turbo --version` = `2.8.9`, and re-ran `npm run lint` successfully under Turbo `2.8.9`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8114,27 +8114,27 @@
       }
     },
     "node_modules/turbo": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.6.tgz",
-      "integrity": "sha512-QMj1SQwUYehc+xJ9SxXn56UO43hfKN64/NFetVW1BwzysRqn+q0FSgrmk+IbJ+djfd8j8zXGKGeqsnUcXwQSUQ==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.9.tgz",
+      "integrity": "sha512-G+Mq8VVQAlpz/0HTsxiNNk/xywaHGl+dk1oiBREgOEVCCDjXInDlONWUn5srRnC9s5tdHTFD1bx1N19eR4hI+g==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "2.8.6",
-        "turbo-darwin-arm64": "2.8.6",
-        "turbo-linux-64": "2.8.6",
-        "turbo-linux-arm64": "2.8.6",
-        "turbo-windows-64": "2.8.6",
-        "turbo-windows-arm64": "2.8.6"
+        "turbo-darwin-64": "2.8.9",
+        "turbo-darwin-arm64": "2.8.9",
+        "turbo-linux-64": "2.8.9",
+        "turbo-linux-arm64": "2.8.9",
+        "turbo-windows-64": "2.8.9",
+        "turbo-windows-arm64": "2.8.9"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.8.6.tgz",
-      "integrity": "sha512-6QeZ/aLZizekiI6tKZN0IGP1a1WYZ9c/qDKPa0rSmj2X0O0Iw/ES4rKZV40S5n8SUJdiU01EFLygHJ2oWaYKXg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.8.9.tgz",
+      "integrity": "sha512-KnCw1ZI9KTnEAhdI9avZrnZ/z4wsM++flMA1w8s8PKOqi5daGpFV36qoPafg4S8TmYMe52JPWEoFr0L+lQ5JIw==",
       "cpu": [
         "x64"
       ],
@@ -8146,9 +8146,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.8.6.tgz",
-      "integrity": "sha512-RS4Z902vB93cQD3PJS/1IMmS0HefrB5ZXuw4ECOrxhOGz5jJVmYFJ6weDzedjoTDeYHHXGo1NoiCSHg69ngWKA==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.8.9.tgz",
+      "integrity": "sha512-CbD5Y2NKJKBXTOZ7z7Cc7vGlFPZkYjApA7ri9lH4iFwKV1X7MoZswh9gyRLetXYWImVX1BqIvP8KftulJg/wIA==",
       "cpu": [
         "arm64"
       ],
@@ -8160,9 +8160,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.8.6.tgz",
-      "integrity": "sha512-hCWDnDepYbrSJdByuryKFoHAGFkvgBYXr6qdaGsYhX1Wgq8isqXCQBKOo99Y/9tXDwKGEeQ7xnkdFvSL7AQ4iQ==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.8.9.tgz",
+      "integrity": "sha512-OXC9HdCtsHvyH+5KUoH8ds+p5WU13vdif0OPbsFzZca4cUXMwKA3HWwUuCgQetk0iAE4cscXpi/t8A263n3VTg==",
       "cpu": [
         "x64"
       ],
@@ -8174,9 +8174,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.8.6.tgz",
-      "integrity": "sha512-oS15aCYEpynG/l69xs/ZnQ0dnz0pHhfHg70Zf5J+j5Cam0/RA0MpcryjneN/9G0PmP8a/6ZxnL5nZahX+wOBPA==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.8.9.tgz",
+      "integrity": "sha512-yI5n8jNXiFA6+CxnXG0gO7h5ZF1+19K8uO3/kXPQmyl37AdiA7ehKJQOvf9OPAnmkGDHcF2HSCPltabERNRmug==",
       "cpu": [
         "arm64"
       ],
@@ -8188,9 +8188,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.8.6.tgz",
-      "integrity": "sha512-eqBxqJD7H/uk9V0QO10VgwY9J2BUXejsGuzChln72Yl+o8GZwsvhOekndRxccR90J8ZO+LKO24+3VzHFh4Cu/g==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.8.9.tgz",
+      "integrity": "sha512-/OztzeGftJAg258M/9vK2ZCkUKUzqrWXJIikiD2pm8TlqHcIYUmepDbyZSDfOiUjMy6NzrLFahpNLnY7b5vNgg==",
       "cpu": [
         "x64"
       ],
@@ -8202,9 +8202,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.8.6.tgz",
-      "integrity": "sha512-I3VEQyxIlNZ6XTg4fLKAkuhcwzIs/GD7Vs1yhelH2aUTjf08wprjBWknDqP7mjAHMpsosRrq4DtfSZEQm83Hxg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.8.9.tgz",
+      "integrity": "sha512-xZ2VTwVTjIqpFZKN4UBxDHCPM3oJ2J5cpRzCBSmRpJ/Pn33wpiYjs+9FB2E03svKaD04/lSSLlEUej0UYsugfg==",
       "cpu": [
         "arm64"
       ],


### PR DESCRIPTION
## Summary
- update lockfile resolution for Turbo from `2.8.6` to `2.8.9` (equivalent scope to Renovate PR #75)
- update roadmap and dependency plan status after #154 merge
- add Phase 7 tracking for issue #156 and log Turbo validation evidence

## Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
- npm ci
- npx turbo --version (`2.8.9`)
- npm run lint (under Turbo `2.8.9`)

Closes #156
