### PR TITLE
feat(cnc): execute persisted wake schedules in backend worker (#265)

### DIFF
--- a/apps/cnc/.env.example
+++ b/apps/cnc/.env.example
@@ -51,5 +51,11 @@ COMMAND_MAX_RETRIES=3
 # Actual delay = COMMAND_RETRY_BASE_DELAY_MS * 2^(retry_count) with ±25% jitter
 COMMAND_RETRY_BASE_DELAY_MS=1000
 
+# Schedule Worker (CNC mode)
+# Polls persisted host wake schedules and dispatches due wake commands
+SCHEDULE_WORKER_ENABLED=true
+SCHEDULE_POLL_INTERVAL_MS=60000
+SCHEDULE_BATCH_SIZE=25
+
 # Logging
 LOG_LEVEL=info

--- a/apps/cnc/README.md
+++ b/apps/cnc/README.md
@@ -236,6 +236,13 @@ Environment variables (`.env`):
 | `WS_ALLOW_QUERY_TOKEN_AUTH` | Allow legacy query token auth (`?token=`) | `false` in production, else `true` |
 | `NODE_HEARTBEAT_INTERVAL` | Expected heartbeat interval (ms) | `30000` |
 | `NODE_TIMEOUT` | Node offline threshold (ms) | `90000` |
+| `COMMAND_TIMEOUT` | Command acknowledgement timeout (ms) | `30000` |
+| `COMMAND_RETENTION_DAYS` | Retention window for historical command rows | `30` |
+| `COMMAND_MAX_RETRIES` | Maximum command retries before terminal failure | `3` |
+| `COMMAND_RETRY_BASE_DELAY_MS` | Base delay for retry backoff (ms) | `1000` |
+| `SCHEDULE_WORKER_ENABLED` | Enable backend wake schedule execution worker | `true` |
+| `SCHEDULE_POLL_INTERVAL_MS` | Wake schedule polling interval (ms) | `60000` |
+| `SCHEDULE_BATCH_SIZE` | Max due schedules processed per worker tick | `25` |
 | `LOG_LEVEL` | Logging level | `info` |
 
 ## WebSocket Protocol

--- a/apps/cnc/src/config/__tests__/index.test.ts
+++ b/apps/cnc/src/config/__tests__/index.test.ts
@@ -47,6 +47,9 @@ describe('config parsing and validation', () => {
       CORS_ORIGINS: 'https://a.example, https://b.example ,',
       WS_REQUIRE_TLS: 'YES',
       WS_ALLOW_QUERY_TOKEN_AUTH: 'off',
+      SCHEDULE_WORKER_ENABLED: 'false',
+      SCHEDULE_POLL_INTERVAL_MS: '45000',
+      SCHEDULE_BATCH_SIZE: '10',
     });
 
     expect(config.operatorAuthTokens).toEqual(['node-token-1', 'node-token-2']);
@@ -54,6 +57,9 @@ describe('config parsing and validation', () => {
     expect(config.corsOrigins).toEqual(['https://a.example', 'https://b.example']);
     expect(config.wsRequireTls).toBe(true);
     expect(config.wsAllowQueryTokenAuth).toBe(false);
+    expect(config.scheduleWorkerEnabled).toBe(false);
+    expect(config.schedulePollIntervalMs).toBe(45000);
+    expect(config.scheduleBatchSize).toBe(10);
   });
 
   it('throws when NODE_TIMEOUT is less than 2x NODE_HEARTBEAT_INTERVAL', async () => {
@@ -96,5 +102,13 @@ describe('config parsing and validation', () => {
         PORT: 'abc',
       })
     ).rejects.toThrow('Invalid numeric environment variable: PORT');
+  });
+
+  it('throws when schedule poll interval is not greater than zero', async () => {
+    await expect(
+      loadConfig({
+        SCHEDULE_POLL_INTERVAL_MS: '0',
+      }),
+    ).rejects.toThrow('SCHEDULE_POLL_INTERVAL_MS must be a finite number > 0');
   });
 });

--- a/apps/cnc/src/config/index.ts
+++ b/apps/cnc/src/config/index.ts
@@ -97,6 +97,9 @@ export const config: ServerConfig = {
   commandRetentionDays: getEnvNumber('COMMAND_RETENTION_DAYS', 30),
   commandMaxRetries: getEnvNumber('COMMAND_MAX_RETRIES', 3),
   commandRetryBaseDelayMs: getEnvNumber('COMMAND_RETRY_BASE_DELAY_MS', 1000),
+  scheduleWorkerEnabled: getEnvBoolean('SCHEDULE_WORKER_ENABLED', true),
+  schedulePollIntervalMs: getEnvNumber('SCHEDULE_POLL_INTERVAL_MS', 60000),
+  scheduleBatchSize: getEnvNumber('SCHEDULE_BATCH_SIZE', 25),
   logLevel: getEnvVar('LOG_LEVEL', 'info'),
 };
 
@@ -131,6 +134,14 @@ if (!Number.isFinite(config.wsMaxConnectionsPerIp) || config.wsMaxConnectionsPer
 
 if (!Number.isFinite(config.jwtTtlSeconds) || config.jwtTtlSeconds <= 0) {
   throw new Error('JWT_TTL_SECONDS must be a finite number > 0');
+}
+
+if (!Number.isFinite(config.schedulePollIntervalMs) || config.schedulePollIntervalMs <= 0) {
+  throw new Error('SCHEDULE_POLL_INTERVAL_MS must be a finite number > 0');
+}
+
+if (!Number.isFinite(config.scheduleBatchSize) || config.scheduleBatchSize <= 0) {
+  throw new Error('SCHEDULE_BATCH_SIZE must be a finite number > 0');
 }
 
 export default config;

--- a/apps/cnc/src/controllers/meta.ts
+++ b/apps/cnc/src/controllers/meta.ts
@@ -28,7 +28,7 @@ const cncCapabilities: CncCapabilitiesResponse = {
       supported: true,
       routes: ['/api/hosts/:fqn/schedules', '/api/hosts/schedules/:id'],
       persistence: 'backend',
-      note: 'Host wake schedules are persisted in CNC backend.',
+      note: 'Host wake schedules are persisted and executed in CNC backend.',
     },
     commandStatusStreaming: {
       supported: false,

--- a/apps/cnc/src/database/__tests__/sqlite-connection.test.ts
+++ b/apps/cnc/src/database/__tests__/sqlite-connection.test.ts
@@ -288,6 +288,22 @@ describe('SqliteDatabase', () => {
       expect(result.rows).toHaveLength(1);
       expect(result.rows[0].id).toBe('node-1');
     });
+
+    it('should honor placeholder indexes when order is not sequential', async () => {
+      await db.query(
+        'INSERT INTO test_nodes (id, name, status) VALUES ($1, $2, $3)',
+        ['node-out-of-order', 'Original', 'offline'],
+      );
+
+      const result = await db.query(
+        'UPDATE test_nodes SET name = $2, status = $3 WHERE id = $1 RETURNING *',
+        ['node-out-of-order', 'Updated', 'online'],
+      );
+
+      expect(result.rows).toHaveLength(1);
+      expect((result.rows[0] as { name: string }).name).toBe('Updated');
+      expect((result.rows[0] as { status: string }).status).toBe('online');
+    });
   });
 
   describe('SELECT queries', () => {

--- a/apps/cnc/src/models/__tests__/HostSchedule.test.ts
+++ b/apps/cnc/src/models/__tests__/HostSchedule.test.ts
@@ -1,0 +1,115 @@
+import db from '../../database/connection';
+import HostScheduleModel from '../HostSchedule';
+
+describe('HostScheduleModel', () => {
+  beforeAll(async () => {
+    await db.connect();
+    await HostScheduleModel.ensureTable();
+  });
+
+  beforeEach(async () => {
+    await db.query('DELETE FROM host_wake_schedules');
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it('lists only enabled due schedules ordered by next trigger', async () => {
+    const nowIso = '2026-02-15T10:00:00.000Z';
+    const dueIso = '2026-02-15T09:00:00.000Z';
+    const futureIso = '2026-02-15T11:00:00.000Z';
+
+    const dueSchedule = await HostScheduleModel.create({
+      hostFqn: 'office@home',
+      hostName: 'office',
+      hostMac: '00:11:22:33:44:55',
+      scheduledTime: '2026-02-16T09:00:00.000Z',
+      frequency: 'daily',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    const futureSchedule = await HostScheduleModel.create({
+      hostFqn: 'lab@home',
+      hostName: 'lab',
+      hostMac: 'AA:BB:CC:DD:EE:FF',
+      scheduledTime: '2026-02-16T10:00:00.000Z',
+      frequency: 'daily',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    const disabledSchedule = await HostScheduleModel.create({
+      hostFqn: 'disabled@home',
+      hostName: 'disabled',
+      hostMac: '11:22:33:44:55:66',
+      scheduledTime: '2026-02-16T10:00:00.000Z',
+      frequency: 'daily',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    await db.query('UPDATE host_wake_schedules SET next_trigger = $1 WHERE id = $2', [
+      dueIso,
+      dueSchedule.id,
+    ]);
+    await db.query('UPDATE host_wake_schedules SET next_trigger = $1 WHERE id = $2', [
+      futureIso,
+      futureSchedule.id,
+    ]);
+    await db.query(
+      'UPDATE host_wake_schedules SET enabled = $1, next_trigger = $2 WHERE id = $3',
+      [db.isSqlite ? 0 : false, dueIso, disabledSchedule.id],
+    );
+
+    const due = await HostScheduleModel.listDue(10, nowIso);
+    expect(due).toHaveLength(1);
+    expect(due[0].id).toBe(dueSchedule.id);
+  });
+
+  it('disables one-time schedules after recording execution attempt', async () => {
+    const schedule = await HostScheduleModel.create({
+      hostFqn: 'one-shot@home',
+      hostName: 'one-shot',
+      hostMac: '00:AA:BB:CC:DD:EE',
+      scheduledTime: '2026-02-15T10:00:00.000Z',
+      frequency: 'once',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    const executedAt = '2026-02-15T10:00:00.000Z';
+    const updated = await HostScheduleModel.recordExecutionAttempt(schedule.id, executedAt);
+
+    expect(updated).not.toBeNull();
+    expect(updated?.enabled).toBe(false);
+    expect(updated?.lastTriggered).toBe(executedAt);
+    expect(updated?.nextTrigger).toBeUndefined();
+  });
+
+  it('advances recurring schedules to the next trigger after execution attempt', async () => {
+    const schedule = await HostScheduleModel.create({
+      hostFqn: 'daily@home',
+      hostName: 'daily',
+      hostMac: 'FF:EE:DD:CC:BB:AA',
+      scheduledTime: '2026-02-15T09:00:00.000Z',
+      frequency: 'daily',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    const executedAt = '2026-02-15T10:00:00.000Z';
+    const updated = await HostScheduleModel.recordExecutionAttempt(schedule.id, executedAt);
+
+    expect(updated).not.toBeNull();
+    expect(updated?.enabled).toBe(true);
+    expect(updated?.lastTriggered).toBe(executedAt);
+    expect(updated?.nextTrigger).toBe('2026-02-16T09:00:00.000Z');
+  });
+});

--- a/apps/cnc/src/server.ts
+++ b/apps/cnc/src/server.ts
@@ -17,6 +17,7 @@ import { createRoutes } from './routes';
 import { createWebSocketServer } from './websocket/server';
 import { errorHandler } from './middleware/errorHandler';
 import { reconcileCommandsOnStartup, startCommandPruning, stopCommandPruning } from './services/commandReconciler';
+import { startWakeScheduleWorker, stopWakeScheduleWorker } from './services/wakeScheduleWorker';
 import { specs } from './swagger';
 import { runtimeMetrics } from './services/runtimeMetrics';
 import { CNC_VERSION } from './utils/cncVersion';
@@ -189,6 +190,14 @@ class Server {
       // Start periodic command pruning
       startCommandPruning(config.commandRetentionDays);
 
+      // Start wake schedule execution worker
+      startWakeScheduleWorker({
+        commandRouter: this.commandRouter,
+        enabled: config.scheduleWorkerEnabled,
+        pollIntervalMs: config.schedulePollIntervalMs,
+        batchSize: config.scheduleBatchSize,
+      });
+
       // Start HTTP server
       this.httpServer.listen(config.port, () => {
         logger.info(`Server listening on port ${config.port}`);
@@ -215,6 +224,9 @@ class Server {
 
       // Stop command pruning
       stopCommandPruning();
+
+      // Stop wake schedule worker
+      stopWakeScheduleWorker();
 
       // Shutdown node manager
       this.nodeManager.shutdown();

--- a/apps/cnc/src/services/__tests__/wakeScheduleWorker.test.ts
+++ b/apps/cnc/src/services/__tests__/wakeScheduleWorker.test.ts
@@ -1,0 +1,199 @@
+import { processDueWakeSchedules, startWakeScheduleWorker, stopWakeScheduleWorker } from '../wakeScheduleWorker';
+import HostScheduleModel from '../../models/HostSchedule';
+import logger from '../../utils/logger';
+import type { CommandRouter } from '../commandRouter';
+
+jest.mock('../../models/HostSchedule', () => ({
+  __esModule: true,
+  default: {
+    listDue: jest.fn(),
+    recordExecutionAttempt: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockedHostScheduleModel = HostScheduleModel as jest.Mocked<typeof HostScheduleModel>;
+const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+describe('wakeScheduleWorker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stopWakeScheduleWorker();
+  });
+
+  afterEach(() => {
+    stopWakeScheduleWorker();
+    jest.useRealTimers();
+  });
+
+  it('returns 0 when there are no due schedules', async () => {
+    const commandRouter = {
+      routeWakeCommand: jest.fn(),
+    } as unknown as CommandRouter;
+
+    mockedHostScheduleModel.listDue.mockResolvedValue([]);
+
+    const processed = await processDueWakeSchedules({ commandRouter });
+
+    expect(processed).toBe(0);
+    expect(commandRouter.routeWakeCommand).not.toHaveBeenCalled();
+    expect(mockedHostScheduleModel.recordExecutionAttempt).not.toHaveBeenCalled();
+  });
+
+  it('routes due schedules and records execution attempts', async () => {
+    const commandRouter = {
+      routeWakeCommand: jest.fn().mockResolvedValue({ success: true }),
+    } as unknown as CommandRouter;
+
+    mockedHostScheduleModel.listDue.mockResolvedValue([
+      {
+        id: 'schedule-1',
+        hostFqn: 'office@home',
+        hostName: 'office',
+        hostMac: '00:11:22:33:44:55',
+        scheduledTime: '2026-02-16T09:00:00.000Z',
+        frequency: 'daily',
+        enabled: true,
+        notifyOnWake: true,
+        timezone: 'UTC',
+        createdAt: '2026-02-15T00:00:00.000Z',
+        updatedAt: '2026-02-15T00:00:00.000Z',
+      },
+      {
+        id: 'schedule-2',
+        hostFqn: 'lab@home',
+        hostName: 'lab',
+        hostMac: 'AA:BB:CC:DD:EE:FF',
+        scheduledTime: '2026-02-16T10:00:00.000Z',
+        frequency: 'weekly',
+        enabled: true,
+        notifyOnWake: true,
+        timezone: 'UTC',
+        createdAt: '2026-02-15T00:00:00.000Z',
+        updatedAt: '2026-02-15T00:00:00.000Z',
+      },
+    ]);
+    mockedHostScheduleModel.recordExecutionAttempt.mockResolvedValue(null);
+
+    const processed = await processDueWakeSchedules({ commandRouter, batchSize: 50 });
+
+    expect(processed).toBe(2);
+    expect(mockedHostScheduleModel.listDue).toHaveBeenCalledWith(50);
+    expect(commandRouter.routeWakeCommand).toHaveBeenCalledTimes(2);
+    expect(mockedHostScheduleModel.recordExecutionAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedLogger.info).toHaveBeenCalledWith(
+      'Wake schedule executed',
+      expect.objectContaining({
+        scheduleId: 'schedule-1',
+        hostFqn: 'office@home',
+      }),
+    );
+  });
+
+  it('continues processing when wake command routing fails', async () => {
+    const commandRouter = {
+      routeWakeCommand: jest.fn().mockRejectedValue(new Error('node offline')),
+    } as unknown as CommandRouter;
+
+    mockedHostScheduleModel.listDue.mockResolvedValue([
+      {
+        id: 'schedule-1',
+        hostFqn: 'office@home',
+        hostName: 'office',
+        hostMac: '00:11:22:33:44:55',
+        scheduledTime: '2026-02-16T09:00:00.000Z',
+        frequency: 'daily',
+        enabled: true,
+        notifyOnWake: true,
+        timezone: 'UTC',
+        createdAt: '2026-02-15T00:00:00.000Z',
+        updatedAt: '2026-02-15T00:00:00.000Z',
+      },
+    ]);
+    mockedHostScheduleModel.recordExecutionAttempt.mockResolvedValue(null);
+
+    const processed = await processDueWakeSchedules({ commandRouter });
+
+    expect(processed).toBe(1);
+    expect(mockedHostScheduleModel.recordExecutionAttempt).toHaveBeenCalledWith(
+      'schedule-1',
+      expect.any(String),
+    );
+    expect(mockedLogger.warn).toHaveBeenCalledWith(
+      'Wake schedule execution failed',
+      expect.objectContaining({
+        scheduleId: 'schedule-1',
+      }),
+    );
+  });
+
+  it('does not schedule intervals when worker is disabled', () => {
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+    const commandRouter = {
+      routeWakeCommand: jest.fn(),
+    } as unknown as CommandRouter;
+
+    startWakeScheduleWorker({
+      commandRouter,
+      enabled: false,
+      pollIntervalMs: 60_000,
+      batchSize: 25,
+    });
+
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(mockedLogger.info).toHaveBeenCalledWith(
+      'Wake schedule worker disabled (SCHEDULE_WORKER_ENABLED=false)',
+    );
+
+    setIntervalSpy.mockRestore();
+  });
+
+  it('schedules polling and avoids overlapping ticks', async () => {
+    jest.useFakeTimers();
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    const commandRouter = {
+      routeWakeCommand: jest.fn(),
+    } as unknown as CommandRouter;
+
+    let resolveListDue: () => void = () => undefined;
+    mockedHostScheduleModel.listDue.mockImplementation(
+      () => new Promise((resolve) => {
+        resolveListDue = () => resolve([]);
+      }),
+    );
+
+    startWakeScheduleWorker({
+      commandRouter,
+      enabled: true,
+      pollIntervalMs: 1000,
+      batchSize: 10,
+    });
+
+    await Promise.resolve();
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(mockedHostScheduleModel.listDue).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(3000);
+    await Promise.resolve();
+    expect(mockedHostScheduleModel.listDue).toHaveBeenCalledTimes(1);
+
+    resolveListDue();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    stopWakeScheduleWorker();
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/apps/cnc/src/services/wakeScheduleWorker.ts
+++ b/apps/cnc/src/services/wakeScheduleWorker.ts
@@ -1,0 +1,113 @@
+import type { CommandRouter } from './commandRouter';
+import HostScheduleModel from '../models/HostSchedule';
+import logger from '../utils/logger';
+
+interface ProcessDueWakeSchedulesParams {
+  commandRouter: CommandRouter;
+  batchSize?: number;
+}
+
+interface StartWakeScheduleWorkerParams {
+  commandRouter: CommandRouter;
+  enabled: boolean;
+  pollIntervalMs: number;
+  batchSize: number;
+}
+
+let workerInterval: NodeJS.Timeout | null = null;
+let isTickRunning = false;
+
+export async function processDueWakeSchedules(
+  params: ProcessDueWakeSchedulesParams,
+): Promise<number> {
+  const dueSchedules = await HostScheduleModel.listDue(params.batchSize ?? 25);
+  if (dueSchedules.length === 0) {
+    return 0;
+  }
+
+  for (const schedule of dueSchedules) {
+    const attemptedAt = new Date().toISOString();
+    const correlationId = `schedule:${schedule.id}:${Date.now()}`;
+
+    try {
+      await params.commandRouter.routeWakeCommand(schedule.hostFqn, { correlationId });
+      logger.info('Wake schedule executed', {
+        scheduleId: schedule.id,
+        hostFqn: schedule.hostFqn,
+        correlationId,
+      });
+    } catch (error) {
+      logger.warn('Wake schedule execution failed', {
+        scheduleId: schedule.id,
+        hostFqn: schedule.hostFqn,
+        correlationId,
+        error,
+      });
+    }
+
+    try {
+      await HostScheduleModel.recordExecutionAttempt(schedule.id, attemptedAt);
+    } catch (error) {
+      logger.error('Failed to record wake schedule execution attempt', {
+        scheduleId: schedule.id,
+        hostFqn: schedule.hostFqn,
+        attemptedAt,
+        error,
+      });
+    }
+  }
+
+  return dueSchedules.length;
+}
+
+export function startWakeScheduleWorker(params: StartWakeScheduleWorkerParams): void {
+  if (workerInterval) {
+    clearInterval(workerInterval);
+    workerInterval = null;
+  }
+
+  if (!params.enabled) {
+    logger.info('Wake schedule worker disabled (SCHEDULE_WORKER_ENABLED=false)');
+    return;
+  }
+
+  const runTick = async () => {
+    if (isTickRunning) {
+      return;
+    }
+
+    isTickRunning = true;
+    try {
+      const count = await processDueWakeSchedules({
+        commandRouter: params.commandRouter,
+        batchSize: params.batchSize,
+      });
+
+      if (count > 0) {
+        logger.info('Processed due wake schedules', { count });
+      }
+    } catch (error) {
+      logger.error('Wake schedule worker tick failed', { error });
+    } finally {
+      isTickRunning = false;
+    }
+  };
+
+  void runTick();
+  workerInterval = setInterval(() => {
+    void runTick();
+  }, params.pollIntervalMs);
+
+  logger.info('Wake schedule worker started', {
+    pollIntervalMs: params.pollIntervalMs,
+    batchSize: params.batchSize,
+  });
+}
+
+export function stopWakeScheduleWorker(): void {
+  if (workerInterval) {
+    clearInterval(workerInterval);
+    workerInterval = null;
+    logger.info('Wake schedule worker stopped');
+  }
+}

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -132,5 +132,8 @@ export interface ServerConfig {
   commandRetentionDays: number;
   commandMaxRetries: number;
   commandRetryBaseDelayMs: number;
+  scheduleWorkerEnabled: boolean;
+  schedulePollIntervalMs: number;
+  scheduleBatchSize: number;
   logLevel: string;
 }


### PR DESCRIPTION
## Summary
- add a backend wake schedule worker that polls due persisted schedules and dispatches wake commands via `CommandRouter`
- advance schedule state after each execution attempt (`last_triggered`, `next_trigger`, and one-time schedule disable)
- wire worker lifecycle into server startup/shutdown with configurable poll interval and batch size
- fix SQLite adapter placeholder binding so numbered placeholders work correctly even when parameter indexes are out-of-order (`$2` before `$1`)
- add tests for schedule persistence progression, worker behavior, and SQLite placeholder mapping

## Config additions
- `SCHEDULE_WORKER_ENABLED` (default `true`)
- `SCHEDULE_POLL_INTERVAL_MS` (default `60000`)
- `SCHEDULE_BATCH_SIZE` (default `25`)

## Verification
- `npm run test -w apps/cnc -- src/database/__tests__/sqlite-connection.test.ts src/models/__tests__/HostSchedule.test.ts src/services/__tests__/wakeScheduleWorker.test.ts src/config/__tests__/index.test.ts`
- `npm run test -w apps/cnc -- src/routes/__tests__/hostRoutes.test.ts src/routes/__tests__/mobileCompatibility.smoke.test.ts src/routes/__tests__/metaRoutes.test.ts`
- `npm run typecheck -w apps/cnc`
- `npm run lint -w apps/cnc`
