### PR TITLE
chore(deps): extract ESLint10 watchdog into repo script

### DIFF
--- a/.github/workflows/eslint10-compat-watchdog.yml
+++ b/.github/workflows/eslint10-compat-watchdog.yml
@@ -13,6 +13,9 @@ jobs:
       issues: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -20,47 +23,8 @@ jobs:
 
       - name: Check compatibility state
         id: check
-        shell: bash
         run: |
-          set -euo pipefail
-
-          plugin_json="$(npm view @typescript-eslint/eslint-plugin@latest version peerDependencies --json)"
-          parser_json="$(npm view @typescript-eslint/parser@latest version peerDependencies --json)"
-          eslint_version="$(npm view eslint@latest version)"
-
-          plugin_version="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.version);" "$plugin_json")"
-          parser_version="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.version);" "$parser_json")"
-          peer_range="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.peerDependencies.eslint || 'unknown');" "$plugin_json")"
-          supports_eslint_10="$(node -e "const range=process.argv[1] || ''; process.stdout.write(/\\b10\\./.test(range) ? 'true' : 'false');" "$peer_range")"
-          checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-
-          if [ "$supports_eslint_10" = "true" ]; then
-            status_line="UNBLOCKED: latest @typescript-eslint peer range includes ESLint 10."
-          else
-            status_line="BLOCKED: latest @typescript-eslint peer range does not include ESLint 10 yet."
-          fi
-
-          cat > watchdog-comment.md <<EOF
-          <!-- eslint10-compat-watchdog -->
-          ## ESLint 10 Compatibility Watchdog
-
-          Checked at: \`${checked_at}\`
-
-          - Latest \`eslint\`: \`${eslint_version}\`
-          - Latest \`@typescript-eslint/eslint-plugin\`: \`${plugin_version}\`
-          - Latest \`@typescript-eslint/parser\`: \`${parser_version}\`
-          - Reported \`eslint\` peer range: \`${peer_range}\`
-          - Status: **${status_line}**
-
-          Tracking issue: #150
-          EOF
-
-          echo "supports_eslint_10=${supports_eslint_10}" >> "$GITHUB_OUTPUT"
-          {
-            echo 'comment_body<<EOF'
-            cat watchdog-comment.md
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
+          node scripts/eslint10-compat-watchdog.cjs --output watchdog-comment.md --github-output "$GITHUB_OUTPUT"
 
       - name: Upsert issue #150 watchdog comment
         uses: actions/github-script@v8

--- a/docs/CI_MANUAL_OPERATIONS.md
+++ b/docs/CI_MANUAL_OPERATIONS.md
@@ -37,6 +37,12 @@ gh workflow run eslint10-compat-watchdog.yml --ref master
 gh workflow run publish-protocol.yml --ref master -f dry-run=true
 ```
 
+Run watchdog check locally without dispatching workflow:
+
+```bash
+npm run deps:check-eslint10
+```
+
 Monitor manual runs:
 
 ```bash

--- a/docs/ROADMAP_V7.md
+++ b/docs/ROADMAP_V7.md
@@ -6,13 +6,13 @@ Scope: New autonomous cycle after V6 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `fab2643` (PR #169).
-- Active execution branch: `docs/170-roadmap-v7-sync`.
+- `master` synced at merge commit `91f3624` (PR #171).
+- Active execution branch: `feat/172-eslint10-watchdog-script`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #170 `[Roadmap] Sync ROADMAP_V7 after #167 merge`
+- #172 `[Dependencies] Extract ESLint 10 watchdog check into reusable repo script`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
@@ -58,6 +58,17 @@ Acceptance criteria:
 
 Status: `Completed` (2026-02-15, PR #169)
 
+### Phase 4: ESLint 10 watchdog script extraction
+Issue: #172  
+Labels: `priority:low`, `technical-debt`, `developer-experience`, `testing`
+
+Acceptance criteria:
+- Extract compatibility check logic into a reusable repository script.
+- Add local command for manual compatibility checks.
+- Update watchdog workflow to use the reusable script while keeping sticky comment behavior.
+
+Status: `In Progress` (2026-02-15)
+
 ## 3. Execution Loop Rules
 
 For each phase:
@@ -82,3 +93,5 @@ For each phase:
 - 2026-02-15: Started issue #167 on branch `docs/167-ci-review-cadence` to add weekly manual-only CI review process and decision log.
 - 2026-02-15: Merged issue #167 via PR #169, adding weekly review cadence, ownership, objective exit criteria, and `docs/CI_MANUAL_REVIEW_LOG.md`.
 - 2026-02-15: Started issue #170 to sync ROADMAP_V7 after #167 merge and refresh open-issue snapshot.
+- 2026-02-15: Merged issue #170 via PR #171, syncing ROADMAP_V7 to completed Phase 3 state and current open issue set.
+- 2026-02-15: Added issue #172 and started Phase 4 on branch `feat/172-eslint10-watchdog-script`.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dev:node-agent": "turbo run dev --filter=@woly-server/node-agent",
     "dev:cnc": "turbo run dev --filter=@woly-server/cnc",
     "format": "prettier --write .",
+    "deps:check-eslint10": "node scripts/eslint10-compat-watchdog.cjs",
     "protocol:build": "npm run build --workspace=@kaonis/woly-protocol",
     "protocol:publish": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol",
     "protocol:publish:next": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol --tag next",

--- a/scripts/eslint10-compat-watchdog.cjs
+++ b/scripts/eslint10-compat-watchdog.cjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const { execFileSync } = require('node:child_process');
+
+function parseArgs(argv) {
+  const options = {
+    outputPath: null,
+    githubOutputPath: null,
+    json: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--output') {
+      options.outputPath = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--github-output') {
+      options.githubOutputPath = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (options.outputPath === '') {
+    throw new Error('Missing value for --output');
+  }
+
+  if (options.githubOutputPath === '') {
+    throw new Error('Missing value for --github-output');
+  }
+
+  return options;
+}
+
+function runNpmView(args) {
+  const output = execFileSync('npm', ['view', ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  return output.trim();
+}
+
+function readLatestEslint10Compatibility() {
+  const pluginRaw = runNpmView([
+    '@typescript-eslint/eslint-plugin@latest',
+    'version',
+    'peerDependencies',
+    '--json',
+  ]);
+  const parserRaw = runNpmView([
+    '@typescript-eslint/parser@latest',
+    'version',
+    'peerDependencies',
+    '--json',
+  ]);
+  const eslintRaw = runNpmView(['eslint@latest', 'version']);
+
+  const plugin = JSON.parse(pluginRaw);
+  const parser = JSON.parse(parserRaw);
+  const eslintVersion = eslintRaw.replace(/^['"]|['"]$/g, '');
+  const peerRange = plugin.peerDependencies?.eslint || 'unknown';
+  const supportsEslint10 = /(^|[^0-9])10(\.|$)/.test(peerRange);
+
+  return {
+    checkedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    eslintVersion,
+    pluginVersion: plugin.version || 'unknown',
+    parserVersion: parser.version || 'unknown',
+    peerRange,
+    supportsEslint10,
+  };
+}
+
+function buildComment(payload) {
+  const statusLine = payload.supportsEslint10
+    ? 'UNBLOCKED: latest @typescript-eslint peer range includes ESLint 10.'
+    : 'BLOCKED: latest @typescript-eslint peer range does not include ESLint 10 yet.';
+
+  return [
+    '<!-- eslint10-compat-watchdog -->',
+    '## ESLint 10 Compatibility Watchdog',
+    '',
+    `Checked at: \`${payload.checkedAt}\``,
+    '',
+    `- Latest \`eslint\`: \`${payload.eslintVersion}\``,
+    `- Latest \`@typescript-eslint/eslint-plugin\`: \`${payload.pluginVersion}\``,
+    `- Latest \`@typescript-eslint/parser\`: \`${payload.parserVersion}\``,
+    `- Reported \`eslint\` peer range: \`${payload.peerRange}\``,
+    `- Status: **${statusLine}**`,
+    '',
+    'Tracking issue: #150',
+  ].join('\n');
+}
+
+function appendGithubOutput(outputPath, supportsEslint10, commentBody) {
+  const delimiter = `WATCHDOG_COMMENT_${Date.now()}`;
+  const buffer = [
+    `supports_eslint_10=${supportsEslint10 ? 'true' : 'false'}`,
+    `comment_body<<${delimiter}`,
+    commentBody,
+    delimiter,
+    '',
+  ].join('\n');
+  fs.appendFileSync(outputPath, buffer, 'utf8');
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'Usage: node scripts/eslint10-compat-watchdog.cjs [options]',
+      '',
+      'Options:',
+      '  --output <path>         Write markdown comment body to file',
+      '  --github-output <path>  Append supports_eslint_10 and comment_body outputs',
+      '  --json                  Print compatibility payload as JSON',
+      '  -h, --help              Show this help text',
+      '',
+    ].join('\n')
+  );
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const payload = readLatestEslint10Compatibility();
+  const comment = buildComment(payload);
+
+  if (options.outputPath) {
+    fs.writeFileSync(options.outputPath, `${comment}\n`, 'utf8');
+  }
+
+  if (options.githubOutputPath) {
+    appendGithubOutput(
+      options.githubOutputPath,
+      payload.supportsEslint10,
+      comment
+    );
+  }
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+
+  process.stdout.write(`${comment}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(
+      `eslint10-compat-watchdog failed: ${error.message || String(error)}\n`
+    );
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  buildComment,
+  parseArgs,
+  readLatestEslint10Compatibility,
+};


### PR DESCRIPTION
## Summary
- extract ESLint 10 compatibility check into scripts/eslint10-compat-watchdog.cjs
- add npm run deps:check-eslint10 for local/manual compatibility checks
- update eslint10 watchdog workflow to call the shared script and keep sticky comment upsert behavior unchanged
- update CI manual operations + ROADMAP_V7 phase tracking for issue #172

## Validation
- npm run deps:check-eslint10
- node scripts/eslint10-compat-watchdog.cjs --json
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build

Closes #172