### PR TITLE
docs: close manual-only review checkpoint and queue next cycle (#200)

### DIFF
--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -65,3 +65,13 @@ Period reviewed: post-merge cycle (#197 to #199)
 - Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T16:46:26Z`) analyzed 1 run and observed only `workflow_dispatch` events.
 - Decision: Continue manual-only
 - Follow-up actions: Execute the next weekly review cycle under issue #200.
+
+Date: 2026-02-15
+Reviewer: Codex autonomous loop
+Period reviewed: post-merge cycle (#199 to #203)
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T16:50:29Z`) analyzed 2 runs and observed only `workflow_dispatch` events.
+- Decision: Continue manual-only
+- Follow-up actions: Execute the next weekly review cycle under issue #204.

--- a/docs/ROADMAP_V9.md
+++ b/docs/ROADMAP_V9.md
@@ -6,14 +6,14 @@ Scope: New autonomous cycle after V8 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `2aea105` (PR #201).
-- Active execution branch: `feat/202-node-agent-coverage-hardening`.
+- `master` synced at merge commit `30b858a` (PR #203).
+- Active execution branch: `docs/200-manual-review-cycle-following`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
 - #200 `[CI] Schedule weekly manual-only operations review (following cycle)`
-- #202 `[Testing][Node-Agent] Coverage hardening for hostDatabase/service edge paths`
+- #204 `[CI] Schedule weekly manual-only operations review (subsequent cycle)`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
@@ -21,9 +21,9 @@ Scope: New autonomous cycle after V8 closeout.
 - Manual workflow jobs are capped to `timeout-minutes: 8`.
 - Local manual-only run audit command is available: `npm run ci:audit:manual`.
 - Local workflow policy guard command is available: `npm run ci:policy:check` (PR #193).
-- Latest manual CI run succeeded: `22039426360` (PR #201, 2026-02-15).
+- Latest manual CI run succeeded: `22039514991` (PR #203, 2026-02-15).
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
-- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T16:46:26Z --fail-on-unexpected` (`2026-02-15T16:50:29Z`).
+- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T16:50:29Z --fail-on-unexpected` (`2026-02-15T17:00:11Z`).
 - Latest ESLint10 compatibility checkpoint remains blocked (`npm run deps:check-eslint10`, 2026-02-15).
 
 ## 2. Iterative Phases
@@ -131,7 +131,18 @@ Acceptance criteria:
   - `npm run build`
 - Maintain node-agent coverage above threshold and record latest snapshot.
 
-Status: `In Progress` (2026-02-15)
+Status: `Completed` (2026-02-15, PR #203)
+
+### Phase 10: Weekly manual-only review cycle (following)
+Issue: #200
+Labels: `priority:low`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Run `npm run ci:audit:manual -- --since <previous-review-iso> --fail-on-unexpected`.
+- Append decision entry to `docs/CI_MANUAL_REVIEW_LOG.md`.
+- Update active roadmap progress and dependency checkpoint notes.
+
+Status: `Completed` (2026-02-15, queued follow-up issue #204)
 
 ## 3. Execution Loop Rules
 
@@ -173,3 +184,6 @@ For each phase:
 - 2026-02-15: Merged issue #198 via PR #201 after manual CI run `22039426360` passed.
 - 2026-02-15: Created issue #202 and started branch `feat/202-node-agent-coverage-hardening`.
 - 2026-02-15: Expanded `hostDatabase` unit coverage for node-agent edge/error branches; latest node-agent snapshot `86.93%` statements (`hostDatabase.ts` `91.26%` statements).
+- 2026-02-15: Merged issue #202 via PR #203 after manual CI run `22039514991` passed.
+- 2026-02-15: Ran scoped manual-only workflow audit for issue #200: `npm run ci:audit:manual -- --since 2026-02-15T16:50:29Z --fail-on-unexpected` (PASS).
+- 2026-02-15: Created follow-up issue #204 to queue the next weekly manual-only review cycle.


### PR DESCRIPTION
## Summary
- close issue #200 with a fresh scoped manual-only audit entry
- update ROADMAP_V9 after #202/#203 and queue follow-up cycle issue #204
- append latest decision entry to docs/CI_MANUAL_REVIEW_LOG.md

## Validation
- npm run ci:audit:manual -- --since 2026-02-15T16:50:29Z --fail-on-unexpected
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build

Closes #200
Refs #204
Refs #4
Refs #150
