### PR TITLE
ci: add local manual-only workflow run audit command (#185)

### DIFF
--- a/docs/CI_MANUAL_OPERATIONS.md
+++ b/docs/CI_MANUAL_OPERATIONS.md
@@ -51,6 +51,16 @@ gh run list --limit 20
 gh run view <run-id> --log-failed
 ```
 
+Run structured local audit for weekly review windows:
+
+```bash
+# Example: only runs created after previous review timestamp
+npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected
+
+# JSON output for logs or automation
+npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --json
+```
+
 ## Rollback Criteria (Re-enable Automatic Runs)
 
 Re-enable automatic CI only when all of the following are true:
@@ -68,7 +78,7 @@ Re-enable automatic CI only when all of the following are true:
 Weekly checklist:
 
 1. Confirm no unexpected automatic workflow runs since previous review:
-   - `gh run list --limit 50`
+   - `npm run ci:audit:manual -- --since <previous-review-iso> --fail-on-unexpected`
 2. Verify manual-only policy still matches budget and throughput needs:
    - count merges since last review
    - count manually dispatched runs since last review

--- a/docs/ROADMAP_V8.md
+++ b/docs/ROADMAP_V8.md
@@ -6,17 +6,19 @@ Scope: New autonomous cycle after V7 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `8627fb8` (PR #183).
-- Active execution branch: `feat/150-eslint10-compatibility-checkpoint-3`.
+- `master` synced at merge commit `86524fa` (PR #184).
+- Active execution branch: `feat/185-manual-ci-audit-command`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
+- #185 `[CI] Add local manual-only run audit command`
 
 ### CI snapshot
 - Repository workflows remain in temporary manual-only mode (`workflow_dispatch` only).
 - GitHub CodeQL default setup remains disabled (`state: not-configured`).
 - Workflow timeout cap standard (`timeout-minutes: 8`) is enforced across manual workflows (PR #183).
+- Local manual-only run audit command is being implemented in issue #185.
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
 - Latest local validation gate passed on 2026-02-15:
   - `npm run lint`
@@ -70,6 +72,18 @@ Acceptance criteria:
 
 Status: `Completed` (2026-02-15, PR #183)
 
+### Phase 5: Local manual-only run audit automation
+Issue: #185  
+Labels: `priority:medium`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Add a local command to audit recent workflow runs for unexpected non-manual events.
+- Support timestamp-scoped checks for weekly review windows.
+- Document command usage in manual CI operations guidance.
+- Validate local gate remains green.
+
+Status: `In Progress` (2026-02-15)
+
 ## 3. Execution Loop Rules
 
 For each phase:
@@ -96,3 +110,5 @@ For each phase:
 - 2026-02-15: Created issue #182 and started branch `fix/182-ci-timeout-caps` to enforce 8-minute manual workflow job timeouts.
 - 2026-02-15: Merged issue #182 via PR #183 and enforced 8-minute timeout caps on all manual workflows.
 - 2026-02-15: Ran another ESLint 10 compatibility checkpoint for issue #150; blocker unchanged (`@typescript-eslint/*@8.55.0` peer range `^8.57 || ^9`).
+- 2026-02-15: Merged issue #150 checkpoint refresh via PR #184 with blocker still unchanged.
+- 2026-02-15: Created issue #185 and started branch `feat/185-manual-ci-audit-command` for local manual-run audit automation.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev:cnc": "turbo run dev --filter=@woly-server/cnc",
     "format": "prettier --write .",
     "deps:check-eslint10": "node scripts/eslint10-compat-watchdog.cjs",
+    "ci:audit:manual": "node scripts/manual-ci-run-audit.cjs",
     "protocol:build": "npm run build --workspace=@kaonis/woly-protocol",
     "protocol:publish": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol",
     "protocol:publish:next": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol --tag next",

--- a/scripts/manual-ci-run-audit.cjs
+++ b/scripts/manual-ci-run-audit.cjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+
+function parseArgs(argv) {
+  const options = {
+    limit: 50,
+    since: null,
+    json: false,
+    failOnUnexpected: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--limit') {
+      const raw = argv[i + 1];
+      if (!raw) {
+        throw new Error('Missing value for --limit');
+      }
+      const parsed = Number.parseInt(raw, 10);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error('--limit must be a positive integer');
+      }
+      options.limit = parsed;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--since') {
+      const raw = argv[i + 1];
+      if (!raw) {
+        throw new Error('Missing value for --since');
+      }
+      const parsed = new Date(raw);
+      if (Number.isNaN(parsed.getTime())) {
+        throw new Error('--since must be a valid ISO-8601 timestamp');
+      }
+      options.since = parsed.toISOString();
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    if (arg === '--fail-on-unexpected') {
+      options.failOnUnexpected = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function fetchRuns(limit) {
+  const output = execFileSync(
+    'gh',
+    [
+      'run',
+      'list',
+      '--limit',
+      String(limit),
+      '--json',
+      'databaseId,event,status,conclusion,workflowName,name,createdAt,headBranch',
+    ],
+    {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+
+  return JSON.parse(output);
+}
+
+function buildSummary(runs, sinceIso) {
+  const checkedAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const threshold = sinceIso ? new Date(sinceIso).getTime() : null;
+  const filteredRuns = runs.filter((run) => {
+    if (!threshold) {
+      return true;
+    }
+    const createdAt = new Date(run.createdAt).getTime();
+    return Number.isFinite(createdAt) && createdAt >= threshold;
+  });
+
+  const countsByEvent = {};
+  for (const run of filteredRuns) {
+    const key = run.event || 'unknown';
+    countsByEvent[key] = (countsByEvent[key] || 0) + 1;
+  }
+
+  const unexpectedRuns = filteredRuns.filter(
+    (run) => run.event !== 'workflow_dispatch'
+  );
+
+  return {
+    checkedAt,
+    since: sinceIso,
+    totalRuns: filteredRuns.length,
+    countsByEvent,
+    unexpectedRunCount: unexpectedRuns.length,
+    unexpectedRuns,
+  };
+}
+
+function renderMarkdown(summary, limit) {
+  const eventLines = Object.entries(summary.countsByEvent)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([event, count]) => `- \`${event}\`: ${count}`);
+
+  const lines = [
+    '## Manual CI Run Audit',
+    '',
+    `Checked at: \`${summary.checkedAt}\``,
+    `Scope: latest ${limit} runs${summary.since ? ` since \`${summary.since}\`` : ''}`,
+    '',
+    `- Total runs analyzed: ${summary.totalRuns}`,
+    '- Allowed event: `workflow_dispatch`',
+    `- Unexpected non-manual runs: ${summary.unexpectedRunCount}`,
+    '- Event distribution:',
+  ];
+
+  if (eventLines.length === 0) {
+    lines.push('- none');
+  } else {
+    lines.push(...eventLines);
+  }
+
+  if (summary.unexpectedRunCount > 0) {
+    lines.push('', 'Unexpected runs:');
+    for (const run of summary.unexpectedRuns.slice(0, 10)) {
+      lines.push(
+        `- #${run.databaseId} \`${run.event}\` ${run.workflowName} (${run.createdAt}, branch \`${run.headBranch || 'unknown'}\`, conclusion \`${run.conclusion || 'none'}\`)`
+      );
+    }
+  }
+
+  lines.push(
+    '',
+    summary.unexpectedRunCount > 0
+      ? 'Status: **FAIL** (unexpected non-manual workflow events detected)'
+      : 'Status: **PASS** (manual-only workflow policy observed in this scope)'
+  );
+
+  return lines.join('\n');
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'Usage: node scripts/manual-ci-run-audit.cjs [options]',
+      '',
+      'Options:',
+      '  --limit <n>             Number of latest runs to inspect (default: 50)',
+      '  --since <iso-8601>      Only include runs created at/after this timestamp',
+      '  --json                  Print machine-readable JSON summary',
+      '  --fail-on-unexpected    Exit non-zero when non-manual runs are detected',
+      '  -h, --help              Show this help text',
+      '',
+    ].join('\n')
+  );
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const runs = fetchRuns(options.limit);
+  const summary = buildSummary(runs, options.since);
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${renderMarkdown(summary, options.limit)}\n`);
+  }
+
+  if (options.failOnUnexpected && summary.unexpectedRunCount > 0) {
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(
+      `manual-ci-run-audit failed: ${error.message || String(error)}\n`
+    );
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  buildSummary,
+  parseArgs,
+  renderMarkdown,
+};


### PR DESCRIPTION
Closes #185

## Summary
- add `scripts/manual-ci-run-audit.cjs` to detect unexpected non-manual workflow events
- add npm alias `ci:audit:manual` in `package.json`
- document audit command usage in `docs/CI_MANUAL_OPERATIONS.md`
- update `docs/ROADMAP_V8.md` with phase #185 execution status

## Validation
- npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected
- npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --json
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
