### PR TITLE
docs: weekly manual-only CI review log update (#179)

### DIFF
--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -25,3 +25,13 @@ Period reviewed: 2026-02-15 bootstrap
 - Budget and throughput assessment: Manual-only mode is active and stable; local gates remain fast via cache.
 - Decision: Continue manual-only
 - Follow-up actions: Re-review in one week or sooner if CI budget posture changes.
+
+Date: 2026-02-15
+Reviewer: Codex autonomous loop
+Period reviewed: post-merge cycle (#172 to #178)
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: No new automatic Actions consumption; manual watchdog dispatch and local-gate-first policy remain effective.
+- Decision: Continue manual-only
+- Follow-up actions: Keep weekly review cadence and reassess rollback criteria when budget posture changes.

--- a/docs/ROADMAP_V8.md
+++ b/docs/ROADMAP_V8.md
@@ -6,13 +6,12 @@ Scope: New autonomous cycle after V7 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `ea6f0aa` (PR #177).
-- Active execution branch: `docs/178-roadmap-v8-bootstrap`.
+- `master` synced at merge commit `0afa905` (PR #180).
+- Active execution branch: `docs/179-manual-ci-review`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #178 `[Roadmap] Close V7 and bootstrap ROADMAP_V8`
 - #179 `[CI] Run weekly manual-only operations review log update`
 
 ### CI snapshot
@@ -36,7 +35,7 @@ Acceptance criteria:
 - Refresh V7 status audit and progress log after #176 merge.
 - Publish `docs/ROADMAP_V8.md` with current status and next phases.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #180)
 
 ### Phase 2: ESLint 10 compatibility unblock monitoring
 Issue: #150  
@@ -58,7 +57,7 @@ Acceptance criteria:
 - Append a review entry in `docs/CI_MANUAL_REVIEW_LOG.md`.
 - Update roadmap progress with decision outcome.
 
-Status: `Planned` (2026-02-15)
+Status: `In Progress` (2026-02-15)
 
 ## 3. Execution Loop Rules
 
@@ -80,3 +79,5 @@ For each phase:
 - 2026-02-15: Created ROADMAP_V8 from issue #178 after V7 dependency/CI follow-up phases merged.
 - 2026-02-15: Carried forward blocker issue #150 with current peer dependency evidence.
 - 2026-02-15: Added issue #179 for the weekly manual-only CI operations review cycle.
+- 2026-02-15: Merged issue #178 via PR #180 and finalized V7 closeout + V8 bootstrap docs on master.
+- 2026-02-15: Started issue #179 on branch `docs/179-manual-ci-review` and executed manual-only CI review checklist with no unexpected automatic runs observed.


### PR DESCRIPTION
Closes #179

## Summary
- append a weekly manual-only CI review entry to `docs/CI_MANUAL_REVIEW_LOG.md`
- update `docs/ROADMAP_V8.md` status audit and phase progress
- record no unexpected automatic workflow runs in the post-merge cycle

## Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
