### PR TITLE
docs: refresh V9 #150 ESLint10 blocker checkpoint

### DIFF
--- a/docs/ROADMAP_V9.md
+++ b/docs/ROADMAP_V9.md
@@ -6,13 +6,12 @@ Scope: New autonomous cycle after V8 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `70ccae6` (PR #189).
-- Active execution branch: `docs/188-manual-ci-review-cycle`.
+- `master` synced at merge commit `694c79b` (PR #190).
+- Active execution branch: `feat/150-eslint10-compatibility-checkpoint-5`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #188 `[CI] Run next weekly manual-only operations review log update`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
@@ -21,6 +20,7 @@ Scope: New autonomous cycle after V8 closeout.
 - Local manual-only run audit command is available: `npm run ci:audit:manual`.
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
 - Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected` (2026-02-15).
+- Latest ESLint10 compatibility checkpoint remains blocked (`npm run deps:check-eslint10`, 2026-02-15).
 
 ## 2. Iterative Phases
 
@@ -43,7 +43,7 @@ Acceptance criteria:
 - If unblocked, execute upgrade with full local validation.
 - If still blocked, record current evidence and continue monitoring.
 
-Status: `Blocked` (2026-02-15 checkpoint: `@typescript-eslint/*@8.55.0` peers `eslint ^8.57 || ^9`)
+Status: `Blocked` (2026-02-15 checkpoint: `@typescript-eslint/*@8.55.0` peers `eslint ^8.57 || ^9`; ESLint 10 still unsupported)
 
 ### Phase 3: Weekly manual-only CI operations review
 Issue: #188  
@@ -54,7 +54,7 @@ Acceptance criteria:
 - Append decision entry to `docs/CI_MANUAL_REVIEW_LOG.md`.
 - Update roadmap progress with decision outcome.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #190)
 
 ### Phase 4: Dependency dashboard checkpoint cadence
 Issue: #4  
@@ -64,7 +64,7 @@ Acceptance criteria:
 - Post dependency/operations checkpoints after each roadmap phase merge.
 - Keep blocker issue links current (especially #150).
 
-Status: `Planned` (2026-02-15)
+Status: `In Progress` (2026-02-15)
 
 ## 3. Execution Loop Rules
 
@@ -88,3 +88,5 @@ For each phase:
 - 2026-02-15: Added issue #188 for the next weekly manual-only CI review cycle.
 - 2026-02-15: Merged issue #187 via PR #189 and published ROADMAP_V9 on master.
 - 2026-02-15: Started issue #188 on branch `docs/188-manual-ci-review-cycle` and executed scoped `ci:audit:manual` check with no unexpected automatic runs.
+- 2026-02-15: Merged issue #188 via PR #190 and logged weekly manual-only review completion.
+- 2026-02-15: Ran another issue #150 checkpoint; blocker unchanged (`@typescript-eslint/*@8.55.0`, peer range `^8.57 || ^9`).


### PR DESCRIPTION
Refs #150

## Summary
- refresh `docs/ROADMAP_V9.md` post-#190 merge status
- record latest ESLint10 compatibility checkpoint evidence (still blocked)
- mark V9 phase #188 complete and set dependency checkpoint cadence phase in progress

## Validation
- npm run deps:check-eslint10
- node scripts/eslint10-compat-watchdog.cjs --json
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
