### PR TITLE
docs: complete manual CI review cycle for #206

### DIFF
--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -85,3 +85,13 @@ Period reviewed: post-merge cycle (#203 to #205)
 - Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T17:00:11Z`) analyzed 1 run and observed only `workflow_dispatch` events.
 - Decision: Continue manual-only
 - Follow-up actions: Execute the next weekly review cycle under issue #206.
+
+Date: 2026-02-15
+Reviewer: Codex autonomous loop
+Period reviewed: post-merge cycle (#205 to #207)
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T17:04:18Z`) analyzed 1 run and observed only `workflow_dispatch` events.
+- Decision: Continue manual-only
+- Follow-up actions: Execute the next weekly review cycle under issue #208.

--- a/docs/ROADMAP_V9.md
+++ b/docs/ROADMAP_V9.md
@@ -6,14 +6,14 @@ Scope: New autonomous cycle after V8 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `c6fd402` (PR #205).
-- Active execution branch: `docs/204-manual-review-cycle-subsequent`.
+- `master` synced at merge commit `65cb82b` (PR #207).
+- Active execution branch: `docs/206-manual-review-cycle-next-subsequent`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #204 `[CI] Schedule weekly manual-only operations review (subsequent cycle)`
 - #206 `[CI] Schedule weekly manual-only operations review (next subsequent cycle)`
+- #208 `[CI] Schedule weekly manual-only operations review (follow-up cycle)`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
@@ -21,9 +21,9 @@ Scope: New autonomous cycle after V8 closeout.
 - Manual workflow jobs are capped to `timeout-minutes: 8`.
 - Local manual-only run audit command is available: `npm run ci:audit:manual`.
 - Local workflow policy guard command is available: `npm run ci:policy:check` (PR #193).
-- Latest manual CI run succeeded: `22039576677` (PR #205, 2026-02-15).
+- Latest manual CI run succeeded: `22039628413` (PR #207, 2026-02-15).
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
-- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T17:00:11Z --fail-on-unexpected` (`2026-02-15T17:04:18Z`).
+- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T17:04:18Z --fail-on-unexpected` (`2026-02-15T17:07:43Z`).
 - Latest ESLint10 compatibility checkpoint remains blocked (`npm run deps:check-eslint10`, 2026-02-15).
 
 ## 2. Iterative Phases
@@ -164,6 +164,17 @@ Acceptance criteria:
 - Append decision entry to `docs/CI_MANUAL_REVIEW_LOG.md`.
 - Update active roadmap progress and dependency checkpoint notes.
 
+Status: `Completed` (2026-02-15, queued follow-up issue #208)
+
+### Phase 13: Weekly manual-only review cycle (follow-up)
+Issue: #208
+Labels: `priority:low`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Run `npm run ci:audit:manual -- --since <previous-review-iso> --fail-on-unexpected`.
+- Append decision entry to `docs/CI_MANUAL_REVIEW_LOG.md`.
+- Update active roadmap progress and dependency checkpoint notes.
+
 Status: `Planned`
 
 ## 3. Execution Loop Rules
@@ -212,3 +223,6 @@ For each phase:
 - 2026-02-15: Merged issue #200 via PR #205 after manual CI run `22039576677` passed.
 - 2026-02-15: Started issue #204 on branch `docs/204-manual-review-cycle-subsequent` and executed scoped audit `npm run ci:audit:manual -- --since 2026-02-15T17:00:11Z --fail-on-unexpected` (PASS).
 - 2026-02-15: Created follow-up issue #206 to queue the next weekly manual-only review cycle.
+- 2026-02-15: Merged issue #204 via PR #207 after manual CI run `22039628413` passed.
+- 2026-02-15: Started issue #206 on branch `docs/206-manual-review-cycle-next-subsequent` and executed scoped audit `npm run ci:audit:manual -- --since 2026-02-15T17:04:18Z --fail-on-unexpected` (PASS).
+- 2026-02-15: Created follow-up issue #208 to queue the next weekly manual-only review cycle.


### PR DESCRIPTION
## Summary
- execute issue #206 manual-only CI review cycle with a scoped audit
- record review evidence in `docs/CI_MANUAL_REVIEW_LOG.md`
- update `docs/ROADMAP_V9.md` status snapshots and queue follow-up issue #208

## Validation
- `npm run ci:audit:manual -- --since 2026-02-15T17:04:18Z --fail-on-unexpected`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`

Closes #206
Refs #208
