### PR TITLE
feat: add ESLint 10 compatibility watchdog workflow (closes #159)

### DIFF
--- a/.github/workflows/eslint10-compat-watchdog.yml
+++ b/.github/workflows/eslint10-compat-watchdog.yml
@@ -1,0 +1,102 @@
+name: ESLint 10 Compatibility Watchdog
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * 1'
+
+jobs:
+  eslint10-watchdog:
+    name: ESLint 10 Compatibility Watchdog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Check compatibility state
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          plugin_json="$(npm view @typescript-eslint/eslint-plugin@latest version peerDependencies --json)"
+          parser_json="$(npm view @typescript-eslint/parser@latest version peerDependencies --json)"
+          eslint_version="$(npm view eslint@latest version)"
+
+          plugin_version="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.version);" "$plugin_json")"
+          parser_version="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.version);" "$parser_json")"
+          peer_range="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.peerDependencies.eslint || 'unknown');" "$plugin_json")"
+          supports_eslint_10="$(node -e "const range=process.argv[1] || ''; process.stdout.write(/\\b10\\./.test(range) ? 'true' : 'false');" "$peer_range")"
+          checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+          if [ "$supports_eslint_10" = "true" ]; then
+            status_line="UNBLOCKED: latest @typescript-eslint peer range includes ESLint 10."
+          else
+            status_line="BLOCKED: latest @typescript-eslint peer range does not include ESLint 10 yet."
+          fi
+
+          cat > watchdog-comment.md <<EOF
+          <!-- eslint10-compat-watchdog -->
+          ## ESLint 10 Compatibility Watchdog
+
+          Checked at: \`${checked_at}\`
+
+          - Latest \`eslint\`: \`${eslint_version}\`
+          - Latest \`@typescript-eslint/eslint-plugin\`: \`${plugin_version}\`
+          - Latest \`@typescript-eslint/parser\`: \`${parser_version}\`
+          - Reported \`eslint\` peer range: \`${peer_range}\`
+          - Status: **${status_line}**
+
+          Tracking issue: #150
+          EOF
+
+          echo "supports_eslint_10=${supports_eslint_10}" >> "$GITHUB_OUTPUT"
+          {
+            echo 'comment_body<<EOF'
+            cat watchdog-comment.md
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upsert issue #150 watchdog comment
+        uses: actions/github-script@v8
+        env:
+          COMMENT_BODY: ${{ steps.check.outputs.comment_body }}
+        with:
+          script: |
+            const issue_number = 150;
+            const marker = '<!-- eslint10-compat-watchdog -->';
+            const body = process.env.COMMENT_BODY;
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.body && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
+++ b/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
@@ -14,6 +14,7 @@ This plan covers the currently deferred or high-risk major dependency updates:
 - Zod v4
 - npm v11
 - Turbo v2.8.9
+- ESLint 10 compatibility watchdog automation
 
 ## 2. Risk Profile
 
@@ -57,6 +58,8 @@ Primary impact:
    Tracking issue: #154
 6. Wave F: Turbo workspace runner update  
    Tracking issue: #156
+7. Wave G: ESLint 10 compatibility watchdog automation  
+   Tracking issue: #159
 
 ## 4. Decision Table (2026-02-15)
 
@@ -70,6 +73,7 @@ Primary impact:
 | npm v11 | Merged | Workspace tooling and CI remained stable; adopted via PR #17 | #148 |
 | ESLint flat config mode | Merged | Migrated to root `eslint.config.js` and removed legacy `.eslintrc` mode via PR #155 | #154 |
 | Turbo v2.8.9 | Merged | Adopted and validated with local + CI gates via PR #157 (issue #156) | #156 |
+| ESLint 10 watchdog automation | In progress | Adds scheduled/manual compatibility checks and sticky issue updates for blocker visibility | #159 |
 
 ## 5. Exit Criteria for #144
 

--- a/docs/ROADMAP_V6.md
+++ b/docs/ROADMAP_V6.md
@@ -6,15 +6,16 @@ Scope: New autonomous cycle after V5 completion.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `8b3fbd5` (PR #157).
+- `master` synced at merge commit `2b23575` (PR #158).
 - Active execution branch: `master`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
+- #159 `[Dependencies] Automate ESLint 10 compatibility watchdog for #150`
 
 ### CI snapshot
-- Post-merge checks for `8b3fbd5` are green (CI + CodeQL).
+- Post-merge checks for `2b23575` are green (CI + CodeQL).
 - Dependency triage workflow and audit/security gates are documented and active.
 
 ## 2. Iterative Phases
@@ -96,6 +97,17 @@ Acceptance criteria:
 
 Status: `Completed` (2026-02-15, PR #157)
 
+### Phase 8: ESLint 10 compatibility watchdog automation
+Issue: #159  
+Labels: `priority:low`, `technical-debt`, `testing`
+
+Acceptance criteria:
+- Add a scheduled + manual GitHub workflow that checks latest `@typescript-eslint` peer support for ESLint 10.
+- Upsert a sticky status comment on issue #150 with blocker/unblock evidence.
+- Keep workflow informational (no fail-on-blocked behavior).
+
+Status: `In Progress` (2026-02-15)
+
 ## 3. Execution Loop Rules
 
 For each phase:
@@ -145,3 +157,7 @@ For each phase:
 - 2026-02-15: Merged #156 via PR #157 and verified post-merge `master` checks green (CI + CodeQL, commit `8b3fbd5`).
 - 2026-02-15: Confirmed dependency dashboard Turbo Renovate PR #75 is closed as superseded by merged PR #157.
 - 2026-02-15: Re-checked ESLint 10 blocker for #150: latest `@typescript-eslint/eslint-plugin@8.55.0` still peers `eslint ^8.57.0 || ^9.0.0`; Renovate ESLint 10 PR #11 remains open and unstable (Protocol Compatibility Check failing).
+- 2026-02-15: Merged blocker-checkpoint docs via PR #158 and verified post-merge `master` checks green (CI + CodeQL, commit `2b23575`).
+- 2026-02-15: Added follow-up issue #159 and started Phase 8 on branch `feat/159-eslint10-watchdog-workflow`.
+- 2026-02-15: Implemented `.github/workflows/eslint10-compat-watchdog.yml` to run scheduled/manual ESLint 10 compatibility checks and upsert a sticky watchdog comment on issue #150.
+- 2026-02-15: Ran local gates for #159 (`npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`) successfully.


### PR DESCRIPTION
## Summary
- add `.github/workflows/eslint10-compat-watchdog.yml`
- run scheduled/manual checks of latest `@typescript-eslint` peer compatibility for ESLint 10
- upsert a sticky watchdog comment on issue #150 with current blocker/unblock evidence
- keep the workflow informational (no fail-on-blocked behavior)
- update roadmap/dependency docs with new Phase 8 tracking for issue #159

## Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build

Closes #159
