### PR TITLE
feat: add authenticated CNC capabilities endpoint for feature negotiation

### DIFF
--- a/apps/cnc/src/controllers/capabilities.ts
+++ b/apps/cnc/src/controllers/capabilities.ts
@@ -1,0 +1,72 @@
+import { Request, Response } from 'express';
+import {
+  PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  cncCapabilitiesResponseSchema,
+  type CncCapabilitiesResponse,
+} from '@kaonis/woly-protocol';
+import logger from '../utils/logger';
+
+const CNC_API_VERSION = '1.0.0';
+
+const CNC_FEATURE_CAPABILITIES = {
+  // Scan command endpoint parity is still in progress.
+  scan: false,
+  // Host metadata persistence is available through host update flows.
+  notesTagsPersistence: true,
+  // Schedule API parity is tracked separately and not yet available.
+  schedulesApi: false,
+  // Mobile currently uses polling for command lifecycle visibility.
+  commandStatusStreaming: false,
+} as const;
+
+export class CapabilitiesController {
+  /**
+   * @swagger
+   * /api/capabilities:
+   *   get:
+   *     summary: Get CNC API capability flags for frontend feature negotiation
+   *     description: Returns API/protocol versions and supported CNC feature flags used by mobile clients.
+   *     tags: [Capabilities]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Capabilities payload
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/CapabilitiesResponse'
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       500:
+   *         $ref: '#/components/responses/InternalError'
+   */
+  async getCapabilities(req: Request, res: Response): Promise<void> {
+    try {
+      const response: CncCapabilitiesResponse = {
+        apiVersion: CNC_API_VERSION,
+        protocolVersion: PROTOCOL_VERSION,
+        supportedProtocolVersions: [...SUPPORTED_PROTOCOL_VERSIONS],
+        capabilities: { ...CNC_FEATURE_CAPABILITIES },
+      };
+
+      const payload = cncCapabilitiesResponseSchema.parse(response);
+      res.status(200).json(payload);
+    } catch (error) {
+      logger.error('Failed to get capabilities', {
+        correlationId: req.correlationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      const errorBody: { error: string; message: string; correlationId?: string } = {
+        error: 'Internal Server Error',
+        message: 'Failed to retrieve capabilities',
+      };
+      if (req.correlationId) {
+        errorBody.correlationId = req.correlationId;
+      }
+      res.status(500).json(errorBody);
+    }
+  }
+}

--- a/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
@@ -1,0 +1,98 @@
+import express, { Express } from 'express';
+import request from 'supertest';
+import { PROTOCOL_VERSION, cncCapabilitiesResponseSchema } from '@kaonis/woly-protocol';
+import { createRoutes } from '../index';
+import { NodeManager } from '../../services/nodeManager';
+import { HostAggregator } from '../../services/hostAggregator';
+import { CommandRouter } from '../../services/commandRouter';
+import { createToken } from './testUtils';
+
+jest.mock('../../config', () => ({
+  __esModule: true,
+  default: {
+    jwtSecret: 'test-secret',
+    jwtIssuer: 'test-issuer',
+    jwtAudience: 'test-audience',
+    port: 8080,
+    dbType: 'sqlite',
+    dbPath: ':memory:',
+    nodeAuthTokens: ['test-node-token'],
+    nodeHeartbeatInterval: 30000,
+    nodeTimeout: 60000,
+    jwtTtlSeconds: 3600,
+  },
+}));
+
+describe('Capabilities Routes', () => {
+  let app: Express;
+  const now = Math.floor(Date.now() / 1000);
+
+  beforeAll(() => {
+    const nodeManager = {} as unknown as NodeManager;
+    const hostAggregator = {} as unknown as HostAggregator;
+    const commandRouter = {} as unknown as CommandRouter;
+
+    app = express();
+    app.use(express.json());
+    app.use('/api', createRoutes(nodeManager, hostAggregator, commandRouter));
+  });
+
+  describe('GET /api/capabilities', () => {
+    it('returns 401 when JWT is missing', async () => {
+      const response = await request(app).get('/api/capabilities');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for role without capabilities access', async () => {
+      const token = createToken({
+        sub: 'viewer-client',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .get('/api/capabilities')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        error: 'Forbidden',
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+
+    it('returns a stable capabilities response for operator role', async () => {
+      const token = createToken({
+        sub: 'mobile-client',
+        role: 'operator',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .get('/api/capabilities')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(cncCapabilitiesResponseSchema.safeParse(response.body).success).toBe(true);
+      expect(response.body.protocolVersion).toBe(PROTOCOL_VERSION);
+      expect(response.body.supportedProtocolVersions).toContain(PROTOCOL_VERSION);
+      expect(response.body.capabilities).toEqual({
+        scan: false,
+        notesTagsPersistence: true,
+        schedulesApi: false,
+        commandStatusStreaming: false,
+      });
+    });
+  });
+});

--- a/apps/cnc/src/routes/index.ts
+++ b/apps/cnc/src/routes/index.ts
@@ -7,6 +7,7 @@ import { NodesController } from '../controllers/nodes';
 import { AdminController } from '../controllers/admin';
 import { HostsController } from '../controllers/hosts';
 import { AuthController } from '../controllers/auth';
+import { CapabilitiesController } from '../controllers/capabilities';
 import { NodeManager } from '../services/nodeManager';
 import { HostAggregator } from '../services/hostAggregator';
 import { CommandRouter } from '../services/commandRouter';
@@ -28,6 +29,7 @@ export function createRoutes(
   const adminController = new AdminController(hostAggregator, nodeManager, commandRouter);
   const hostsController = new HostsController(hostAggregator, commandRouter);
   const authController = new AuthController();
+  const capabilitiesController = new CapabilitiesController();
 
   // Public API routes with rate limiting
   router.post('/auth/token', strictAuthLimiter, (req, res) => authController.issueToken(req, res));
@@ -35,6 +37,7 @@ export function createRoutes(
   // Route group protection
   router.use('/nodes', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
   router.use('/hosts', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
+  router.use('/capabilities', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
   router.use('/admin', apiLimiter, authenticateJwt, authorizeRoles('admin'));
 
   // Node API routes (protected)
@@ -52,6 +55,7 @@ export function createRoutes(
   router.post('/hosts/wakeup/:fqn', (req, res) => hostsController.wakeupHost(req, res));
   router.put('/hosts/:fqn', (req, res) => hostsController.updateHost(req, res));
   router.delete('/hosts/:fqn', (req, res) => hostsController.deleteHost(req, res));
+  router.get('/capabilities', (req, res) => capabilitiesController.getCapabilities(req, res));
 
   // Admin API routes
   router.delete('/admin/nodes/:id', (req, res) => adminController.deleteNode(req, res));

--- a/apps/cnc/src/swagger.ts
+++ b/apps/cnc/src/swagger.ts
@@ -54,6 +54,10 @@ const options: swaggerJsdoc.Options = {
         description: 'Aggregated host management across nodes',
       },
       {
+        name: 'Capabilities',
+        description: 'Feature negotiation and version metadata',
+      },
+      {
         name: 'Admin',
         description: 'Administrative operations (requires admin role)',
       },
@@ -266,6 +270,61 @@ const options: swaggerJsdoc.Options = {
               type: 'string',
               description: 'Request correlation identifier for end-to-end tracing',
               example: 'corr_2a8f6842-6f8f-4e8f-b6dc-f7dbd9a18e68',
+            },
+          },
+        },
+        CapabilitiesResponse: {
+          type: 'object',
+          required: ['apiVersion', 'protocolVersion', 'supportedProtocolVersions', 'capabilities'],
+          properties: {
+            apiVersion: {
+              type: 'string',
+              description: 'CNC API version',
+              example: '1.0.0',
+            },
+            protocolVersion: {
+              type: 'string',
+              description: 'Current active protocol version used by C&C and nodes',
+              example: '1.0.0',
+            },
+            supportedProtocolVersions: {
+              type: 'array',
+              description: 'List of accepted protocol versions',
+              items: {
+                type: 'string',
+              },
+              example: ['1.0.0'],
+            },
+            capabilities: {
+              type: 'object',
+              required: [
+                'scan',
+                'notesTagsPersistence',
+                'schedulesApi',
+                'commandStatusStreaming',
+              ],
+              properties: {
+                scan: {
+                  type: 'boolean',
+                  description: 'Whether CNC scan command API is available for mobile clients',
+                  example: false,
+                },
+                notesTagsPersistence: {
+                  type: 'boolean',
+                  description: 'Whether host notes/tags persistence is supported server-side',
+                  example: true,
+                },
+                schedulesApi: {
+                  type: 'boolean',
+                  description: 'Whether server-managed wake schedule CRUD is available',
+                  example: false,
+                },
+                commandStatusStreaming: {
+                  type: 'boolean',
+                  description: 'Whether command lifecycle streaming is available to clients',
+                  example: false,
+                },
+              },
             },
           },
         },

--- a/packages/protocol/src/__tests__/schemas.test.ts
+++ b/packages/protocol/src/__tests__/schemas.test.ts
@@ -1,6 +1,8 @@
 import {
   hostSchema,
   hostStatusSchema,
+  cncCapabilitiesResponseSchema,
+  cncFeatureCapabilitiesSchema,
   commandStateSchema,
   errorResponseSchema,
   outboundNodeMessageSchema,
@@ -123,6 +125,66 @@ describe('errorResponseSchema', () => {
 
   it('rejects missing message', () => {
     expect(errorResponseSchema.safeParse({ error: 'ERR' }).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cncCapabilitiesResponseSchema
+// ---------------------------------------------------------------------------
+
+describe('cncCapabilitiesResponseSchema', () => {
+  it('accepts valid capabilities response', () => {
+    const result = cncCapabilitiesResponseSchema.safeParse({
+      apiVersion: '1.0.0',
+      protocolVersion: PROTOCOL_VERSION,
+      supportedProtocolVersions: [PROTOCOL_VERSION],
+      capabilities: {
+        scan: true,
+        notesTagsPersistence: true,
+        schedulesApi: false,
+        commandStatusStreaming: false,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects response without required feature flags', () => {
+    const result = cncCapabilitiesResponseSchema.safeParse({
+      apiVersion: '1.0.0',
+      protocolVersion: PROTOCOL_VERSION,
+      supportedProtocolVersions: [PROTOCOL_VERSION],
+      capabilities: {
+        scan: true,
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty supported protocol version list', () => {
+    const result = cncCapabilitiesResponseSchema.safeParse({
+      apiVersion: '1.0.0',
+      protocolVersion: PROTOCOL_VERSION,
+      supportedProtocolVersions: [],
+      capabilities: {
+        scan: true,
+        notesTagsPersistence: true,
+        schedulesApi: false,
+        commandStatusStreaming: false,
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('cncFeatureCapabilitiesSchema', () => {
+  it('accepts explicit boolean values for all features', () => {
+    const result = cncFeatureCapabilitiesSchema.safeParse({
+      scan: false,
+      notesTagsPersistence: true,
+      schedulesApi: false,
+      commandStatusStreaming: true,
+    });
+    expect(result.success).toBe(true);
   });
 });
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -59,6 +59,22 @@ export interface ErrorResponse {
   details?: unknown;
 }
 
+// --- CNC API capabilities ---
+
+export interface CncFeatureCapabilities {
+  scan: boolean;
+  notesTagsPersistence: boolean;
+  schedulesApi: boolean;
+  commandStatusStreaming: boolean;
+}
+
+export interface CncCapabilitiesResponse {
+  apiVersion: string;
+  protocolVersion: string;
+  supportedProtocolVersions: string[];
+  capabilities: CncFeatureCapabilities;
+}
+
 // --- WebSocket message types ---
 
 export type NodeMessage =
@@ -134,6 +150,20 @@ export const errorResponseSchema = z.object({
   message: z.string().min(1),
   code: z.string().optional(),
   details: z.unknown().optional(),
+});
+
+export const cncFeatureCapabilitiesSchema = z.object({
+  scan: z.boolean(),
+  notesTagsPersistence: z.boolean(),
+  schedulesApi: z.boolean(),
+  commandStatusStreaming: z.boolean(),
+});
+
+export const cncCapabilitiesResponseSchema = z.object({
+  apiVersion: z.string().min(1),
+  protocolVersion: z.string().min(1),
+  supportedProtocolVersions: z.array(z.string().min(1)).min(1),
+  capabilities: cncFeatureCapabilitiesSchema,
 });
 
 const nodeMetadataSchema = z.object({


### PR DESCRIPTION
## Linked Issues
- Protocol: #257
- Backend: #254
- Frontend follow-up: kaonis/woly#319

## 3-Part Chain
- [x] Protocol contract: add `cncCapabilitiesResponseSchema` and typed DTO exports in `packages/protocol`.
- [x] Backend endpoint: add authenticated `GET /api/capabilities` route/controller in CNC app.
- [x] Frontend integration issue linked for capability consumption (`kaonis/woly#319`).

## What Changed
- Added protocol DTO + zod schema for CNC capability negotiation payload.
- Added CNC controller/route for `/api/capabilities` with stable feature flags and version metadata.
- Added integration tests for auth + payload contract.
- Expanded mobile compatibility smoke test to cover capabilities endpoint.
- Updated OpenAPI docs with `CapabilitiesResponse` schema and `Capabilities` tag.

## Local Validation Evidence
- `npm ci`
- `npm run build -w packages/protocol`
- `npm run test -w packages/protocol -- contract.cross-repo`
- `npm run test -w packages/protocol -- schemas.test.ts`
- `npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts src/routes/__tests__/capabilitiesRoutes.test.ts`
- `npm run typecheck`
- `npm run lint`

Note: `npm run validate:standard` is not available in this branch baseline; equivalent available checks were run (`typecheck` + `lint`).

Closes #254
