### PR TITLE
docs(ci): add manual-only review cadence and exit criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Required local gate before PR merge:
 
 Manual operations and rollback criteria are documented in:
 - [docs/CI_MANUAL_OPERATIONS.md](docs/CI_MANUAL_OPERATIONS.md)
+- [docs/CI_MANUAL_REVIEW_LOG.md](docs/CI_MANUAL_REVIEW_LOG.md)
 
 Main workflow definition:
 - [.github/workflows/ci.yml](.github/workflows/ci.yml)

--- a/docs/CI_MANUAL_OPERATIONS.md
+++ b/docs/CI_MANUAL_OPERATIONS.md
@@ -52,6 +52,35 @@ Re-enable automatic CI only when all of the following are true:
 2. Maintainers agree to restore mandatory remote PR checks.
 3. No active incident requires temporary CI spend controls.
 
+## Weekly Review Cadence
+
+- Cadence: once per week (recommended every Monday).
+- Owner: repository maintainer on weekly rotation.
+- Decision log location: `docs/CI_MANUAL_REVIEW_LOG.md`.
+
+Weekly checklist:
+
+1. Confirm no unexpected automatic workflow runs since previous review:
+   - `gh run list --limit 50`
+2. Verify manual-only policy still matches budget and throughput needs:
+   - count merges since last review
+   - count manually dispatched runs since last review
+3. Confirm local validation gate remains standard before merge:
+   - `npm run lint`
+   - `npm run typecheck`
+   - `npm run test:ci`
+   - `npm run build`
+4. Record decision in the review log:
+   - `Continue manual-only` or `Start rollback`
+
+## Objective Exit Criteria
+
+Start rollback to automatic CI only when all criteria are met:
+
+1. At least two consecutive weekly reviews indicate Actions spend is within planned budget.
+2. Manual-only mode is causing measurable delivery friction (for example delayed validation or merge bottlenecks).
+3. Maintainers explicitly approve re-enabling automatic `push` and `pull_request` triggers.
+
 ## Rollback Steps
 
 1. Restore automatic triggers in workflow files:

--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -1,0 +1,27 @@
+# Manual CI Review Log
+
+Record weekly decisions for temporary manual-only CI mode.
+
+## Template
+
+Date:
+Reviewer:
+Period reviewed:
+
+- Unexpected automatic workflow runs observed: Yes/No
+- Local gate policy followed: Yes/No
+- Budget and throughput assessment: <brief summary>
+- Decision: Continue manual-only / Start rollback
+- Follow-up actions:
+
+## Entries
+
+Date: 2026-02-15
+Reviewer: Codex autonomous loop
+Period reviewed: 2026-02-15 bootstrap
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Manual-only mode is active and stable; local gates remain fast via cache.
+- Decision: Continue manual-only
+- Follow-up actions: Re-review in one week or sooner if CI budget posture changes.

--- a/docs/ROADMAP_V7.md
+++ b/docs/ROADMAP_V7.md
@@ -6,13 +6,12 @@ Scope: New autonomous cycle after V6 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `69adf2e` (PR #165).
-- Active execution branch: `docs/166-roadmap-v7-bootstrap`.
+- `master` synced at merge commit `88cf0fc` (PR #168).
+- Active execution branch: `docs/167-ci-review-cadence`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #166 `[Roadmap] Close V6 and bootstrap ROADMAP_V7`
 - #167 `[CI] Define review cadence and exit criteria for manual-only mode`
 
 ### CI snapshot
@@ -35,7 +34,7 @@ Acceptance criteria:
 - Add V6 post-merge log entries for #164 / PR #165.
 - Publish `docs/ROADMAP_V7.md` with current status audit and phased plan.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #168)
 
 ### Phase 2: ESLint 10 compatibility unblock monitoring
 Issue: #150  
@@ -57,7 +56,7 @@ Acceptance criteria:
 - Define objective exit criteria for re-enabling automatic workflows.
 - Document decision ownership and recording process.
 
-Status: `Planned` (2026-02-15)
+Status: `In Progress` (2026-02-15)
 
 ## 3. Execution Loop Rules
 
@@ -79,3 +78,5 @@ For each phase:
 - 2026-02-15: Created ROADMAP_V7 from issue #166 after V6 manual-only CI transition merged.
 - 2026-02-15: Re-checked ESLint 10 blocker for #150: `eslint@10.0.0` exists, but latest `@typescript-eslint/*@8.55.0` still peers `eslint ^8.57.0 || ^9.0.0`.
 - 2026-02-15: Added follow-up issue #167 to formalize manual-only CI review cadence and re-enable criteria.
+- 2026-02-15: Merged roadmap bootstrap issue #166 via PR #168 and advanced V7 execution to Phase 3.
+- 2026-02-15: Started issue #167 on branch `docs/167-ci-review-cadence` to add weekly manual-only CI review process and decision log.


### PR DESCRIPTION
## Summary
- add weekly manual-only CI review process, ownership, and objective rollback criteria
- add persistent review log template at docs/CI_MANUAL_REVIEW_LOG.md
- update ROADMAP_V7 to reflect #166 completion and #167 in-progress execution

## Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build

Closes #167