### PR TITLE
feat(protocol): export CNC API DTO schemas for app/backend contracts

### DIFF
--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -2,7 +2,14 @@
  * Core type definitions for WoLy C&C Backend
  */
 
-import type { CommandState, Host, NodeMetadata as ProtocolNodeMetadata } from '@kaonis/woly-protocol';
+import type {
+  CncCapabilitiesResponse as ProtocolCncCapabilitiesResponse,
+  CncCapabilityDescriptor as ProtocolCncCapabilityDescriptor,
+  CommandState,
+  Host,
+  HostPortScanResponse as ProtocolHostPortScanResponse,
+  NodeMetadata as ProtocolNodeMetadata,
+} from '@kaonis/woly-protocol';
 
 // Node Types
 export interface Node {
@@ -66,27 +73,9 @@ export interface HostsResponse {
   };
 }
 
-export interface CapabilityDescriptor {
-  supported: boolean;
-  routes?: string[];
-  persistence?: 'backend' | 'local' | 'none';
-  transport?: 'websocket' | 'sse' | null;
-  note?: string;
-}
-
-export interface CncCapabilitiesResponse {
-  mode: 'cnc';
-  versions: {
-    cncApi: string;
-    protocol: string;
-  };
-  capabilities: {
-    scan: CapabilityDescriptor;
-    notesTags: CapabilityDescriptor;
-    schedules: CapabilityDescriptor;
-    commandStatusStreaming: CapabilityDescriptor;
-  };
-}
+export type CapabilityDescriptor = ProtocolCncCapabilityDescriptor;
+export type CncCapabilitiesResponse = ProtocolCncCapabilitiesResponse;
+export type HostPortScanResponse = ProtocolHostPortScanResponse;
 
 export interface WakeupResponse {
   success: boolean;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -61,6 +61,48 @@ export interface ErrorResponse {
   details?: unknown;
 }
 
+export interface CncCapabilityDescriptor {
+  supported: boolean;
+  routes?: string[];
+  persistence?: 'backend' | 'local' | 'none';
+  transport?: 'websocket' | 'sse' | null;
+  note?: string;
+}
+
+export interface CncCapabilitiesResponse {
+  mode: 'cnc';
+  versions: {
+    cncApi: string;
+    protocol: string;
+  };
+  capabilities: {
+    scan: CncCapabilityDescriptor;
+    notesTags: CncCapabilityDescriptor;
+    schedules: CncCapabilityDescriptor;
+    commandStatusStreaming: CncCapabilityDescriptor;
+  };
+}
+
+export interface HostPort {
+  port: number;
+  protocol: 'tcp';
+  service: string;
+}
+
+export interface HostPortScanResponse {
+  target: string;
+  scannedAt: string;
+  openPorts: HostPort[];
+  scan?: {
+    commandId?: string;
+    state?: CommandState;
+    nodeId?: string;
+    message?: string;
+  };
+  message?: string;
+  correlationId?: string;
+}
+
 // --- WebSocket message types ---
 
 export type NodeMessage =
@@ -142,6 +184,48 @@ export const errorResponseSchema = z.object({
   message: z.string().min(1),
   code: z.string().optional(),
   details: z.unknown().optional(),
+});
+
+export const cncCapabilityDescriptorSchema: z.ZodType<CncCapabilityDescriptor> = z.object({
+  supported: z.boolean(),
+  routes: z.array(z.string().min(1)).optional(),
+  persistence: z.enum(['backend', 'local', 'none']).optional(),
+  transport: z.enum(['websocket', 'sse']).nullable().optional(),
+  note: z.string().min(1).optional(),
+});
+
+export const cncCapabilitiesResponseSchema: z.ZodType<CncCapabilitiesResponse> = z.object({
+  mode: z.literal('cnc'),
+  versions: z.object({
+    cncApi: z.string().min(1),
+    protocol: z.string().min(1),
+  }),
+  capabilities: z.object({
+    scan: cncCapabilityDescriptorSchema,
+    notesTags: cncCapabilityDescriptorSchema,
+    schedules: cncCapabilityDescriptorSchema,
+    commandStatusStreaming: cncCapabilityDescriptorSchema,
+  }),
+});
+
+export const hostPortSchema: z.ZodType<HostPort> = z.object({
+  port: z.number().int().positive(),
+  protocol: z.literal('tcp'),
+  service: z.string().min(1),
+});
+
+export const hostPortScanResponseSchema: z.ZodType<HostPortScanResponse> = z.object({
+  target: z.string().min(1),
+  scannedAt: z.string().min(1),
+  openPorts: z.array(hostPortSchema),
+  scan: z.object({
+    commandId: z.string().min(1).optional(),
+    state: commandStateSchema.optional(),
+    nodeId: z.string().min(1).optional(),
+    message: z.string().min(1).optional(),
+  }).optional(),
+  message: z.string().min(1).optional(),
+  correlationId: z.string().min(1).optional(),
 });
 
 const nodeMetadataSchema = z.object({


### PR DESCRIPTION
## CNC Sync Classification
- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)
- Protocol issue: kaonis/woly-server#257
- Backend issue: kaonis/woly-server#254
- Frontend issue: kaonis/woly#308

## 3-Part Chain Checklist (required for CNC feature changes)
- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates
- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Local Validation (required for CNC feature changes)
Commands run:
```bash
npm run test -w packages/protocol -- schemas.test
npm run test -w packages/protocol -- contract.cross-repo.test.ts
npm run build -w packages/protocol
npm run typecheck -w apps/cnc
```

Result summary:
- [x] Local validation passed
- [ ] Any known gaps are documented below

Notes:
- Stacked on top of PR #260.
- Adds protocol exports for CNC API DTOs used by app/backend coordination:
  - `CncCapabilityDescriptor` + `cncCapabilityDescriptorSchema`
  - `CncCapabilitiesResponse` + `cncCapabilitiesResponseSchema`
  - `HostPort` + `hostPortSchema`
  - `HostPortScanResponse` + `hostPortScanResponseSchema`
- Updates C&C app types to consume these protocol exports instead of duplicating DTO definitions.
