### PR TITLE
docs: refresh V9 after #193 and queue follow-up #194

### DIFF
--- a/docs/ROADMAP_V9.md
+++ b/docs/ROADMAP_V9.md
@@ -6,20 +6,20 @@ Scope: New autonomous cycle after V8 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `1c2c838` (PR #191).
-- Active execution branch: `feat/192-workflow-policy-guard`.
+- `master` synced at merge commit `ebf5b5c` (PR #193).
+- Active execution branch: `docs/194-v9-followup-queue`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #192 `[CI] Add local workflow policy guard for manual-only mode`
+- #194 `[CI] Schedule next weekly manual-only operations review`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
 - GitHub CodeQL default setup remains disabled (`state: not-configured`).
 - Manual workflow jobs are capped to `timeout-minutes: 8`.
 - Local manual-only run audit command is available: `npm run ci:audit:manual`.
-- Local workflow policy guard command is being implemented in issue #192.
+- Local workflow policy guard command is available: `npm run ci:policy:check` (PR #193).
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
 - Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected` (2026-02-15).
 - Latest ESLint10 compatibility checkpoint remains blocked (`npm run deps:check-eslint10`, 2026-02-15).
@@ -66,7 +66,7 @@ Acceptance criteria:
 - Post dependency/operations checkpoints after each roadmap phase merge.
 - Keep blocker issue links current (especially #150).
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #193)
 
 ### Phase 5: Local workflow policy guardrail
 Issue: #192  
@@ -77,6 +77,16 @@ Acceptance criteria:
 - Ensure no `push`, `pull_request`, or `schedule` triggers are present.
 - Ensure all workflow jobs define `timeout-minutes` with value `<= 8`.
 - Provide local command + docs usage.
+
+Status: `Completed` (2026-02-15, PR #193)
+
+### Phase 6: Queue next weekly review cycle
+Issue: #194  
+Labels: `priority:low`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Create follow-up issue for next weekly manual-only review cycle.
+- Keep roadmap issue snapshot and phase plan aligned with queued review work.
 
 Status: `In Progress` (2026-02-15)
 
@@ -106,3 +116,5 @@ For each phase:
 - 2026-02-15: Ran another issue #150 checkpoint; blocker unchanged (`@typescript-eslint/*@8.55.0`, peer range `^8.57 || ^9`).
 - 2026-02-15: Merged issue #150 checkpoint refresh via PR #191 and kept blocker status unchanged.
 - 2026-02-15: Created issue #192 and started branch `feat/192-workflow-policy-guard` for local workflow policy validation.
+- 2026-02-15: Merged issue #192 via PR #193 and published local workflow policy guardrails.
+- 2026-02-15: Created issue #194 and started branch `docs/194-v9-followup-queue` to queue next weekly manual-only review cycle.


### PR DESCRIPTION
Refs #194

## Summary
- update `docs/ROADMAP_V9.md` after #193 merge
- mark phase #192 completed and record policy-guardrail rollout
- add and track phase #194 as the queued next weekly review cycle

## Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
