### PR TITLE
docs: complete manual CI review cycle for #204

### DIFF
--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -75,3 +75,13 @@ Period reviewed: post-merge cycle (#199 to #203)
 - Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T16:50:29Z`) analyzed 2 runs and observed only `workflow_dispatch` events.
 - Decision: Continue manual-only
 - Follow-up actions: Execute the next weekly review cycle under issue #204.
+
+Date: 2026-02-15
+Reviewer: Codex autonomous loop
+Period reviewed: post-merge cycle (#203 to #205)
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T17:00:11Z`) analyzed 1 run and observed only `workflow_dispatch` events.
+- Decision: Continue manual-only
+- Follow-up actions: Execute the next weekly review cycle under issue #206.

--- a/docs/ROADMAP_V9.md
+++ b/docs/ROADMAP_V9.md
@@ -6,14 +6,14 @@ Scope: New autonomous cycle after V8 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `30b858a` (PR #203).
-- Active execution branch: `docs/200-manual-review-cycle-following`.
+- `master` synced at merge commit `c6fd402` (PR #205).
+- Active execution branch: `docs/204-manual-review-cycle-subsequent`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #200 `[CI] Schedule weekly manual-only operations review (following cycle)`
 - #204 `[CI] Schedule weekly manual-only operations review (subsequent cycle)`
+- #206 `[CI] Schedule weekly manual-only operations review (next subsequent cycle)`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
@@ -21,9 +21,9 @@ Scope: New autonomous cycle after V8 closeout.
 - Manual workflow jobs are capped to `timeout-minutes: 8`.
 - Local manual-only run audit command is available: `npm run ci:audit:manual`.
 - Local workflow policy guard command is available: `npm run ci:policy:check` (PR #193).
-- Latest manual CI run succeeded: `22039514991` (PR #203, 2026-02-15).
+- Latest manual CI run succeeded: `22039576677` (PR #205, 2026-02-15).
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
-- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T16:50:29Z --fail-on-unexpected` (`2026-02-15T17:00:11Z`).
+- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T17:00:11Z --fail-on-unexpected` (`2026-02-15T17:04:18Z`).
 - Latest ESLint10 compatibility checkpoint remains blocked (`npm run deps:check-eslint10`, 2026-02-15).
 
 ## 2. Iterative Phases
@@ -144,6 +144,28 @@ Acceptance criteria:
 
 Status: `Completed` (2026-02-15, queued follow-up issue #204)
 
+### Phase 11: Weekly manual-only review cycle (subsequent)
+Issue: #204
+Labels: `priority:low`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Run `npm run ci:audit:manual -- --since <previous-review-iso> --fail-on-unexpected`.
+- Append decision entry to `docs/CI_MANUAL_REVIEW_LOG.md`.
+- Update active roadmap progress and dependency checkpoint notes.
+
+Status: `Completed` (2026-02-15, queued follow-up issue #206)
+
+### Phase 12: Weekly manual-only review cycle (next subsequent)
+Issue: #206
+Labels: `priority:low`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Run `npm run ci:audit:manual -- --since <previous-review-iso> --fail-on-unexpected`.
+- Append decision entry to `docs/CI_MANUAL_REVIEW_LOG.md`.
+- Update active roadmap progress and dependency checkpoint notes.
+
+Status: `Planned`
+
 ## 3. Execution Loop Rules
 
 For each phase:
@@ -187,3 +209,6 @@ For each phase:
 - 2026-02-15: Merged issue #202 via PR #203 after manual CI run `22039514991` passed.
 - 2026-02-15: Ran scoped manual-only workflow audit for issue #200: `npm run ci:audit:manual -- --since 2026-02-15T16:50:29Z --fail-on-unexpected` (PASS).
 - 2026-02-15: Created follow-up issue #204 to queue the next weekly manual-only review cycle.
+- 2026-02-15: Merged issue #200 via PR #205 after manual CI run `22039576677` passed.
+- 2026-02-15: Started issue #204 on branch `docs/204-manual-review-cycle-subsequent` and executed scoped audit `npm run ci:audit:manual -- --since 2026-02-15T17:00:11Z --fail-on-unexpected` (PASS).
+- 2026-02-15: Created follow-up issue #206 to queue the next weekly manual-only review cycle.


### PR DESCRIPTION
## Summary
- execute issue #204 manual-only CI review cycle with a scoped audit
- record review evidence in `docs/CI_MANUAL_REVIEW_LOG.md`
- update `docs/ROADMAP_V9.md` status snapshots and queue follow-up issue #206

## Validation
- `npm run ci:audit:manual -- --since 2026-02-15T17:00:11Z --fail-on-unexpected`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`

Closes #204
Refs #206
