### PR TITLE
docs(roadmap): close V7 and bootstrap ROADMAP_V8

### DIFF
--- a/docs/ROADMAP_V7.md
+++ b/docs/ROADMAP_V7.md
@@ -6,13 +6,13 @@ Scope: New autonomous cycle after V6 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `164659f` (PR #175).
-- Active execution branch: `feat/176-renovate-eslint-suppress`.
+- `master` synced at merge commit `ea6f0aa` (PR #177).
+- Active execution branch: `docs/178-roadmap-v8-bootstrap`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #176 `[Dependencies] Temporarily suppress Renovate ESLint 10 major updates while blocked`
+- #178 `[Roadmap] Close V7 and bootstrap ROADMAP_V8`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
@@ -90,7 +90,7 @@ Acceptance criteria:
 - Keep all non-ESLint-major dependency updates unaffected.
 - Document temporary rationale and traceability in config + roadmap.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #177)
 
 ## 3. Execution Loop Rules
 
@@ -122,3 +122,5 @@ For each phase:
 - 2026-02-15: Added issue #174, manually dispatched watchdog workflow run `22037969724`, and validated success with sticky issue #150 comment refresh at `2026-02-15T15:11:45Z`.
 - 2026-02-15: Merged issue #174 via PR #175 and logged successful post-extraction watchdog validation evidence on master.
 - 2026-02-15: Added issue #176 and started Phase 6 on branch `feat/176-renovate-eslint-suppress`.
+- 2026-02-15: Merged issue #176 via PR #177, adding temporary Renovate suppression for blocked ESLint major updates and reducing dependency dashboard churn.
+- 2026-02-15: Added issue #178 to close out V7 and bootstrap ROADMAP_V8 with refreshed status audit.

--- a/docs/ROADMAP_V8.md
+++ b/docs/ROADMAP_V8.md
@@ -1,0 +1,82 @@
+# Woly-Server Roadmap V8
+
+Date: 2026-02-15
+Scope: New autonomous cycle after V7 closeout.
+
+## 1. Status Audit
+
+### Repository and branch status
+- `master` synced at merge commit `ea6f0aa` (PR #177).
+- Active execution branch: `docs/178-roadmap-v8-bootstrap`.
+
+### Open issue snapshot (`kaonis/woly-server`)
+- #4 `Dependency Dashboard`
+- #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
+- #178 `[Roadmap] Close V7 and bootstrap ROADMAP_V8`
+- #179 `[CI] Run weekly manual-only operations review log update`
+
+### CI snapshot
+- Repository workflows remain in temporary manual-only mode (`workflow_dispatch` only).
+- GitHub CodeQL default setup remains disabled (`state: not-configured`).
+- Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
+- Latest local validation gate passed on 2026-02-15:
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+
+## 2. Iterative Phases
+
+### Phase 1: V7 closeout and V8 bootstrap
+Issue: #178  
+Labels: `priority:low`, `documentation`, `developer-experience`
+
+Acceptance criteria:
+- Mark V7 Phase 6 completed with merged PR reference.
+- Refresh V7 status audit and progress log after #176 merge.
+- Publish `docs/ROADMAP_V8.md` with current status and next phases.
+
+Status: `In Progress` (2026-02-15)
+
+### Phase 2: ESLint 10 compatibility unblock monitoring
+Issue: #150  
+Labels: `priority:low`, `technical-debt`, `testing`
+
+Acceptance criteria:
+- Re-check latest `@typescript-eslint/*` peer compatibility for ESLint 10.
+- If unblocked, execute upgrade with full local validation.
+- If still blocked, record current evidence and continue monitoring.
+
+Status: `Blocked` (2026-02-15; latest `@typescript-eslint/*@8.55.0` peers `eslint ^8.57 || ^9`)
+
+### Phase 3: Weekly manual-only CI operations review
+Issue: #179  
+Labels: `priority:low`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Run the weekly manual-only CI review checklist.
+- Append a review entry in `docs/CI_MANUAL_REVIEW_LOG.md`.
+- Update roadmap progress with decision outcome.
+
+Status: `Planned` (2026-02-15)
+
+## 3. Execution Loop Rules
+
+For each phase:
+1. Create branch `feat/<issue>-<slug>` or `fix/<issue>-<slug>` (or `docs/<issue>-<slug>` for docs-only work).
+2. Implement smallest complete change meeting acceptance criteria.
+3. Add/update tests when behavior changes.
+4. Run local gate:
+   - `npm run lint`
+   - `npm run typecheck`
+   - `npm run test:ci`
+   - `npm run build`
+5. Open PR (`Closes #<issue>`) and merge after local validation.
+6. Verify post-merge state and confirm no unexpected automatic workflow runs.
+7. Update roadmap progress and continue.
+
+## 4. Progress Log
+
+- 2026-02-15: Created ROADMAP_V8 from issue #178 after V7 dependency/CI follow-up phases merged.
+- 2026-02-15: Carried forward blocker issue #150 with current peer dependency evidence.
+- 2026-02-15: Added issue #179 for the weekly manual-only CI operations review cycle.


### PR DESCRIPTION
## Summary
- mark ROADMAP_V7 phase 6 completed after PR #177
- refresh V7 status audit/open issue snapshot and progress log
- add docs/ROADMAP_V8.md with fresh status audit and next roadmap phases (#150 blocker + #179 weekly review)

## Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build

Closes #178