### PR TITLE
ci: add local manual-only workflow policy guard (#192)

### DIFF
--- a/docs/CI_MANUAL_OPERATIONS.md
+++ b/docs/CI_MANUAL_OPERATIONS.md
@@ -61,6 +61,13 @@ npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected
 npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --json
 ```
 
+Run policy guard to verify workflow files still enforce manual-only mode:
+
+```bash
+npm run ci:policy:check
+npm run ci:policy:check -- --json
+```
+
 ## Rollback Criteria (Re-enable Automatic Runs)
 
 Re-enable automatic CI only when all of the following are true:
@@ -82,6 +89,7 @@ Weekly checklist:
 2. Verify manual-only policy still matches budget and throughput needs:
    - count merges since last review
    - count manually dispatched runs since last review
+   - `npm run ci:policy:check`
 3. Confirm local validation gate remains standard before merge:
    - `npm run lint`
    - `npm run typecheck`

--- a/docs/ROADMAP_V9.md
+++ b/docs/ROADMAP_V9.md
@@ -6,18 +6,20 @@ Scope: New autonomous cycle after V8 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `694c79b` (PR #190).
-- Active execution branch: `feat/150-eslint10-compatibility-checkpoint-5`.
+- `master` synced at merge commit `1c2c838` (PR #191).
+- Active execution branch: `feat/192-workflow-policy-guard`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
+- #192 `[CI] Add local workflow policy guard for manual-only mode`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
 - GitHub CodeQL default setup remains disabled (`state: not-configured`).
 - Manual workflow jobs are capped to `timeout-minutes: 8`.
 - Local manual-only run audit command is available: `npm run ci:audit:manual`.
+- Local workflow policy guard command is being implemented in issue #192.
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
 - Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected` (2026-02-15).
 - Latest ESLint10 compatibility checkpoint remains blocked (`npm run deps:check-eslint10`, 2026-02-15).
@@ -66,6 +68,18 @@ Acceptance criteria:
 
 Status: `In Progress` (2026-02-15)
 
+### Phase 5: Local workflow policy guardrail
+Issue: #192  
+Labels: `priority:medium`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Validate workflow triggers remain manual-only (`workflow_dispatch`).
+- Ensure no `push`, `pull_request`, or `schedule` triggers are present.
+- Ensure all workflow jobs define `timeout-minutes` with value `<= 8`.
+- Provide local command + docs usage.
+
+Status: `In Progress` (2026-02-15)
+
 ## 3. Execution Loop Rules
 
 For each phase:
@@ -90,3 +104,5 @@ For each phase:
 - 2026-02-15: Started issue #188 on branch `docs/188-manual-ci-review-cycle` and executed scoped `ci:audit:manual` check with no unexpected automatic runs.
 - 2026-02-15: Merged issue #188 via PR #190 and logged weekly manual-only review completion.
 - 2026-02-15: Ran another issue #150 checkpoint; blocker unchanged (`@typescript-eslint/*@8.55.0`, peer range `^8.57 || ^9`).
+- 2026-02-15: Merged issue #150 checkpoint refresh via PR #191 and kept blocker status unchanged.
+- 2026-02-15: Created issue #192 and started branch `feat/192-workflow-policy-guard` for local workflow policy validation.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "format": "prettier --write .",
     "deps:check-eslint10": "node scripts/eslint10-compat-watchdog.cjs",
     "ci:audit:manual": "node scripts/manual-ci-run-audit.cjs",
+    "ci:policy:check": "node scripts/manual-ci-workflow-policy-check.cjs",
     "protocol:build": "npm run build --workspace=@kaonis/woly-protocol",
     "protocol:publish": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol",
     "protocol:publish:next": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol --tag next",

--- a/scripts/manual-ci-workflow-policy-check.cjs
+++ b/scripts/manual-ci-workflow-policy-check.cjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const WORKFLOWS_DIR = path.join(process.cwd(), '.github', 'workflows');
+const MAX_TIMEOUT_MINUTES = 8;
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    help: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function listWorkflowFiles() {
+  const entries = fs.readdirSync(WORKFLOWS_DIR, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.yml'))
+    .map((entry) => path.join(WORKFLOWS_DIR, entry.name))
+    .sort();
+}
+
+function parseJobs(lines) {
+  const jobs = [];
+  let inJobs = false;
+  let activeJob = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+
+    if (/^jobs:\s*$/.test(line)) {
+      inJobs = true;
+      activeJob = null;
+      continue;
+    }
+
+    if (inJobs && /^[a-zA-Z0-9_-]+:\s*$/.test(line)) {
+      // Reached next top-level section.
+      inJobs = false;
+      activeJob = null;
+    }
+
+    if (!inJobs) {
+      continue;
+    }
+
+    const jobMatch = line.match(/^  ([a-zA-Z0-9_-]+):\s*$/);
+    if (jobMatch) {
+      activeJob = {
+        id: jobMatch[1],
+        timeoutMinutes: null,
+      };
+      jobs.push(activeJob);
+      continue;
+    }
+
+    if (!activeJob) {
+      continue;
+    }
+
+    const timeoutMatch = line.match(/^\s{4}timeout-minutes:\s*(\d+)\s*$/);
+    if (timeoutMatch) {
+      activeJob.timeoutMinutes = Number.parseInt(timeoutMatch[1], 10);
+    }
+  }
+
+  return jobs;
+}
+
+function validateWorkflow(filePath) {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const lines = source.split('\n');
+  const violations = [];
+  const jobs = parseJobs(lines);
+
+  if (!/^\s*workflow_dispatch:\s*$/m.test(source)) {
+    violations.push('missing `workflow_dispatch` trigger');
+  }
+
+  for (const forbidden of ['push', 'pull_request', 'schedule']) {
+    if (new RegExp(`^\\s*${forbidden}:\\s*$`, 'm').test(source)) {
+      violations.push(`forbidden trigger present: \`${forbidden}\``);
+    }
+  }
+
+  if (jobs.length === 0) {
+    violations.push('no jobs found');
+  }
+
+  for (const job of jobs) {
+    if (job.timeoutMinutes === null) {
+      violations.push(
+        `job \`${job.id}\` missing \`timeout-minutes\` (required <= ${MAX_TIMEOUT_MINUTES})`
+      );
+      continue;
+    }
+
+    if (job.timeoutMinutes > MAX_TIMEOUT_MINUTES) {
+      violations.push(
+        `job \`${job.id}\` timeout \`${job.timeoutMinutes}\` exceeds limit \`${MAX_TIMEOUT_MINUTES}\``
+      );
+    }
+  }
+
+  return {
+    file: path.relative(process.cwd(), filePath),
+    jobs,
+    violations,
+    passed: violations.length === 0,
+  };
+}
+
+function buildSummary(results) {
+  const checkedAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const failed = results.filter((result) => !result.passed);
+
+  return {
+    checkedAt,
+    filesChecked: results.length,
+    failedFiles: failed.length,
+    results,
+  };
+}
+
+function renderReport(summary) {
+  const lines = [
+    '## Manual CI Workflow Policy Check',
+    '',
+    `Checked at: \`${summary.checkedAt}\``,
+    `Files checked: ${summary.filesChecked}`,
+    `Failed files: ${summary.failedFiles}`,
+    '',
+  ];
+
+  for (const result of summary.results) {
+    if (result.passed) {
+      lines.push(`- PASS: \`${result.file}\``);
+      continue;
+    }
+
+    lines.push(`- FAIL: \`${result.file}\``);
+    for (const violation of result.violations) {
+      lines.push(`  - ${violation}`);
+    }
+  }
+
+  lines.push(
+    '',
+    summary.failedFiles === 0
+      ? 'Status: **PASS** (manual-only workflow policy is compliant).'
+      : 'Status: **FAIL** (manual-only workflow policy violations detected).'
+  );
+
+  return lines.join('\n');
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'Usage: node scripts/manual-ci-workflow-policy-check.cjs [options]',
+      '',
+      'Options:',
+      '  --json        Print machine-readable JSON output',
+      '  -h, --help    Show this help text',
+      '',
+    ].join('\n')
+  );
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const files = listWorkflowFiles();
+  const results = files.map(validateWorkflow);
+  const summary = buildSummary(results);
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${renderReport(summary)}\n`);
+  }
+
+  if (summary.failedFiles > 0) {
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(
+      `manual-ci-workflow-policy-check failed: ${error.message || String(error)}\n`
+    );
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  parseArgs,
+  parseJobs,
+  validateWorkflow,
+};


### PR DESCRIPTION
Closes #192

## Summary
- add `scripts/manual-ci-workflow-policy-check.cjs` to validate manual-only workflow policy
- add `ci:policy:check` npm script alias
- document policy check usage in `docs/CI_MANUAL_OPERATIONS.md`
- update `docs/ROADMAP_V9.md` with issue #192 phase tracking

## Validation
- npm run ci:policy:check
- npm run ci:policy:check -- --json
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
