### PR TITLE
feat(cnc): add persisted host wake schedule API and contracts (#255)

### DIFF
--- a/apps/cnc/README.md
+++ b/apps/cnc/README.md
@@ -178,6 +178,10 @@ Requires `Authorization: Bearer <jwt>` with role `operator` or `admin`.
 GET    /api/hosts
 GET    /api/hosts/ports/:fqn
 GET    /api/hosts/scan-ports/:fqn
+GET    /api/hosts/:fqn/schedules
+POST   /api/hosts/:fqn/schedules
+PUT    /api/hosts/schedules/:id
+DELETE /api/hosts/schedules/:id
 GET    /api/hosts/:fqn
 POST   /api/hosts/wakeup/:fqn
 PUT    /api/hosts/:fqn

--- a/apps/cnc/src/controllers/meta.ts
+++ b/apps/cnc/src/controllers/meta.ts
@@ -25,9 +25,10 @@ const cncCapabilities: CncCapabilitiesResponse = {
       note: 'Host notes/tags are accepted via PUT /api/hosts/:fqn.',
     },
     schedules: {
-      supported: false,
-      routes: [],
-      note: 'Planned in kaonis/woly-server#255.',
+      supported: true,
+      routes: ['/api/hosts/:fqn/schedules', '/api/hosts/schedules/:id'],
+      persistence: 'backend',
+      note: 'Host wake schedules are persisted in CNC backend.',
     },
     commandStatusStreaming: {
       supported: false,

--- a/apps/cnc/src/controllers/schedules.ts
+++ b/apps/cnc/src/controllers/schedules.ts
@@ -1,0 +1,229 @@
+import { Request, Response } from 'express';
+import {
+  createHostWakeScheduleRequestSchema,
+  updateHostWakeScheduleRequestSchema,
+} from '@kaonis/woly-protocol';
+import { HostAggregator } from '../services/hostAggregator';
+import HostScheduleModel from '../models/HostSchedule';
+import logger from '../utils/logger';
+
+export class SchedulesController {
+  constructor(private readonly hostAggregator: HostAggregator) {}
+
+  /**
+   * @swagger
+   * /api/hosts/{fqn}/schedules:
+   *   get:
+   *     summary: List wake schedules for a host
+   *     tags: [Hosts]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: fqn
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Host schedules
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       404:
+   *         $ref: '#/components/responses/NotFound'
+   */
+  async listHostSchedules(req: Request, res: Response): Promise<void> {
+    try {
+      const fqn = req.params.fqn as string;
+      const host = await this.hostAggregator.getHostByFQN(fqn);
+
+      if (!host) {
+        res.status(404).json({
+          error: 'Not Found',
+          message: `Host ${fqn} not found`,
+        });
+        return;
+      }
+
+      const schedules = await HostScheduleModel.listByHostFqn(fqn);
+      res.json({ schedules });
+    } catch (error) {
+      logger.error('Failed to list host schedules', { fqn: req.params.fqn, error });
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to list host schedules',
+      });
+    }
+  }
+
+  /**
+   * @swagger
+   * /api/hosts/{fqn}/schedules:
+   *   post:
+   *     summary: Create a wake schedule for a host
+   *     tags: [Hosts]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: fqn
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       201:
+   *         description: Created schedule
+   *       400:
+   *         $ref: '#/components/responses/BadRequest'
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       404:
+   *         $ref: '#/components/responses/NotFound'
+   */
+  async createHostSchedule(req: Request, res: Response): Promise<void> {
+    try {
+      const fqn = req.params.fqn as string;
+      const host = await this.hostAggregator.getHostByFQN(fqn);
+
+      if (!host) {
+        res.status(404).json({
+          error: 'Not Found',
+          message: `Host ${fqn} not found`,
+        });
+        return;
+      }
+
+      const parseResult = createHostWakeScheduleRequestSchema.safeParse(req.body);
+      if (!parseResult.success) {
+        res.status(400).json({
+          error: 'Bad Request',
+          message: 'Invalid request body',
+          details: parseResult.error.issues,
+        });
+        return;
+      }
+
+      const payload = parseResult.data;
+      const created = await HostScheduleModel.create({
+        hostFqn: fqn,
+        hostName: host.name,
+        hostMac: host.mac,
+        scheduledTime: payload.scheduledTime,
+        frequency: payload.frequency,
+        enabled: payload.enabled ?? true,
+        notifyOnWake: payload.notifyOnWake ?? true,
+        timezone: payload.timezone ?? 'UTC',
+      });
+
+      res.status(201).json(created);
+    } catch (error) {
+      logger.error('Failed to create host schedule', { fqn: req.params.fqn, error });
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to create host schedule',
+      });
+    }
+  }
+
+  /**
+   * @swagger
+   * /api/hosts/schedules/{id}:
+   *   put:
+   *     summary: Update wake schedule by id
+   *     tags: [Hosts]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Updated schedule
+   *       400:
+   *         $ref: '#/components/responses/BadRequest'
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       404:
+   *         $ref: '#/components/responses/NotFound'
+   */
+  async updateSchedule(req: Request, res: Response): Promise<void> {
+    try {
+      const id = req.params.id as string;
+      const parseResult = updateHostWakeScheduleRequestSchema.safeParse(req.body);
+      if (!parseResult.success) {
+        res.status(400).json({
+          error: 'Bad Request',
+          message: 'Invalid request body',
+          details: parseResult.error.issues,
+        });
+        return;
+      }
+
+      const updated = await HostScheduleModel.update(id, parseResult.data);
+      if (!updated) {
+        res.status(404).json({
+          error: 'Not Found',
+          message: `Schedule ${id} not found`,
+        });
+        return;
+      }
+
+      res.json(updated);
+    } catch (error) {
+      logger.error('Failed to update schedule', { id: req.params.id, error });
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to update schedule',
+      });
+    }
+  }
+
+  /**
+   * @swagger
+   * /api/hosts/schedules/{id}:
+   *   delete:
+   *     summary: Delete wake schedule by id
+   *     tags: [Hosts]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Deleted schedule
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       404:
+   *         $ref: '#/components/responses/NotFound'
+   */
+  async deleteSchedule(req: Request, res: Response): Promise<void> {
+    try {
+      const id = req.params.id as string;
+      const deleted = await HostScheduleModel.delete(id);
+      if (!deleted) {
+        res.status(404).json({
+          error: 'Not Found',
+          message: `Schedule ${id} not found`,
+        });
+        return;
+      }
+
+      res.json({ success: true, id });
+    } catch (error) {
+      logger.error('Failed to delete schedule', { id: req.params.id, error });
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to delete schedule',
+      });
+    }
+  }
+}
+
+export default SchedulesController;

--- a/apps/cnc/src/models/HostSchedule.ts
+++ b/apps/cnc/src/models/HostSchedule.ts
@@ -1,0 +1,365 @@
+import { randomUUID } from 'crypto';
+import db from '../database/connection';
+import type { HostWakeSchedule, ScheduleFrequency } from '../types';
+
+interface HostScheduleRow {
+  id: string;
+  host_fqn: string;
+  host_name: string;
+  host_mac: string;
+  scheduled_time: string | Date;
+  frequency: ScheduleFrequency;
+  enabled: boolean | number;
+  notify_on_wake: boolean | number;
+  timezone: string;
+  last_triggered: string | Date | null;
+  next_trigger: string | Date | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+}
+
+interface CreateHostScheduleInput {
+  hostFqn: string;
+  hostName: string;
+  hostMac: string;
+  scheduledTime: string;
+  frequency: ScheduleFrequency;
+  enabled: boolean;
+  notifyOnWake: boolean;
+  timezone: string;
+}
+
+interface UpdateHostScheduleInput {
+  scheduledTime?: string;
+  frequency?: ScheduleFrequency;
+  enabled?: boolean;
+  notifyOnWake?: boolean;
+  timezone?: string;
+}
+
+const isSqlite = db.isSqlite;
+
+const SQLITE_CREATE_TABLE = `
+  CREATE TABLE IF NOT EXISTS host_wake_schedules (
+    id TEXT PRIMARY KEY,
+    host_fqn TEXT NOT NULL,
+    host_name TEXT NOT NULL,
+    host_mac TEXT NOT NULL,
+    scheduled_time DATETIME NOT NULL,
+    frequency TEXT NOT NULL CHECK(frequency IN ('once', 'daily', 'weekly', 'weekdays', 'weekends')),
+    enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+    notify_on_wake INTEGER NOT NULL DEFAULT 1 CHECK(notify_on_wake IN (0, 1)),
+    timezone TEXT NOT NULL DEFAULT 'UTC',
+    last_triggered DATETIME,
+    next_trigger DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  )
+`;
+
+const POSTGRES_CREATE_TABLE = `
+  CREATE TABLE IF NOT EXISTS host_wake_schedules (
+    id VARCHAR(64) PRIMARY KEY,
+    host_fqn VARCHAR(512) NOT NULL,
+    host_name VARCHAR(255) NOT NULL,
+    host_mac VARCHAR(17) NOT NULL,
+    scheduled_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    frequency VARCHAR(16) NOT NULL CHECK(frequency IN ('once', 'daily', 'weekly', 'weekdays', 'weekends')),
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    notify_on_wake BOOLEAN NOT NULL DEFAULT true,
+    timezone VARCHAR(64) NOT NULL DEFAULT 'UTC',
+    last_triggered TIMESTAMP WITH TIME ZONE,
+    next_trigger TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+  )
+`;
+
+const CREATE_INDEXES = [
+  'CREATE INDEX IF NOT EXISTS idx_host_wake_schedules_host_fqn ON host_wake_schedules(host_fqn)',
+  'CREATE INDEX IF NOT EXISTS idx_host_wake_schedules_next_trigger ON host_wake_schedules(next_trigger)',
+  'CREATE INDEX IF NOT EXISTS idx_host_wake_schedules_enabled ON host_wake_schedules(enabled)',
+];
+
+function toIsoString(value: string | Date | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}
+
+function toBoolean(value: boolean | number): boolean {
+  if (typeof value === 'boolean') return value;
+  return value === 1;
+}
+
+function mapRow(row: HostScheduleRow): HostWakeSchedule {
+  return {
+    id: row.id,
+    hostFqn: row.host_fqn,
+    hostName: row.host_name,
+    hostMac: row.host_mac,
+    scheduledTime: toIsoString(row.scheduled_time) ?? new Date(row.scheduled_time).toISOString(),
+    frequency: row.frequency,
+    enabled: toBoolean(row.enabled),
+    notifyOnWake: toBoolean(row.notify_on_wake),
+    timezone: row.timezone,
+    createdAt: toIsoString(row.created_at) ?? new Date(row.created_at).toISOString(),
+    updatedAt: toIsoString(row.updated_at) ?? new Date(row.updated_at).toISOString(),
+    ...(toIsoString(row.last_triggered) ? { lastTriggered: toIsoString(row.last_triggered) } : {}),
+    ...(toIsoString(row.next_trigger) ? { nextTrigger: toIsoString(row.next_trigger) } : {}),
+  };
+}
+
+function normalizeFrequency(raw: string): ScheduleFrequency {
+  return raw as ScheduleFrequency;
+}
+
+function computeNextTrigger(
+  scheduledTimeIso: string,
+  frequency: ScheduleFrequency,
+  enabled: boolean,
+): string | null {
+  if (!enabled) return null;
+
+  const scheduledTime = new Date(scheduledTimeIso);
+  if (Number.isNaN(scheduledTime.getTime())) {
+    return null;
+  }
+
+  const now = new Date();
+
+  if (frequency === 'once') {
+    return scheduledTime > now ? scheduledTime.toISOString() : null;
+  }
+
+  const buildCandidate = (base: Date): Date => {
+    const candidate = new Date(base);
+    candidate.setUTCHours(
+      scheduledTime.getUTCHours(),
+      scheduledTime.getUTCMinutes(),
+      scheduledTime.getUTCSeconds(),
+      0,
+    );
+    return candidate;
+  };
+
+  const today = new Date(now);
+  today.setUTCHours(0, 0, 0, 0);
+
+  if (frequency === 'daily') {
+    const candidate = buildCandidate(today);
+    if (candidate <= now) {
+      candidate.setUTCDate(candidate.getUTCDate() + 1);
+    }
+    return candidate.toISOString();
+  }
+
+  if (frequency === 'weekly') {
+    const targetDay = scheduledTime.getUTCDay();
+    const candidate = buildCandidate(today);
+    const currentDay = candidate.getUTCDay();
+    let deltaDays = (targetDay - currentDay + 7) % 7;
+    if (deltaDays === 0 && candidate <= now) {
+      deltaDays = 7;
+    }
+    candidate.setUTCDate(candidate.getUTCDate() + deltaDays);
+    return candidate.toISOString();
+  }
+
+  const weekdaySet = frequency === 'weekdays'
+    ? new Set([1, 2, 3, 4, 5])
+    : new Set([0, 6]);
+
+  const candidate = buildCandidate(today);
+  for (let i = 0; i < 8; i += 1) {
+    const day = candidate.getUTCDay();
+    const isTargetDay = weekdaySet.has(day);
+    if (isTargetDay && candidate > now) {
+      return candidate.toISOString();
+    }
+    candidate.setUTCDate(candidate.getUTCDate() + 1);
+  }
+
+  return null;
+}
+
+export class HostScheduleModel {
+  private static tableReady: Promise<void> | null = null;
+
+  static async ensureTable(): Promise<void> {
+    if (!this.tableReady) {
+      this.tableReady = this.createTable().catch((error) => {
+        this.tableReady = null;
+        throw error;
+      });
+    }
+
+    await this.tableReady;
+  }
+
+  private static async createTable(): Promise<void> {
+    const createTableStatement = isSqlite ? SQLITE_CREATE_TABLE : POSTGRES_CREATE_TABLE;
+    await db.query(createTableStatement);
+
+    for (const statement of CREATE_INDEXES) {
+      await db.query(statement);
+    }
+  }
+
+  static async listByHostFqn(hostFqn: string): Promise<HostWakeSchedule[]> {
+    await this.ensureTable();
+    const result = await db.query<HostScheduleRow>(
+      `SELECT *
+       FROM host_wake_schedules
+       WHERE host_fqn = $1
+       ORDER BY created_at DESC`,
+      [hostFqn],
+    );
+
+    return result.rows.map(mapRow);
+  }
+
+  static async findById(id: string): Promise<HostWakeSchedule | null> {
+    await this.ensureTable();
+    const result = await db.query<HostScheduleRow>(
+      'SELECT * FROM host_wake_schedules WHERE id = $1',
+      [id],
+    );
+
+    if (!result.rows.length) {
+      return null;
+    }
+
+    return mapRow(result.rows[0]);
+  }
+
+  static async create(input: CreateHostScheduleInput): Promise<HostWakeSchedule> {
+    await this.ensureTable();
+
+    const id = randomUUID();
+    const frequency = normalizeFrequency(input.frequency);
+    const nextTrigger = computeNextTrigger(input.scheduledTime, frequency, input.enabled);
+
+    if (isSqlite) {
+      await db.query(
+        `INSERT INTO host_wake_schedules
+          (id, host_fqn, host_name, host_mac, scheduled_time, frequency, enabled, notify_on_wake, timezone, next_trigger)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        [
+          id,
+          input.hostFqn,
+          input.hostName,
+          input.hostMac,
+          input.scheduledTime,
+          frequency,
+          input.enabled ? 1 : 0,
+          input.notifyOnWake ? 1 : 0,
+          input.timezone,
+          nextTrigger,
+        ],
+      );
+    } else {
+      await db.query(
+        `INSERT INTO host_wake_schedules
+          (id, host_fqn, host_name, host_mac, scheduled_time, frequency, enabled, notify_on_wake, timezone, next_trigger)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        [
+          id,
+          input.hostFqn,
+          input.hostName,
+          input.hostMac,
+          input.scheduledTime,
+          frequency,
+          input.enabled,
+          input.notifyOnWake,
+          input.timezone,
+          nextTrigger,
+        ],
+      );
+    }
+
+    const created = await this.findById(id);
+    if (!created) {
+      throw new Error('Failed to create schedule');
+    }
+
+    return created;
+  }
+
+  static async update(id: string, updates: UpdateHostScheduleInput): Promise<HostWakeSchedule | null> {
+    await this.ensureTable();
+
+    const existing = await this.findById(id);
+    if (!existing) {
+      return null;
+    }
+
+    const nextValues = {
+      scheduledTime: updates.scheduledTime ?? existing.scheduledTime,
+      frequency: updates.frequency ?? existing.frequency,
+      enabled: updates.enabled ?? existing.enabled,
+      notifyOnWake: updates.notifyOnWake ?? existing.notifyOnWake,
+      timezone: updates.timezone ?? existing.timezone,
+    };
+
+    const nextTrigger = computeNextTrigger(
+      nextValues.scheduledTime,
+      nextValues.frequency,
+      nextValues.enabled,
+    );
+
+    if (isSqlite) {
+      await db.query(
+        `UPDATE host_wake_schedules
+         SET scheduled_time = $2,
+             frequency = $3,
+             enabled = $4,
+             notify_on_wake = $5,
+             timezone = $6,
+             next_trigger = $7,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE id = $1`,
+        [
+          id,
+          nextValues.scheduledTime,
+          nextValues.frequency,
+          nextValues.enabled ? 1 : 0,
+          nextValues.notifyOnWake ? 1 : 0,
+          nextValues.timezone,
+          nextTrigger,
+        ],
+      );
+    } else {
+      await db.query(
+        `UPDATE host_wake_schedules
+         SET scheduled_time = $2,
+             frequency = $3,
+             enabled = $4,
+             notify_on_wake = $5,
+             timezone = $6,
+             next_trigger = $7,
+             updated_at = NOW()
+         WHERE id = $1`,
+        [
+          id,
+          nextValues.scheduledTime,
+          nextValues.frequency,
+          nextValues.enabled,
+          nextValues.notifyOnWake,
+          nextValues.timezone,
+          nextTrigger,
+        ],
+      );
+    }
+
+    return this.findById(id);
+  }
+
+  static async delete(id: string): Promise<boolean> {
+    await this.ensureTable();
+    const result = await db.query('DELETE FROM host_wake_schedules WHERE id = $1', [id]);
+    return result.rowCount > 0;
+  }
+}
+
+export default HostScheduleModel;

--- a/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
@@ -344,6 +344,186 @@ describe('Host Routes Authentication and Authorization', () => {
     });
   });
 
+  describe('GET /api/hosts/:fqn/schedules', () => {
+    it('returns 401 when no authorization header is provided', async () => {
+      const response = await request(app).get('/api/hosts/node1.example.com/schedules');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for unsupported role', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .get('/api/hosts/node1.example.com/schedules')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+
+    it('allows access with valid operator token', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'operator',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .get('/api/hosts/node1.example.com/schedules')
+        .set('Authorization', `Bearer ${token}`);
+
+      // Will be 404 since host doesn't exist in mock, but auth passed
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/hosts/:fqn/schedules', () => {
+    it('returns 401 when no authorization header is provided', async () => {
+      const response = await request(app)
+        .post('/api/hosts/node1.example.com/schedules')
+        .send({
+          scheduledTime: '2026-02-16T09:00:00.000Z',
+          frequency: 'daily',
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for unsupported role', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .post('/api/hosts/node1.example.com/schedules')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          scheduledTime: '2026-02-16T09:00:00.000Z',
+          frequency: 'daily',
+        });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+
+    it('allows access with valid operator token', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'operator',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .post('/api/hosts/node1.example.com/schedules')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          scheduledTime: '2026-02-16T09:00:00.000Z',
+          frequency: 'daily',
+        });
+
+      // Will be 404 since host doesn't exist in mock, but auth passed
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('PUT /api/hosts/schedules/:id', () => {
+    it('returns 401 when no authorization header is provided', async () => {
+      const response = await request(app)
+        .put('/api/hosts/schedules/schedule-1')
+        .send({ enabled: false });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for unsupported role', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .put('/api/hosts/schedules/schedule-1')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ enabled: false });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+  });
+
+  describe('DELETE /api/hosts/schedules/:id', () => {
+    it('returns 401 when no authorization header is provided', async () => {
+      const response = await request(app).delete('/api/hosts/schedules/schedule-1');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for unsupported role', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .delete('/api/hosts/schedules/schedule-1')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+  });
+
   describe('POST /api/hosts/wakeup/:fqn', () => {
     it('returns 401 when no authorization header is provided', async () => {
       const response = await request(app).post('/api/hosts/wakeup/node1.example.com');

--- a/apps/cnc/src/routes/__tests__/metaRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/metaRoutes.test.ts
@@ -106,7 +106,10 @@ describe('Capabilities Route', () => {
         capabilities: {
           scan: { supported: true },
           notesTags: { supported: true, persistence: 'backend' },
-          schedules: { supported: false },
+          schedules: {
+            supported: true,
+            persistence: 'backend',
+          },
           commandStatusStreaming: { supported: false, transport: null },
         },
       });

--- a/apps/cnc/src/routes/index.ts
+++ b/apps/cnc/src/routes/index.ts
@@ -6,6 +6,7 @@ import { Router } from 'express';
 import { NodesController } from '../controllers/nodes';
 import { AdminController } from '../controllers/admin';
 import { HostsController } from '../controllers/hosts';
+import { SchedulesController } from '../controllers/schedules';
 import { AuthController } from '../controllers/auth';
 import { MetaController } from '../controllers/meta';
 import { NodeManager } from '../services/nodeManager';
@@ -30,6 +31,7 @@ export function createRoutes(
   const nodesController = new NodesController(nodeManager);
   const adminController = new AdminController(hostAggregator, nodeManager, commandRouter);
   const hostsController = new HostsController(hostAggregator, commandRouter);
+  const schedulesController = new SchedulesController(hostAggregator);
   const authController = new AuthController();
   const metaController = new MetaController();
 
@@ -57,6 +59,11 @@ export function createRoutes(
   // IMPORTANT: ports/scan-ports must be registered before the :fqn catch-all
   router.get('/hosts/ports/:fqn', (req, res) => hostsController.getHostPorts(req, res));
   router.get('/hosts/scan-ports/:fqn', (req, res) => hostsController.scanHostPorts(req, res));
+  // IMPORTANT: schedule routes must be registered before the :fqn catch-all
+  router.get('/hosts/:fqn/schedules', (req, res) => schedulesController.listHostSchedules(req, res));
+  router.post('/hosts/:fqn/schedules', (req, res) => schedulesController.createHostSchedule(req, res));
+  router.put('/hosts/schedules/:id', (req, res) => schedulesController.updateSchedule(req, res));
+  router.delete('/hosts/schedules/:id', (req, res) => schedulesController.deleteSchedule(req, res));
   router.get('/hosts', (req, res) => hostsController.getHosts(req, res));
   router.get('/hosts/:fqn', (req, res) => hostsController.getHostByFQN(req, res));
   router.post('/hosts/wakeup/:fqn', (req, res) => hostsController.wakeupHost(req, res));

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -6,9 +6,11 @@ import type {
   CncCapabilitiesResponse as ProtocolCncCapabilitiesResponse,
   CncCapabilityDescriptor as ProtocolCncCapabilityDescriptor,
   CommandState,
+  HostWakeSchedule as ProtocolHostWakeSchedule,
   Host,
   HostPortScanResponse as ProtocolHostPortScanResponse,
   NodeMetadata as ProtocolNodeMetadata,
+  ScheduleFrequency as ProtocolScheduleFrequency,
 } from '@kaonis/woly-protocol';
 
 // Node Types
@@ -76,6 +78,8 @@ export interface HostsResponse {
 export type CapabilityDescriptor = ProtocolCncCapabilityDescriptor;
 export type CncCapabilitiesResponse = ProtocolCncCapabilitiesResponse;
 export type HostPortScanResponse = ProtocolHostPortScanResponse;
+export type ScheduleFrequency = ProtocolScheduleFrequency;
+export type HostWakeSchedule = ProtocolHostWakeSchedule;
 
 export interface WakeupResponse {
   success: boolean;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -103,6 +103,49 @@ export interface HostPortScanResponse {
   correlationId?: string;
 }
 
+export type ScheduleFrequency = 'once' | 'daily' | 'weekly' | 'weekdays' | 'weekends';
+
+export interface HostWakeSchedule {
+  id: string;
+  hostFqn: string;
+  hostName: string;
+  hostMac: string;
+  scheduledTime: string;
+  frequency: ScheduleFrequency;
+  enabled: boolean;
+  notifyOnWake: boolean;
+  timezone: string;
+  createdAt: string;
+  updatedAt: string;
+  lastTriggered?: string;
+  nextTrigger?: string;
+}
+
+export interface HostSchedulesResponse {
+  schedules: HostWakeSchedule[];
+}
+
+export interface CreateHostWakeScheduleRequest {
+  scheduledTime: string;
+  frequency: ScheduleFrequency;
+  enabled?: boolean;
+  notifyOnWake?: boolean;
+  timezone?: string;
+}
+
+export interface UpdateHostWakeScheduleRequest {
+  scheduledTime?: string;
+  frequency?: ScheduleFrequency;
+  enabled?: boolean;
+  notifyOnWake?: boolean;
+  timezone?: string;
+}
+
+export interface DeleteHostWakeScheduleResponse {
+  success: boolean;
+  id: string;
+}
+
 // --- WebSocket message types ---
 
 export type NodeMessage =
@@ -227,6 +270,58 @@ export const hostPortScanResponseSchema: z.ZodType<HostPortScanResponse> = z.obj
   message: z.string().min(1).optional(),
   correlationId: z.string().min(1).optional(),
 });
+
+export const scheduleFrequencySchema = z.enum(['once', 'daily', 'weekly', 'weekdays', 'weekends']);
+
+export const hostWakeScheduleSchema: z.ZodType<HostWakeSchedule> = z.object({
+  id: z.string().min(1),
+  hostFqn: z.string().min(1),
+  hostName: z.string().min(1),
+  hostMac: z.string().min(1),
+  scheduledTime: z.string().datetime(),
+  frequency: scheduleFrequencySchema,
+  enabled: z.boolean(),
+  notifyOnWake: z.boolean(),
+  timezone: z.string().min(1).max(64),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  lastTriggered: z.string().datetime().optional(),
+  nextTrigger: z.string().datetime().optional(),
+});
+
+export const hostSchedulesResponseSchema: z.ZodType<HostSchedulesResponse> = z.object({
+  schedules: z.array(hostWakeScheduleSchema),
+});
+
+export const createHostWakeScheduleRequestSchema: z.ZodType<CreateHostWakeScheduleRequest> = z
+  .object({
+    scheduledTime: z.string().datetime(),
+    frequency: scheduleFrequencySchema,
+    enabled: z.boolean().optional(),
+    notifyOnWake: z.boolean().optional(),
+    timezone: z.string().min(1).max(64).optional(),
+  })
+  .strict();
+
+export const updateHostWakeScheduleRequestSchema: z.ZodType<UpdateHostWakeScheduleRequest> = z
+  .object({
+    scheduledTime: z.string().datetime().optional(),
+    frequency: scheduleFrequencySchema.optional(),
+    enabled: z.boolean().optional(),
+    notifyOnWake: z.boolean().optional(),
+    timezone: z.string().min(1).max(64).optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+export const deleteHostWakeScheduleResponseSchema: z.ZodType<DeleteHostWakeScheduleResponse> = z
+  .object({
+    success: z.literal(true),
+    id: z.string().min(1),
+  })
+  .strict();
 
 const nodeMetadataSchema = z.object({
   version: z.string().min(1),


### PR DESCRIPTION
## Summary
- add CNC wake schedule CRUD endpoints for hosts (`GET/POST /api/hosts/:fqn/schedules`, `PUT/DELETE /api/hosts/schedules/:id`)
- persist schedules in backend storage (SQLite/Postgres) with computed `nextTrigger` metadata and host scoping
- advertise schedule support in `/api/capabilities` and document routes in CNC README
- add protocol contract exports + zod schemas for schedule request/response payloads and consume those schemas in CNC controller validation
- extend route/auth/mobile compatibility tests to cover schedule contracts and auth-failure envelopes

## Verification
- `npm run test -w packages/protocol`
- `npm run typecheck -w packages/protocol`
- `npm run test -w apps/cnc -- src/routes/__tests__/hostRoutes.test.ts src/routes/__tests__/mobileCompatibility.smoke.test.ts src/routes/__tests__/metaRoutes.test.ts`
- `npm run typecheck -w apps/cnc`
- `npm run lint -w apps/cnc`
