### PR TITLE
ci(cnc): add path-scoped mobile contract gate (#256)

### DIFF
--- a/.github/workflows/cnc-mobile-contract-gate.yml
+++ b/.github/workflows/cnc-mobile-contract-gate.yml
@@ -1,0 +1,50 @@
+name: CNC Mobile Contract Gate
+
+on:
+  pull_request:
+    paths:
+      - 'apps/cnc/src/routes/**'
+      - 'apps/cnc/src/controllers/**'
+      - 'apps/cnc/src/types.ts'
+      - 'packages/protocol/src/**'
+      - 'packages/protocol/package.json'
+      - 'apps/cnc/package.json'
+      - '.github/workflows/cnc-mobile-contract-gate.yml'
+
+concurrency:
+  group: cnc-mobile-contract-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-gate:
+    name: Route/Protocol Contract Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build protocol package
+        run: npm run build -w packages/protocol
+
+      - name: Run protocol schema tests
+        run: npm run test -w packages/protocol -- schemas.test
+
+      - name: Run CNC mobile compatibility contract tests
+        run: |
+          npm run test -w apps/cnc -- src/routes/__tests__/hostRoutes.test.ts src/routes/__tests__/mobileCompatibility.smoke.test.ts src/routes/__tests__/metaRoutes.test.ts
+
+      - name: Run CNC typecheck
+        run: npm run typecheck -w apps/cnc


### PR DESCRIPTION
## Summary
- add a minimal PR workflow `CNC Mobile Contract Gate` that only runs when CNC route/controller/protocol paths change
- keep GitHub Actions budget low by scoping trigger paths and running a narrow set of contract checks only
- run the exact mobile compatibility + protocol schema checks needed to catch CNC API contract drift

## Workflow behavior
- Trigger: `pull_request` with path filters for:
  - `apps/cnc/src/routes/**`
  - `apps/cnc/src/controllers/**`
  - `apps/cnc/src/types.ts`
  - `packages/protocol/src/**`
  - related package/workflow files
- Checks:
  - `npm run build -w packages/protocol`
  - `npm run test -w packages/protocol -- schemas.test`
  - `npm run test -w apps/cnc -- src/routes/__tests__/hostRoutes.test.ts src/routes/__tests__/mobileCompatibility.smoke.test.ts src/routes/__tests__/metaRoutes.test.ts`
  - `npm run typecheck -w apps/cnc`

## Local verification
- `npm run test -w packages/protocol -- schemas.test`
- `npm run test -w apps/cnc -- src/routes/__tests__/hostRoutes.test.ts src/routes/__tests__/mobileCompatibility.smoke.test.ts src/routes/__tests__/metaRoutes.test.ts`
- `npm run typecheck -w apps/cnc`
