### PR TITLE
docs: weekly manual-only CI review update (#188)

### DIFF
--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -35,3 +35,13 @@ Period reviewed: post-merge cycle (#172 to #178)
 - Budget and throughput assessment: No new automatic Actions consumption; manual watchdog dispatch and local-gate-first policy remain effective.
 - Decision: Continue manual-only
 - Follow-up actions: Keep weekly review cadence and reassess rollback criteria when budget posture changes.
+
+Date: 2026-02-15
+Reviewer: Codex autonomous loop
+Period reviewed: post-merge cycle (#179 to #187)
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T15:11:32Z`) confirmed only manual dispatch events; budget controls remain effective.
+- Decision: Continue manual-only
+- Follow-up actions: Continue weekly audits using `ci:audit:manual` and reassess rollback criteria when budget posture changes.

--- a/docs/ROADMAP_V8.md
+++ b/docs/ROADMAP_V8.md
@@ -6,13 +6,12 @@ Scope: New autonomous cycle after V7 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `38daddf` (PR #186).
-- Active execution branch: `docs/187-roadmap-v9-bootstrap`.
+- `master` synced at merge commit `70ccae6` (PR #189).
+- Active execution branch: `docs/188-manual-ci-review-cycle`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #187 `[Roadmap] Close V8 and bootstrap ROADMAP_V9`
 - #188 `[CI] Run next weekly manual-only operations review log update`
 
 ### CI snapshot
@@ -94,7 +93,7 @@ Acceptance criteria:
 - Refresh V8 status audit and open issue snapshot.
 - Create `docs/ROADMAP_V9.md` with carry-forward phases and issue links.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #189)
 
 ## 3. Execution Loop Rules
 
@@ -127,3 +126,4 @@ For each phase:
 - 2026-02-15: Merged issue #185 via PR #186 and published `ci:audit:manual` for weekly manual-only run audits.
 - 2026-02-15: Created issue #187 and started branch `docs/187-roadmap-v9-bootstrap` to close V8 and bootstrap V9.
 - 2026-02-15: Created issue #188 for the next weekly manual-only operations review cycle.
+- 2026-02-15: Merged issue #187 via PR #189 and completed V8 closeout with ROADMAP_V9 bootstrap.

--- a/docs/ROADMAP_V9.md
+++ b/docs/ROADMAP_V9.md
@@ -6,13 +6,12 @@ Scope: New autonomous cycle after V8 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `38daddf` (PR #186).
-- Active execution branch: `docs/187-roadmap-v9-bootstrap`.
+- `master` synced at merge commit `70ccae6` (PR #189).
+- Active execution branch: `docs/188-manual-ci-review-cycle`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #187 `[Roadmap] Close V8 and bootstrap ROADMAP_V9`
 - #188 `[CI] Run next weekly manual-only operations review log update`
 
 ### CI snapshot
@@ -21,6 +20,7 @@ Scope: New autonomous cycle after V8 closeout.
 - Manual workflow jobs are capped to `timeout-minutes: 8`.
 - Local manual-only run audit command is available: `npm run ci:audit:manual`.
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
+- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected` (2026-02-15).
 
 ## 2. Iterative Phases
 
@@ -32,7 +32,7 @@ Acceptance criteria:
 - Finalize V8 status after #185 merge.
 - Publish `docs/ROADMAP_V9.md` with carry-forward phases and issue links.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #189)
 
 ### Phase 2: ESLint 10 compatibility unblock monitoring
 Issue: #150  
@@ -54,7 +54,7 @@ Acceptance criteria:
 - Append decision entry to `docs/CI_MANUAL_REVIEW_LOG.md`.
 - Update roadmap progress with decision outcome.
 
-Status: `Planned` (2026-02-15)
+Status: `In Progress` (2026-02-15)
 
 ### Phase 4: Dependency dashboard checkpoint cadence
 Issue: #4  
@@ -86,3 +86,5 @@ For each phase:
 - 2026-02-15: Bootstrapped ROADMAP_V9 from issue #187 after merging phase #185 (PR #186).
 - 2026-02-15: Carried forward blocker issue #150 pending ESLint 10 peer support in `@typescript-eslint/*`.
 - 2026-02-15: Added issue #188 for the next weekly manual-only CI review cycle.
+- 2026-02-15: Merged issue #187 via PR #189 and published ROADMAP_V9 on master.
+- 2026-02-15: Started issue #188 on branch `docs/188-manual-ci-review-cycle` and executed scoped `ci:audit:manual` check with no unexpected automatic runs.


### PR DESCRIPTION
Closes #188

## Summary
- append new manual-only review entry to `docs/CI_MANUAL_REVIEW_LOG.md`
- update `docs/ROADMAP_V9.md` with #187 completion and #188 execution progress
- update `docs/ROADMAP_V8.md` to mark phase #187 complete after PR #189 merge

## Validation
- npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected
- npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --json
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
