### PR TITLE
ci: enforce 8-minute timeout cap on manual workflows (#182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
   protocol-compatibility:
     name: Protocol Compatibility Check
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     permissions:
       contents: read
 
@@ -49,6 +50,7 @@ jobs:
   validate:
     name: Build, Lint, Typecheck, Test
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     needs: protocol-compatibility
     permissions:
       contents: read

--- a/.github/workflows/eslint10-compat-watchdog.yml
+++ b/.github/workflows/eslint10-compat-watchdog.yml
@@ -8,6 +8,7 @@ jobs:
   eslint10-watchdog:
     name: ESLint 10 Compatibility Watchdog
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/publish-protocol.yml
+++ b/.github/workflows/publish-protocol.yml
@@ -13,6 +13,7 @@ jobs:
   publish:
     name: Build & Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     permissions:
       contents: read
       id-token: write

--- a/docs/CI_MANUAL_OPERATIONS.md
+++ b/docs/CI_MANUAL_OPERATIONS.md
@@ -10,6 +10,7 @@ Actions workflows are manual-only.
 - Workflow triggers are limited to `workflow_dispatch`.
 - Automatic `push`, `pull_request`, `schedule`, and tag-triggered workflow runs are disabled.
 - GitHub CodeQL default setup is disabled (`state: not-configured`) to prevent automatic dynamic runs.
+- Each workflow job has `timeout-minutes: 8` to cap manual-run spend and prevent hangs.
 
 ## Required Local Gate Before PR
 

--- a/docs/ROADMAP_V8.md
+++ b/docs/ROADMAP_V8.md
@@ -6,17 +6,18 @@ Scope: New autonomous cycle after V7 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `0afa905` (PR #180).
-- Active execution branch: `docs/179-manual-ci-review`.
+- `master` synced at merge commit `ef81588` (PR #181).
+- Active execution branch: `fix/182-ci-timeout-caps`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #179 `[CI] Run weekly manual-only operations review log update`
+- #182 `[CI] Enforce 8-minute timeout cap on manual workflows`
 
 ### CI snapshot
 - Repository workflows remain in temporary manual-only mode (`workflow_dispatch` only).
 - GitHub CodeQL default setup remains disabled (`state: not-configured`).
+- Workflow timeout cap standard (`timeout-minutes: 8`) is being enforced via issue #182.
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
 - Latest local validation gate passed on 2026-02-15:
   - `npm run lint`
@@ -57,6 +58,17 @@ Acceptance criteria:
 - Append a review entry in `docs/CI_MANUAL_REVIEW_LOG.md`.
 - Update roadmap progress with decision outcome.
 
+Status: `Completed` (2026-02-15, PR #181)
+
+### Phase 4: Manual workflow timeout cap enforcement
+Issue: #182  
+Labels: `priority:medium`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Add `timeout-minutes: 8` to all workflow jobs.
+- Document timeout policy in manual CI operations guidance.
+- Validate local gate remains green after workflow/doc updates.
+
 Status: `In Progress` (2026-02-15)
 
 ## 3. Execution Loop Rules
@@ -81,3 +93,5 @@ For each phase:
 - 2026-02-15: Added issue #179 for the weekly manual-only CI operations review cycle.
 - 2026-02-15: Merged issue #178 via PR #180 and finalized V7 closeout + V8 bootstrap docs on master.
 - 2026-02-15: Started issue #179 on branch `docs/179-manual-ci-review` and executed manual-only CI review checklist with no unexpected automatic runs observed.
+- 2026-02-15: Merged issue #179 via PR #181 and recorded weekly manual-only review completion on master.
+- 2026-02-15: Created issue #182 and started branch `fix/182-ci-timeout-caps` to enforce 8-minute manual workflow job timeouts.


### PR DESCRIPTION
Closes #182

## Summary
- add `timeout-minutes: 8` to all jobs in manual workflows
- document the timeout cap policy in `docs/CI_MANUAL_OPERATIONS.md`
- update `docs/ROADMAP_V8.md` phase status and progress log

## Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
