### PR TITLE
docs: complete manual-only review checkpoint and queue next cycle (#194)

### DIFF
--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -45,3 +45,13 @@ Period reviewed: post-merge cycle (#179 to #187)
 - Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T15:11:32Z`) confirmed only manual dispatch events; budget controls remain effective.
 - Decision: Continue manual-only
 - Follow-up actions: Continue weekly audits using `ci:audit:manual` and reassess rollback criteria when budget posture changes.
+
+Date: 2026-02-15
+Reviewer: Codex autonomous loop
+Period reviewed: post-merge cycle (#189 to #197)
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T15:11:32Z`) analyzed 4 runs and observed only `workflow_dispatch` events.
+- Decision: Continue manual-only
+- Follow-up actions: Execute the next weekly review cycle under issue #198.

--- a/docs/ROADMAP_V9.md
+++ b/docs/ROADMAP_V9.md
@@ -6,14 +6,14 @@ Scope: New autonomous cycle after V8 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `ebf5b5c` (PR #193).
-- Active execution branch: `feat/196-cnc-coverage-hardening`.
+- `master` synced at merge commit `22951e9` (PR #197).
+- Active execution branch: `docs/194-manual-review-cycle`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
 - #194 `[CI] Schedule next weekly manual-only operations review`
-- #196 `[Testing][CNC] Coverage hardening for service/controller edge paths`
+- #198 `[CI] Schedule weekly manual-only operations review (next cycle)`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
@@ -21,8 +21,9 @@ Scope: New autonomous cycle after V8 closeout.
 - Manual workflow jobs are capped to `timeout-minutes: 8`.
 - Local manual-only run audit command is available: `npm run ci:audit:manual`.
 - Local workflow policy guard command is available: `npm run ci:policy:check` (PR #193).
+- Latest manual CI run succeeded: `22039325902` (PR #197, 2026-02-15).
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
-- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected` (2026-02-15).
+- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected` (`2026-02-15T16:46:26Z`).
 - Latest ESLint10 compatibility checkpoint remains blocked (`npm run deps:check-eslint10`, 2026-02-15).
 
 ## 2. Iterative Phases
@@ -89,7 +90,7 @@ Acceptance criteria:
 - Create follow-up issue for next weekly manual-only review cycle.
 - Keep roadmap issue snapshot and phase plan aligned with queued review work.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, queued follow-up issue #198)
 
 ### Phase 7: CNC coverage hardening tranche
 Issue: #196
@@ -104,7 +105,7 @@ Acceptance criteria:
   - `npm run build`
 - Keep CNC statement coverage at/above target threshold (>= 80%) and document latest snapshot.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #197)
 
 ## 3. Execution Loop Rules
 
@@ -137,3 +138,6 @@ For each phase:
 - 2026-02-15: Created issue #196 and started branch `feat/196-cnc-coverage-hardening` for continued CNC coverage hardening.
 - 2026-02-15: Expanded CNC branch/error-path tests (notably `hostAggregator`) and re-validated local gates (`lint`, `typecheck`, `test:ci`, `build`) successfully.
 - 2026-02-15: Latest CNC coverage snapshot: `86.85%` statements (`apps/cnc`) with service coverage raised (`hostAggregator.ts` now `100%` lines).
+- 2026-02-15: Merged issue #196 via PR #197 after manual CI run `22039325902` passed.
+- 2026-02-15: Ran scoped manual-only workflow audit for issue #194: `npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected` (PASS).
+- 2026-02-15: Created follow-up issue #198 to queue the next weekly manual-only review cycle.


### PR DESCRIPTION
## Summary
- close the current manual-only CI review cycle for issue #194
- record the latest scoped manual-audit result in docs/CI_MANUAL_REVIEW_LOG.md
- refresh ROADMAP_V9 phase/status snapshot after #196/#197 and queue the next cycle (#198)

## Validation
- npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build

Closes #194
Refs #198
Refs #4
Refs #150