### PR TITLE
docs: complete manual CI review cycle for #208

### DIFF
--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -95,3 +95,13 @@ Period reviewed: post-merge cycle (#205 to #207)
 - Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T17:04:18Z`) analyzed 1 run and observed only `workflow_dispatch` events.
 - Decision: Continue manual-only
 - Follow-up actions: Execute the next weekly review cycle under issue #208.
+
+Date: 2026-02-15
+Reviewer: Codex autonomous loop
+Period reviewed: post-merge cycle (#207 to #209)
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T17:07:43Z`) analyzed 1 run and observed only `workflow_dispatch` events.
+- Decision: Continue manual-only
+- Follow-up actions: Execute the next weekly review cycle under issue #210.

--- a/docs/ROADMAP_V9.md
+++ b/docs/ROADMAP_V9.md
@@ -6,14 +6,14 @@ Scope: New autonomous cycle after V8 closeout.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `65cb82b` (PR #207).
-- Active execution branch: `docs/206-manual-review-cycle-next-subsequent`.
+- `master` synced at merge commit `1d39ffc` (PR #209).
+- Active execution branch: `docs/208-manual-review-cycle-follow-up`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #206 `[CI] Schedule weekly manual-only operations review (next subsequent cycle)`
 - #208 `[CI] Schedule weekly manual-only operations review (follow-up cycle)`
+- #210 `[CI] Schedule weekly manual-only operations review (rolling follow-up cycle)`
 
 ### CI snapshot
 - Repository workflows are in temporary manual-only mode (`workflow_dispatch` only).
@@ -21,9 +21,9 @@ Scope: New autonomous cycle after V8 closeout.
 - Manual workflow jobs are capped to `timeout-minutes: 8`.
 - Local manual-only run audit command is available: `npm run ci:audit:manual`.
 - Local workflow policy guard command is available: `npm run ci:policy:check` (PR #193).
-- Latest manual CI run succeeded: `22039628413` (PR #207, 2026-02-15).
+- Latest manual CI run succeeded: `22039678335` (PR #209, 2026-02-15).
 - Latest manual ESLint10 watchdog run succeeded: `22037969724` (2026-02-15).
-- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T17:04:18Z --fail-on-unexpected` (`2026-02-15T17:07:43Z`).
+- Latest manual-only audit passed: `npm run ci:audit:manual -- --since 2026-02-15T17:07:43Z --fail-on-unexpected` (`2026-02-15T17:10:46Z`).
 - Latest ESLint10 compatibility checkpoint remains blocked (`npm run deps:check-eslint10`, 2026-02-15).
 
 ## 2. Iterative Phases
@@ -175,6 +175,17 @@ Acceptance criteria:
 - Append decision entry to `docs/CI_MANUAL_REVIEW_LOG.md`.
 - Update active roadmap progress and dependency checkpoint notes.
 
+Status: `Completed` (2026-02-15, queued follow-up issue #210)
+
+### Phase 14: Weekly manual-only review cycle (rolling follow-up)
+Issue: #210
+Labels: `priority:low`, `developer-experience`, `technical-debt`
+
+Acceptance criteria:
+- Run `npm run ci:audit:manual -- --since <previous-review-iso> --fail-on-unexpected`.
+- Append decision entry to `docs/CI_MANUAL_REVIEW_LOG.md`.
+- Update active roadmap progress and dependency checkpoint notes.
+
 Status: `Planned`
 
 ## 3. Execution Loop Rules
@@ -226,3 +237,6 @@ For each phase:
 - 2026-02-15: Merged issue #204 via PR #207 after manual CI run `22039628413` passed.
 - 2026-02-15: Started issue #206 on branch `docs/206-manual-review-cycle-next-subsequent` and executed scoped audit `npm run ci:audit:manual -- --since 2026-02-15T17:04:18Z --fail-on-unexpected` (PASS).
 - 2026-02-15: Created follow-up issue #208 to queue the next weekly manual-only review cycle.
+- 2026-02-15: Merged issue #206 via PR #209 after manual CI run `22039678335` passed.
+- 2026-02-15: Started issue #208 on branch `docs/208-manual-review-cycle-follow-up` and executed scoped audit `npm run ci:audit:manual -- --since 2026-02-15T17:07:43Z --fail-on-unexpected` (PASS).
+- 2026-02-15: Created follow-up issue #210 to queue the next weekly manual-only review cycle.


### PR DESCRIPTION
## Summary
- execute issue #208 manual-only CI review cycle with a scoped audit
- record review evidence in `docs/CI_MANUAL_REVIEW_LOG.md`
- update `docs/ROADMAP_V9.md` status snapshots and queue follow-up issue #210

## Validation
- `npm run ci:audit:manual -- --since 2026-02-15T17:07:43Z --fail-on-unexpected`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`

Closes #208
Refs #210
