### PR TITLE
docs: refresh #150 ESLint 10 compatibility checkpoint

### DIFF
--- a/docs/ROADMAP_V8.md
+++ b/docs/ROADMAP_V8.md
@@ -6,18 +6,17 @@ Scope: New autonomous cycle after V7 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `ef81588` (PR #181).
-- Active execution branch: `fix/182-ci-timeout-caps`.
+- `master` synced at merge commit `8627fb8` (PR #183).
+- Active execution branch: `feat/150-eslint10-compatibility-checkpoint-3`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #182 `[CI] Enforce 8-minute timeout cap on manual workflows`
 
 ### CI snapshot
 - Repository workflows remain in temporary manual-only mode (`workflow_dispatch` only).
 - GitHub CodeQL default setup remains disabled (`state: not-configured`).
-- Workflow timeout cap standard (`timeout-minutes: 8`) is being enforced via issue #182.
+- Workflow timeout cap standard (`timeout-minutes: 8`) is enforced across manual workflows (PR #183).
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
 - Latest local validation gate passed on 2026-02-15:
   - `npm run lint`
@@ -47,7 +46,7 @@ Acceptance criteria:
 - If unblocked, execute upgrade with full local validation.
 - If still blocked, record current evidence and continue monitoring.
 
-Status: `Blocked` (2026-02-15; latest `@typescript-eslint/*@8.55.0` peers `eslint ^8.57 || ^9`)
+Status: `Blocked` (2026-02-15 checkpoint: `@typescript-eslint/*@8.55.0` peers `eslint ^8.57 || ^9`; ESLint 10 still unsupported)
 
 ### Phase 3: Weekly manual-only CI operations review
 Issue: #179  
@@ -69,7 +68,7 @@ Acceptance criteria:
 - Document timeout policy in manual CI operations guidance.
 - Validate local gate remains green after workflow/doc updates.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #183)
 
 ## 3. Execution Loop Rules
 
@@ -95,3 +94,5 @@ For each phase:
 - 2026-02-15: Started issue #179 on branch `docs/179-manual-ci-review` and executed manual-only CI review checklist with no unexpected automatic runs observed.
 - 2026-02-15: Merged issue #179 via PR #181 and recorded weekly manual-only review completion on master.
 - 2026-02-15: Created issue #182 and started branch `fix/182-ci-timeout-caps` to enforce 8-minute manual workflow job timeouts.
+- 2026-02-15: Merged issue #182 via PR #183 and enforced 8-minute timeout caps on all manual workflows.
+- 2026-02-15: Ran another ESLint 10 compatibility checkpoint for issue #150; blocker unchanged (`@typescript-eslint/*@8.55.0` peer range `^8.57 || ^9`).


### PR DESCRIPTION
Refs #150

## Summary
- rerun ESLint 10 compatibility checks for `@typescript-eslint/*`
- confirm blocker still present (`eslint` peer range remains `^8.57.0 || ^9.0.0`)
- update `docs/ROADMAP_V8.md` with current blocker evidence and #182 completion state

## Validation
- npm run deps:check-eslint10
- node scripts/eslint10-compat-watchdog.cjs --json
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
