### PR TITLE
feat(cnc): implement server-side wake schedule API and persistence

### DIFF
--- a/apps/cnc/src/controllers/capabilities.ts
+++ b/apps/cnc/src/controllers/capabilities.ts
@@ -14,8 +14,8 @@ const CNC_FEATURE_CAPABILITIES = {
   scan: false,
   // Host metadata persistence is available through host update flows.
   notesTagsPersistence: true,
-  // Schedule API parity is tracked separately and not yet available.
-  schedulesApi: false,
+  // Schedule API CRUD is available server-side.
+  schedulesApi: true,
   // Mobile currently uses polling for command lifecycle visibility.
   commandStatusStreaming: false,
 } as const;

--- a/apps/cnc/src/controllers/schedules.ts
+++ b/apps/cnc/src/controllers/schedules.ts
@@ -1,0 +1,341 @@
+import { Request, Response } from 'express';
+import {
+  createWakeScheduleRequestSchema,
+  updateWakeScheduleRequestSchema,
+  wakeScheduleListResponseSchema,
+  wakeScheduleSchema,
+} from '@kaonis/woly-protocol';
+import { z } from 'zod';
+import { WakeScheduleModel } from '../models/WakeSchedule';
+import logger from '../utils/logger';
+
+const listSchedulesQuerySchema = z.object({
+  hostFqn: z.string().min(1).optional(),
+});
+
+function isValidTimezone(timezone: string): boolean {
+  try {
+    Intl.DateTimeFormat('en-US', { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function badRequest(res: Response, message: string, details?: unknown): void {
+  res.status(400).json({
+    error: 'Bad Request',
+    message,
+    ...(details ? { details } : {}),
+  });
+}
+
+function ownerSub(req: Request): string | null {
+  return req.auth?.sub ?? null;
+}
+
+export class SchedulesController {
+  /**
+   * @swagger
+   * /api/schedules:
+   *   get:
+   *     summary: List wake schedules for authenticated subject
+   *     description: Returns wake schedules scoped to the authenticated JWT subject with optional host FQN filter.
+   *     tags: [Schedules]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: hostFqn
+   *         schema:
+   *           type: string
+   *         description: Optional fully-qualified host identity filter (hostname@location)
+   *         example: office-pc@home-node
+   *     responses:
+   *       200:
+   *         description: Wake schedules list
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 schedules:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/WakeSchedule'
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       500:
+   *         $ref: '#/components/responses/InternalError'
+   */
+  async listSchedules(req: Request, res: Response): Promise<void> {
+    try {
+      const authSub = ownerSub(req);
+      if (!authSub) {
+        res.status(401).json({
+          error: 'Unauthorized',
+          message: 'Authentication required',
+          code: 'AUTH_UNAUTHORIZED',
+        });
+        return;
+      }
+
+      const queryParse = listSchedulesQuerySchema.safeParse(req.query);
+      if (!queryParse.success) {
+        badRequest(res, 'Invalid query parameters', queryParse.error.issues);
+        return;
+      }
+
+      const schedules = await WakeScheduleModel.list(authSub, queryParse.data.hostFqn);
+      const payload = wakeScheduleListResponseSchema.parse({ schedules });
+      res.status(200).json(payload);
+    } catch (error) {
+      logger.error('Failed to list wake schedules', {
+        ownerSub: req.auth?.sub,
+        correlationId: req.correlationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to retrieve wake schedules',
+      });
+    }
+  }
+
+  /**
+   * @swagger
+   * /api/schedules:
+   *   post:
+   *     summary: Create wake schedule
+   *     description: Creates a wake schedule scoped to the authenticated JWT subject.
+   *     tags: [Schedules]
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/CreateWakeScheduleRequest'
+   *     responses:
+   *       201:
+   *         description: Created wake schedule
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/WakeSchedule'
+   *       400:
+   *         $ref: '#/components/responses/BadRequest'
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       500:
+   *         $ref: '#/components/responses/InternalError'
+   */
+  async createSchedule(req: Request, res: Response): Promise<void> {
+    try {
+      const authSub = ownerSub(req);
+      if (!authSub) {
+        res.status(401).json({
+          error: 'Unauthorized',
+          message: 'Authentication required',
+          code: 'AUTH_UNAUTHORIZED',
+        });
+        return;
+      }
+
+      const parseResult = createWakeScheduleRequestSchema.safeParse(req.body);
+      if (!parseResult.success) {
+        badRequest(res, 'Invalid request body', parseResult.error.issues);
+        return;
+      }
+
+      if (!isValidTimezone(parseResult.data.timezone)) {
+        badRequest(res, 'timezone must be a valid IANA timezone name');
+        return;
+      }
+
+      const created = await WakeScheduleModel.create(authSub, parseResult.data);
+      const payload = wakeScheduleSchema.parse(created);
+      res.status(201).json(payload);
+    } catch (error) {
+      logger.error('Failed to create wake schedule', {
+        ownerSub: req.auth?.sub,
+        correlationId: req.correlationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to create wake schedule',
+      });
+    }
+  }
+
+  /**
+   * @swagger
+   * /api/schedules/{id}:
+   *   put:
+   *     summary: Update wake schedule
+   *     description: Updates a wake schedule owned by the authenticated JWT subject.
+   *     tags: [Schedules]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Wake schedule ID
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/UpdateWakeScheduleRequest'
+   *     responses:
+   *       200:
+   *         description: Updated wake schedule
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/WakeSchedule'
+   *       400:
+   *         $ref: '#/components/responses/BadRequest'
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       404:
+   *         $ref: '#/components/responses/NotFound'
+   *       500:
+   *         $ref: '#/components/responses/InternalError'
+   */
+  async updateSchedule(req: Request, res: Response): Promise<void> {
+    try {
+      const authSub = ownerSub(req);
+      if (!authSub) {
+        res.status(401).json({
+          error: 'Unauthorized',
+          message: 'Authentication required',
+          code: 'AUTH_UNAUTHORIZED',
+        });
+        return;
+      }
+
+      const scheduleId = typeof req.params.id === 'string' ? req.params.id.trim() : '';
+      if (!scheduleId) {
+        badRequest(res, 'Schedule id is required');
+        return;
+      }
+
+      const parseResult = updateWakeScheduleRequestSchema.safeParse(req.body);
+      if (!parseResult.success) {
+        badRequest(res, 'Invalid request body', parseResult.error.issues);
+        return;
+      }
+
+      if (
+        parseResult.data.timezone !== undefined &&
+        !isValidTimezone(parseResult.data.timezone)
+      ) {
+        badRequest(res, 'timezone must be a valid IANA timezone name');
+        return;
+      }
+
+      const updated = await WakeScheduleModel.update(authSub, scheduleId, parseResult.data);
+      if (!updated) {
+        res.status(404).json({
+          error: 'Not Found',
+          message: `Wake schedule ${scheduleId} not found`,
+        });
+        return;
+      }
+
+      const payload = wakeScheduleSchema.parse(updated);
+      res.status(200).json(payload);
+    } catch (error) {
+      logger.error('Failed to update wake schedule', {
+        ownerSub: req.auth?.sub,
+        scheduleId: req.params.id,
+        correlationId: req.correlationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to update wake schedule',
+      });
+    }
+  }
+
+  /**
+   * @swagger
+   * /api/schedules/{id}:
+   *   delete:
+   *     summary: Delete wake schedule
+   *     description: Deletes a wake schedule owned by the authenticated JWT subject.
+   *     tags: [Schedules]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Wake schedule ID
+   *     responses:
+   *       200:
+   *         description: Schedule deleted
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       404:
+   *         $ref: '#/components/responses/NotFound'
+   *       500:
+   *         $ref: '#/components/responses/InternalError'
+   */
+  async deleteSchedule(req: Request, res: Response): Promise<void> {
+    try {
+      const authSub = ownerSub(req);
+      if (!authSub) {
+        res.status(401).json({
+          error: 'Unauthorized',
+          message: 'Authentication required',
+          code: 'AUTH_UNAUTHORIZED',
+        });
+        return;
+      }
+
+      const scheduleId = typeof req.params.id === 'string' ? req.params.id.trim() : '';
+      if (!scheduleId) {
+        badRequest(res, 'Schedule id is required');
+        return;
+      }
+
+      const deleted = await WakeScheduleModel.delete(authSub, scheduleId);
+      if (!deleted) {
+        res.status(404).json({
+          error: 'Not Found',
+          message: `Wake schedule ${scheduleId} not found`,
+        });
+        return;
+      }
+
+      res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error('Failed to delete wake schedule', {
+        ownerSub: req.auth?.sub,
+        scheduleId: req.params.id,
+        correlationId: req.correlationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to delete wake schedule',
+      });
+    }
+  }
+}
+
+export default SchedulesController;

--- a/apps/cnc/src/models/WakeSchedule.ts
+++ b/apps/cnc/src/models/WakeSchedule.ts
@@ -1,0 +1,246 @@
+import { randomUUID } from 'crypto';
+import type {
+  CreateWakeScheduleRequest,
+  UpdateWakeScheduleRequest,
+  WakeSchedule,
+  ScheduleFrequency,
+} from '@kaonis/woly-protocol';
+import db from '../database/connection';
+import logger from '../utils/logger';
+
+interface WakeScheduleRow {
+  id: string;
+  owner_sub: string;
+  host_fqn: string;
+  host_name: string;
+  host_mac: string;
+  scheduled_time: string | Date;
+  timezone: string;
+  frequency: ScheduleFrequency;
+  enabled: boolean | number;
+  notify_on_wake: boolean | number;
+  created_at: string | Date;
+  updated_at: string | Date;
+  last_triggered: string | Date | null;
+  next_trigger: string | Date | null;
+}
+
+const isSqlite = db.isSqlite;
+
+function toBoolean(value: boolean | number): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  return value !== 0;
+}
+
+function toIsoString(value: string | Date): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid timestamp from database: ${String(value)}`);
+  }
+  return parsed.toISOString();
+}
+
+function toNullableIsoString(value: string | Date | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  return toIsoString(value);
+}
+
+function asDbBoolean(value: boolean): boolean | number {
+  return isSqlite ? (value ? 1 : 0) : value;
+}
+
+function rowToRecord(row: WakeScheduleRow): WakeSchedule {
+  return {
+    id: String(row.id),
+    hostName: String(row.host_name),
+    hostMac: String(row.host_mac),
+    hostFqn: String(row.host_fqn),
+    scheduledTime: toIsoString(row.scheduled_time),
+    timezone: String(row.timezone),
+    frequency: row.frequency,
+    enabled: toBoolean(row.enabled),
+    notifyOnWake: toBoolean(row.notify_on_wake),
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+    lastTriggered: toNullableIsoString(row.last_triggered),
+    nextTrigger: toNullableIsoString(row.next_trigger),
+  };
+}
+
+export class WakeScheduleModel {
+  static async create(ownerSub: string, input: CreateWakeScheduleRequest): Promise<WakeSchedule> {
+    const query = `
+      INSERT INTO wake_schedules (
+        id,
+        owner_sub,
+        host_fqn,
+        host_name,
+        host_mac,
+        scheduled_time,
+        timezone,
+        frequency,
+        enabled,
+        notify_on_wake,
+        next_trigger
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      RETURNING *
+    `;
+
+    const scheduleId = randomUUID();
+
+    const result = await db.query<WakeScheduleRow>(query, [
+      scheduleId,
+      ownerSub,
+      input.hostFqn,
+      input.hostName,
+      input.hostMac,
+      input.scheduledTime,
+      input.timezone ?? 'UTC',
+      input.frequency,
+      asDbBoolean(input.enabled ?? true),
+      asDbBoolean(input.notifyOnWake ?? true),
+      input.nextTrigger ?? null,
+    ]);
+
+    if (!result.rows.length) {
+      throw new Error('Failed to create wake schedule');
+    }
+
+    return rowToRecord(result.rows[0]);
+  }
+
+  static async list(ownerSub: string, hostFqn?: string): Promise<WakeSchedule[]> {
+    const result = hostFqn
+      ? await db.query<WakeScheduleRow>(
+          `
+            SELECT *
+            FROM wake_schedules
+            WHERE owner_sub = $1 AND host_fqn = $2
+            ORDER BY created_at DESC
+          `,
+          [ownerSub, hostFqn],
+        )
+      : await db.query<WakeScheduleRow>(
+          `
+            SELECT *
+            FROM wake_schedules
+            WHERE owner_sub = $1
+            ORDER BY created_at DESC
+          `,
+          [ownerSub],
+        );
+
+    return result.rows.map(rowToRecord);
+  }
+
+  static async findById(ownerSub: string, id: string): Promise<WakeSchedule | null> {
+    const result = await db.query<WakeScheduleRow>(
+      `
+        SELECT *
+        FROM wake_schedules
+        WHERE owner_sub = $1 AND id = $2
+        LIMIT 1
+      `,
+      [ownerSub, id],
+    );
+
+    if (!result.rows.length) {
+      return null;
+    }
+
+    return rowToRecord(result.rows[0]);
+  }
+
+  static async update(
+    ownerSub: string,
+    id: string,
+    updates: UpdateWakeScheduleRequest,
+  ): Promise<WakeSchedule | null> {
+    const assignments: string[] = [];
+    const params: unknown[] = [];
+    let index = 1;
+
+    const setField = (column: string, value: unknown): void => {
+      assignments.push(`${column} = $${index}`);
+      params.push(value);
+      index += 1;
+    };
+
+    if (updates.hostFqn !== undefined) setField('host_fqn', updates.hostFqn);
+    if (updates.hostName !== undefined) setField('host_name', updates.hostName);
+    if (updates.hostMac !== undefined) setField('host_mac', updates.hostMac);
+    if (updates.scheduledTime !== undefined) setField('scheduled_time', updates.scheduledTime);
+    if (updates.timezone !== undefined) setField('timezone', updates.timezone);
+    if (updates.frequency !== undefined) setField('frequency', updates.frequency);
+    if (updates.enabled !== undefined) setField('enabled', asDbBoolean(updates.enabled));
+    if (updates.notifyOnWake !== undefined) {
+      setField('notify_on_wake', asDbBoolean(updates.notifyOnWake));
+    }
+    if (updates.nextTrigger !== undefined) setField('next_trigger', updates.nextTrigger);
+    if (updates.lastTriggered !== undefined) setField('last_triggered', updates.lastTriggered);
+
+    if (!assignments.length) {
+      return this.findById(ownerSub, id);
+    }
+
+    assignments.push(`updated_at = ${isSqlite ? 'CURRENT_TIMESTAMP' : 'NOW()'}`);
+    const ownerSubPlaceholder = `$${index}`;
+    params.push(ownerSub);
+    index += 1;
+    const idPlaceholder = `$${index}`;
+    params.push(id);
+
+    if (isSqlite) {
+      const updateQuery = `
+        UPDATE wake_schedules
+        SET ${assignments.join(', ')}
+        WHERE owner_sub = ${ownerSubPlaceholder} AND id = ${idPlaceholder}
+      `;
+
+      const updateResult = await db.query(updateQuery, params);
+      if (updateResult.rowCount === 0) {
+        return null;
+      }
+
+      return this.findById(ownerSub, id);
+    }
+
+    const query = `
+      UPDATE wake_schedules
+      SET ${assignments.join(', ')}
+      WHERE owner_sub = ${ownerSubPlaceholder} AND id = ${idPlaceholder}
+      RETURNING *
+    `;
+
+    const result = await db.query<WakeScheduleRow>(query, params);
+
+    if (!result.rows.length) {
+      return null;
+    }
+
+    return rowToRecord(result.rows[0]);
+  }
+
+  static async delete(ownerSub: string, id: string): Promise<boolean> {
+    const result = await db.query(
+      `
+        DELETE FROM wake_schedules
+        WHERE owner_sub = $1 AND id = $2
+      `,
+      [ownerSub, id],
+    );
+
+    if (result.rowCount > 0) {
+      logger.info('Wake schedule deleted', { ownerSub, scheduleId: id });
+    }
+
+    return result.rowCount > 0;
+  }
+}
+
+export default WakeScheduleModel;

--- a/apps/cnc/src/models/__tests__/WakeSchedule.test.ts
+++ b/apps/cnc/src/models/__tests__/WakeSchedule.test.ts
@@ -1,0 +1,98 @@
+import { WakeScheduleModel } from '../WakeSchedule';
+import db from '../../database/connection';
+
+describe('WakeScheduleModel', () => {
+  beforeEach(async () => {
+    await db.query('DELETE FROM wake_schedules WHERE owner_sub LIKE $1', ['test-%']);
+  });
+
+  it('creates and lists schedules with defaults', async () => {
+    const created = await WakeScheduleModel.create('test-user-1', {
+      hostName: 'office-pc',
+      hostMac: 'AA:BB:CC:DD:EE:FF',
+      hostFqn: 'office-pc@home-node',
+      scheduledTime: '2026-02-16T08:00:00.000Z',
+      frequency: 'daily',
+    });
+
+    expect(created.id).toBeTruthy();
+    expect(created.timezone).toBe('UTC');
+    expect(created.enabled).toBe(true);
+    expect(created.notifyOnWake).toBe(true);
+
+    const listed = await WakeScheduleModel.list('test-user-1');
+    expect(listed).toHaveLength(1);
+    expect(listed[0].id).toBe(created.id);
+  });
+
+  it('scopes queries by owner subject', async () => {
+    await WakeScheduleModel.create('test-user-a', {
+      hostName: 'office-a',
+      hostMac: 'AA:AA:AA:AA:AA:AA',
+      hostFqn: 'office-a@node-a',
+      scheduledTime: '2026-02-16T09:00:00.000Z',
+      frequency: 'once',
+    });
+
+    await WakeScheduleModel.create('test-user-b', {
+      hostName: 'office-b',
+      hostMac: 'BB:BB:BB:BB:BB:BB',
+      hostFqn: 'office-b@node-b',
+      scheduledTime: '2026-02-16T10:00:00.000Z',
+      frequency: 'weekly',
+    });
+
+    const userASchedules = await WakeScheduleModel.list('test-user-a');
+    const userBSchedules = await WakeScheduleModel.list('test-user-b');
+
+    expect(userASchedules).toHaveLength(1);
+    expect(userASchedules[0].hostName).toBe('office-a');
+    expect(userBSchedules).toHaveLength(1);
+    expect(userBSchedules[0].hostName).toBe('office-b');
+  });
+
+  it('updates schedule fields and returns the updated record', async () => {
+    const created = await WakeScheduleModel.create('test-user-update', {
+      hostName: 'office-pc',
+      hostMac: 'AA:BB:CC:DD:EE:FF',
+      hostFqn: 'office-pc@home-node',
+      scheduledTime: '2026-02-16T08:00:00.000Z',
+      frequency: 'daily',
+      timezone: 'UTC',
+    });
+
+    const updated = await WakeScheduleModel.update('test-user-update', created.id, {
+      enabled: false,
+      frequency: 'weekdays',
+      timezone: 'America/New_York',
+      nextTrigger: '2026-02-17T13:00:00.000Z',
+      lastTriggered: '2026-02-16T13:00:00.000Z',
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.enabled).toBe(false);
+    expect(updated!.frequency).toBe('weekdays');
+    expect(updated!.timezone).toBe('America/New_York');
+    expect(updated!.nextTrigger).toBe('2026-02-17T13:00:00.000Z');
+    expect(updated!.lastTriggered).toBe('2026-02-16T13:00:00.000Z');
+  });
+
+  it('deletes schedules by owner scope', async () => {
+    const created = await WakeScheduleModel.create('test-user-delete', {
+      hostName: 'office-pc',
+      hostMac: 'AA:BB:CC:DD:EE:FF',
+      hostFqn: 'office-pc@home-node',
+      scheduledTime: '2026-02-16T08:00:00.000Z',
+      frequency: 'daily',
+    });
+
+    const wrongOwnerDelete = await WakeScheduleModel.delete('test-other-user', created.id);
+    expect(wrongOwnerDelete).toBe(false);
+
+    const deleted = await WakeScheduleModel.delete('test-user-delete', created.id);
+    expect(deleted).toBe(true);
+
+    const listed = await WakeScheduleModel.list('test-user-delete');
+    expect(listed).toHaveLength(0);
+  });
+});

--- a/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
@@ -90,7 +90,7 @@ describe('Capabilities Routes', () => {
       expect(response.body.capabilities).toEqual({
         scan: false,
         notesTagsPersistence: true,
-        schedulesApi: false,
+        schedulesApi: true,
         commandStatusStreaming: false,
       });
     });

--- a/apps/cnc/src/routes/__tests__/scheduleRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/scheduleRoutes.test.ts
@@ -1,0 +1,192 @@
+import express, { Express } from 'express';
+import request from 'supertest';
+import {
+  wakeScheduleSchema,
+  wakeScheduleListResponseSchema,
+} from '@kaonis/woly-protocol';
+import { createRoutes } from '../index';
+import { NodeManager } from '../../services/nodeManager';
+import { HostAggregator } from '../../services/hostAggregator';
+import { CommandRouter } from '../../services/commandRouter';
+import { createToken } from './testUtils';
+import db from '../../database/connection';
+
+jest.mock('../../config', () => ({
+  __esModule: true,
+  default: {
+    jwtSecret: 'test-secret',
+    jwtIssuer: 'test-issuer',
+    jwtAudience: 'test-audience',
+    port: 8080,
+    dbType: 'sqlite',
+    dbPath: ':memory:',
+    nodeAuthTokens: ['test-node-token'],
+    nodeHeartbeatInterval: 30000,
+    nodeTimeout: 60000,
+    jwtTtlSeconds: 3600,
+  },
+}));
+
+describe('Schedule Routes', () => {
+  let app: Express;
+  const now = Math.floor(Date.now() / 1000);
+
+  beforeAll(() => {
+    const nodeManager = {} as unknown as NodeManager;
+    const hostAggregator = {} as unknown as HostAggregator;
+    const commandRouter = {} as unknown as CommandRouter;
+
+    app = express();
+    app.use(express.json());
+    app.use('/api', createRoutes(nodeManager, hostAggregator, commandRouter));
+  });
+
+  beforeEach(async () => {
+    await db.query('DELETE FROM wake_schedules');
+  });
+
+  const operatorToken = createToken({
+    sub: 'mobile-user-a',
+    role: 'operator',
+    iss: 'test-issuer',
+    aud: 'test-audience',
+    exp: now + 3600,
+    nbf: now - 10,
+  });
+
+  const secondOperatorToken = createToken({
+    sub: 'mobile-user-b',
+    role: 'operator',
+    iss: 'test-issuer',
+    aud: 'test-audience',
+    exp: now + 3600,
+    nbf: now - 10,
+  });
+
+  describe('GET /api/schedules', () => {
+    it('returns 401 when JWT is missing', async () => {
+      const response = await request(app).get('/api/schedules');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for viewer role', async () => {
+      const viewerToken = createToken({
+        sub: 'viewer-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .get('/api/schedules')
+        .set('Authorization', `Bearer ${viewerToken}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        error: 'Forbidden',
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+  });
+
+  describe('CRUD contract', () => {
+    it('creates, lists, updates and deletes schedules with owner scoping', async () => {
+      const createResponse = await request(app)
+        .post('/api/schedules')
+        .set('Authorization', `Bearer ${operatorToken}`)
+        .send({
+          hostName: 'office-pc',
+          hostMac: 'AA:BB:CC:DD:EE:FF',
+          hostFqn: 'office-pc@home-node',
+          scheduledTime: '2026-02-16T08:00:00.000Z',
+          frequency: 'daily',
+          timezone: 'America/New_York',
+          notifyOnWake: true,
+        });
+
+      expect(createResponse.status).toBe(201);
+      expect(wakeScheduleSchema.safeParse(createResponse.body).success).toBe(true);
+      const scheduleId = createResponse.body.id as string;
+
+      await request(app)
+        .post('/api/schedules')
+        .set('Authorization', `Bearer ${secondOperatorToken}`)
+        .send({
+          hostName: 'other-pc',
+          hostMac: '11:22:33:44:55:66',
+          hostFqn: 'other-pc@branch-node',
+          scheduledTime: '2026-02-16T09:00:00.000Z',
+          frequency: 'once',
+          timezone: 'UTC',
+        });
+
+      const listResponse = await request(app)
+        .get('/api/schedules')
+        .set('Authorization', `Bearer ${operatorToken}`);
+
+      expect(listResponse.status).toBe(200);
+      expect(wakeScheduleListResponseSchema.safeParse(listResponse.body).success).toBe(true);
+      expect(listResponse.body.schedules).toHaveLength(1);
+      expect(listResponse.body.schedules[0].id).toBe(scheduleId);
+
+      const updateResponse = await request(app)
+        .put(`/api/schedules/${scheduleId}`)
+        .set('Authorization', `Bearer ${operatorToken}`)
+        .send({
+          enabled: false,
+          frequency: 'weekdays',
+          nextTrigger: '2026-02-17T13:00:00.000Z',
+        });
+
+      expect(updateResponse.status).toBe(200);
+      expect(updateResponse.body.enabled).toBe(false);
+      expect(updateResponse.body.frequency).toBe('weekdays');
+
+      const crossTenantUpdate = await request(app)
+        .put(`/api/schedules/${scheduleId}`)
+        .set('Authorization', `Bearer ${secondOperatorToken}`)
+        .send({ enabled: true });
+      expect(crossTenantUpdate.status).toBe(404);
+
+      const deleteResponse = await request(app)
+        .delete(`/api/schedules/${scheduleId}`)
+        .set('Authorization', `Bearer ${operatorToken}`);
+
+      expect(deleteResponse.status).toBe(200);
+      expect(deleteResponse.body).toEqual({ success: true });
+
+      const finalList = await request(app)
+        .get('/api/schedules')
+        .set('Authorization', `Bearer ${operatorToken}`);
+
+      expect(finalList.status).toBe(200);
+      expect(finalList.body.schedules).toHaveLength(0);
+    });
+
+    it('returns 400 for invalid request payloads', async () => {
+      const response = await request(app)
+        .post('/api/schedules')
+        .set('Authorization', `Bearer ${operatorToken}`)
+        .send({
+          hostName: 'office-pc',
+          hostMac: 'AA:BB:CC:DD:EE:FF',
+          hostFqn: 'office-pc@home-node',
+          scheduledTime: 'invalid-date',
+          frequency: 'daily',
+          timezone: 'Invalid/Timezone',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: 'Bad Request',
+      });
+    });
+  });
+});

--- a/apps/cnc/src/routes/index.ts
+++ b/apps/cnc/src/routes/index.ts
@@ -8,6 +8,7 @@ import { AdminController } from '../controllers/admin';
 import { HostsController } from '../controllers/hosts';
 import { AuthController } from '../controllers/auth';
 import { CapabilitiesController } from '../controllers/capabilities';
+import { SchedulesController } from '../controllers/schedules';
 import { NodeManager } from '../services/nodeManager';
 import { HostAggregator } from '../services/hostAggregator';
 import { CommandRouter } from '../services/commandRouter';
@@ -30,6 +31,7 @@ export function createRoutes(
   const hostsController = new HostsController(hostAggregator, commandRouter);
   const authController = new AuthController();
   const capabilitiesController = new CapabilitiesController();
+  const schedulesController = new SchedulesController();
 
   // Public API routes with rate limiting
   router.post('/auth/token', strictAuthLimiter, (req, res) => authController.issueToken(req, res));
@@ -38,6 +40,7 @@ export function createRoutes(
   router.use('/nodes', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
   router.use('/hosts', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
   router.use('/capabilities', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
+  router.use('/schedules', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
   router.use('/admin', apiLimiter, authenticateJwt, authorizeRoles('admin'));
 
   // Node API routes (protected)
@@ -56,6 +59,10 @@ export function createRoutes(
   router.put('/hosts/:fqn', (req, res) => hostsController.updateHost(req, res));
   router.delete('/hosts/:fqn', (req, res) => hostsController.deleteHost(req, res));
   router.get('/capabilities', (req, res) => capabilitiesController.getCapabilities(req, res));
+  router.get('/schedules', (req, res) => schedulesController.listSchedules(req, res));
+  router.post('/schedules', (req, res) => schedulesController.createSchedule(req, res));
+  router.put('/schedules/:id', (req, res) => schedulesController.updateSchedule(req, res));
+  router.delete('/schedules/:id', (req, res) => schedulesController.deleteSchedule(req, res));
 
   // Admin API routes
   router.delete('/admin/nodes/:id', (req, res) => adminController.deleteNode(req, res));

--- a/apps/cnc/src/swagger.ts
+++ b/apps/cnc/src/swagger.ts
@@ -58,6 +58,10 @@ const options: swaggerJsdoc.Options = {
         description: 'Feature negotiation and version metadata',
       },
       {
+        name: 'Schedules',
+        description: 'Server-managed wake schedule CRUD endpoints',
+      },
+      {
         name: 'Admin',
         description: 'Administrative operations (requires admin role)',
       },
@@ -317,7 +321,7 @@ const options: swaggerJsdoc.Options = {
                 schedulesApi: {
                   type: 'boolean',
                   description: 'Whether server-managed wake schedule CRUD is available',
-                  example: false,
+                  example: true,
                 },
                 commandStatusStreaming: {
                   type: 'boolean',
@@ -325,6 +329,183 @@ const options: swaggerJsdoc.Options = {
                   example: false,
                 },
               },
+            },
+          },
+        },
+        ScheduleFrequency: {
+          type: 'string',
+          enum: ['once', 'daily', 'weekly', 'weekdays', 'weekends'],
+          description: 'Wake schedule recurrence frequency',
+          example: 'daily',
+        },
+        WakeSchedule: {
+          type: 'object',
+          required: [
+            'id',
+            'hostName',
+            'hostMac',
+            'hostFqn',
+            'scheduledTime',
+            'timezone',
+            'frequency',
+            'enabled',
+            'notifyOnWake',
+            'createdAt',
+            'updatedAt',
+            'lastTriggered',
+            'nextTrigger',
+          ],
+          properties: {
+            id: {
+              type: 'string',
+              description: 'Wake schedule identifier',
+              example: '8ca21661-2333-4af7-a78c-c8518caef5ee',
+            },
+            hostName: {
+              type: 'string',
+              description: 'Display host name',
+              example: 'Office-Mac',
+            },
+            hostMac: {
+              type: 'string',
+              description: 'Host MAC address',
+              example: '00:11:22:33:44:55',
+            },
+            hostFqn: {
+              type: 'string',
+              description: 'Fully-qualified host identity (hostname@location)',
+              example: 'Office-Mac@Home',
+            },
+            scheduledTime: {
+              type: 'string',
+              format: 'date-time',
+              description: 'Anchor schedule time in ISO-8601 UTC',
+              example: '2026-02-16T08:00:00.000Z',
+            },
+            timezone: {
+              type: 'string',
+              description: 'IANA timezone used by client-side recurrence calculations',
+              example: 'America/New_York',
+            },
+            frequency: {
+              $ref: '#/components/schemas/ScheduleFrequency',
+            },
+            enabled: {
+              type: 'boolean',
+              description: 'Whether schedule is active',
+              example: true,
+            },
+            notifyOnWake: {
+              type: 'boolean',
+              description: 'Whether client should notify on wake execution',
+              example: true,
+            },
+            createdAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-02-15T20:00:00.000Z',
+            },
+            updatedAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-02-15T20:00:00.000Z',
+            },
+            lastTriggered: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: null,
+            },
+            nextTrigger: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2026-02-16T08:00:00.000Z',
+            },
+          },
+        },
+        CreateWakeScheduleRequest: {
+          type: 'object',
+          required: ['hostName', 'hostMac', 'hostFqn', 'scheduledTime', 'frequency'],
+          properties: {
+            hostName: {
+              type: 'string',
+              example: 'Office-Mac',
+            },
+            hostMac: {
+              type: 'string',
+              example: '00:11:22:33:44:55',
+            },
+            hostFqn: {
+              type: 'string',
+              example: 'Office-Mac@Home',
+            },
+            scheduledTime: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-02-16T08:00:00.000Z',
+            },
+            timezone: {
+              type: 'string',
+              example: 'UTC',
+            },
+            frequency: {
+              $ref: '#/components/schemas/ScheduleFrequency',
+            },
+            enabled: {
+              type: 'boolean',
+              example: true,
+            },
+            notifyOnWake: {
+              type: 'boolean',
+              example: true,
+            },
+            nextTrigger: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2026-02-16T08:00:00.000Z',
+            },
+          },
+        },
+        UpdateWakeScheduleRequest: {
+          type: 'object',
+          description: 'Partial update payload; at least one property is required',
+          properties: {
+            hostName: {
+              type: 'string',
+            },
+            hostMac: {
+              type: 'string',
+            },
+            hostFqn: {
+              type: 'string',
+            },
+            scheduledTime: {
+              type: 'string',
+              format: 'date-time',
+            },
+            timezone: {
+              type: 'string',
+            },
+            frequency: {
+              $ref: '#/components/schemas/ScheduleFrequency',
+            },
+            enabled: {
+              type: 'boolean',
+            },
+            notifyOnWake: {
+              type: 'boolean',
+            },
+            nextTrigger: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+            },
+            lastTriggered: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
             },
           },
         },

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -35,12 +35,16 @@ export type {
   CncCommand,
   CommandResultPayload,
   CommandState,
+  CreateWakeScheduleRequest,
   ErrorResponse,
   HostPayload,
   HostStatus,
   NodeMessage,
   NodeRegistration,
   RegisteredCommandData,
+  ScheduleFrequency,
+  UpdateWakeScheduleRequest,
+  WakeSchedule,
 } from '@kaonis/woly-protocol';
 
 export interface CommandResult {


### PR DESCRIPTION
## Summary
- add canonical wake schedule DTOs and request/response schemas to `@kaonis/woly-protocol`
- add `wake_schedules` persistence schema for PostgreSQL + SQLite in CNC backend
- implement authenticated server-side wake schedule CRUD endpoints at `/api/schedules`
- scope schedule records by authenticated JWT subject (`req.auth.sub`) for tenant isolation
- update capabilities negotiation to advertise `schedulesApi: true`
- extend OpenAPI components/routes for schedule contracts and timezone semantics
- add protocol/model/route/mobile compatibility tests for schedule API contracts and auth failures

## Linked issues
- Protocol issue: kaonis/woly-server#257
- Backend issue: Closes #255
- Frontend issue: kaonis/woly#310

## Local validation (full CI mirror)
- `npm ci`
- `npm run build -w packages/protocol`
- `npm run test -w packages/protocol -- schemas.test`
- `npm run test -w packages/protocol -- contract.cross-repo`
- `npm run test -w apps/node-agent -- protocol.contract`
- `npm run test -w apps/cnc -- protocol.contract`
- `npm run test:schema-gate -w apps/cnc`
- `npm run security:audit -w apps/node-agent`
- `npx turbo run lint typecheck test:ci build`
