### PR TITLE
docs(ci): add manual-only CI operations runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,22 +177,29 @@ docker run -d --net host \
 
 ## CI
 
-GitHub Actions runs on every push and PR to `master`:
+GitHub Actions is currently in a temporary manual-only mode to control Actions spend.
+Automatic runs on `push`/`pull_request` are disabled.
+
+Current validation flow:
 
 1. Protocol compatibility gate (schema tests, cross-repo contracts, app protocol contracts, C&C schema gate)
-2. Build, lint, typecheck, and test all workspaces via Turborepo
-3. Upload coverage reports as artifacts
+2. Build, lint, typecheck, and test all workspaces via Turborepo (via local gate and optional manual workflow dispatch)
+3. Upload coverage reports as artifacts when `ci.yml` is manually dispatched
 
-All checks must pass for a PR to be merged. The workflow runs:
+Required local gate before PR merge:
 - `npx turbo run lint typecheck test:ci build`
 
-See [.github/workflows/ci.yml](.github/workflows/ci.yml).
+Manual operations and rollback criteria are documented in:
+- [docs/CI_MANUAL_OPERATIONS.md](docs/CI_MANUAL_OPERATIONS.md)
+
+Main workflow definition:
+- [.github/workflows/ci.yml](.github/workflows/ci.yml)
 
 Dependency update review cadence and decision rules are documented in:
 - [docs/DEPENDENCY_TRIAGE_WORKFLOW.md](docs/DEPENDENCY_TRIAGE_WORKFLOW.md)
 - [docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md](docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md)
 
-**Note:** To enforce PR blocking, configure branch protection rules in GitHub repository settings to require the `validate` status check to pass before merging.
+**Note:** Branch protection requirements should match the current CI mode (manual-only vs automatic).
 
 ## Tech Stack
 

--- a/docs/CI_MANUAL_OPERATIONS.md
+++ b/docs/CI_MANUAL_OPERATIONS.md
@@ -1,0 +1,63 @@
+# Manual CI Operations (Temporary)
+
+Date: 2026-02-15
+
+This repository is currently in a temporary budget-control mode where all GitHub
+Actions workflows are manual-only.
+
+## Current Policy
+
+- Workflow triggers are limited to `workflow_dispatch`.
+- Automatic `push`, `pull_request`, `schedule`, and tag-triggered workflow runs are disabled.
+- GitHub CodeQL default setup is disabled (`state: not-configured`) to prevent automatic dynamic runs.
+
+## Required Local Gate Before PR
+
+Run all commands from repo root and require exit code 0 for each:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run build
+```
+
+## Manual Workflow Dispatch
+
+Use either GitHub UI (`Actions` tab) or GitHub CLI:
+
+```bash
+# Main CI workflow
+gh workflow run ci.yml --ref master
+
+# ESLint 10 compatibility watchdog
+gh workflow run eslint10-compat-watchdog.yml --ref master
+
+# Protocol publish workflow (safe validation mode)
+gh workflow run publish-protocol.yml --ref master -f dry-run=true
+```
+
+Monitor manual runs:
+
+```bash
+gh run list --limit 20
+gh run view <run-id> --log-failed
+```
+
+## Rollback Criteria (Re-enable Automatic Runs)
+
+Re-enable automatic CI only when all of the following are true:
+
+1. GitHub Actions budget is stable for sustained PR + merge throughput.
+2. Maintainers agree to restore mandatory remote PR checks.
+3. No active incident requires temporary CI spend controls.
+
+## Rollback Steps
+
+1. Restore automatic triggers in workflow files:
+   - `.github/workflows/ci.yml`
+   - `.github/workflows/eslint10-compat-watchdog.yml`
+   - `.github/workflows/publish-protocol.yml`
+2. Re-enable CodeQL default setup from repository settings (`Security` -> `Code security and analysis`).
+3. Run one manual validation cycle (`ci.yml`) after rollback to confirm baseline health.
+4. Update roadmap/docs to record rollback date and rationale.

--- a/docs/ROADMAP_V6.md
+++ b/docs/ROADMAP_V6.md
@@ -12,10 +12,10 @@ Scope: New autonomous cycle after V5 completion.
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #162 `[CI] Temporarily switch all workflows to manual-only dispatch`
+- #164 `[CI] Document manual-only operations and rollback criteria`
 
 ### CI snapshot
-- Post-merge checks for `3bff69a` are green (CI + CodeQL).
+- Post-merge checks for `0763bf7` did not auto-run by design (manual-only mode enabled).
 - Dependency triage workflow and audit/security gates are documented and active.
 
 ## 2. Iterative Phases
@@ -117,6 +117,17 @@ Acceptance criteria:
 - Keep workflows runnable via `workflow_dispatch`.
 - Continue enforcing quality via local gates before merge.
 
+Status: `Completed` (2026-02-15, PR #163)
+
+### Phase 10: Manual CI operations documentation and rollback criteria
+Issue: #164  
+Labels: `priority:low`, `documentation`, `developer-experience`
+
+Acceptance criteria:
+- Add a repo doc defining local CI gate and manual workflow dispatch commands.
+- Define explicit rollback criteria and steps to re-enable automatic workflows.
+- Update README/roadmap references to reflect the temporary manual-only CI mode.
+
 Status: `In Progress` (2026-02-15)
 
 ## 3. Execution Loop Rules
@@ -128,8 +139,8 @@ For each phase:
 4. Run local gate:
    - `npm run typecheck`
    - `npm run test:ci`
-5. Open PR (`Closes #<issue>`) and merge after green CI.
-6. Verify post-merge `master` CI.
+5. Open PR (`Closes #<issue>`) and merge after green CI (or local gate in manual-only mode).
+6. Verify post-merge `master` CI (or confirm no unexpected auto runs in manual-only mode).
 7. Update roadmap progress and continue.
 
 ## 4. Progress Log
@@ -176,3 +187,6 @@ For each phase:
 - 2026-02-15: Manually dispatched `ESLint 10 Compatibility Watchdog` workflow run `22036729002`; it completed successfully and updated sticky comment `#issuecomment-3904488716` on issue #150.
 - 2026-02-15: Added follow-up issue #162 and started Phase 9 on branch `chore/162-manual-only-workflows`.
 - 2026-02-15: Updated workflow triggers to manual-only dispatch in `ci.yml`, `eslint10-compat-watchdog.yml`, and `publish-protocol.yml` to temporarily reduce Actions spend.
+- 2026-02-15: Merged #162 via PR #163 and confirmed no automatic workflow runs were triggered on `master` merge commit `0763bf7`.
+- 2026-02-15: Disabled GitHub CodeQL default setup (`state: not-configured`) to stop automatic `dynamic` CodeQL workflow runs.
+- 2026-02-15: Added follow-up issue #164, started Phase 10 on branch `docs/164-manual-ci-ops`, and drafted manual CI operations documentation.


### PR DESCRIPTION
## Summary
- add docs/CI_MANUAL_OPERATIONS.md with local gate commands, manual workflow dispatch steps, and rollback criteria
- update README CI section to reflect temporary manual-only workflow mode
- update ROADMAP_V6 to mark Phase 9 complete and track Phase 10 issue #164

## Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build

Closes #164