### PR TITLE
docs(policy): add CNC frontend-backend sync guardrails (#269)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Linked Issues
+
+- Backend issue (`woly-server`): #
+- Frontend issue (`woly`): #
+- Protocol issue (if contract changed): #
+
+## CNC 3-Part Chain
+
+- [ ] Protocol contract stage is covered (or explicitly unchanged with rationale).
+- [ ] Backend endpoint/command stage is implemented.
+- [ ] Frontend integration stage is linked and tracked.
+
+## Contract Compatibility
+
+- [ ] `npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts`
+- [ ] `npm run typecheck -w apps/cnc`
+- [ ] `npm run test:consumer-typecheck -w packages/protocol` (if protocol/contracts touched)
+- [ ] App-side protocol export/typecheck link included (when relevant).
+
+## Capability Negotiation / Mode Behavior
+
+- [ ] CNC behavior is capability-driven (not probe-driven) for the touched feature.
+- [ ] Any standalone fallback change is sequenced after CNC parity validation.
+
+## CI Budget
+
+- [ ] No broad always-on workflow added.
+- [ ] Any new automatic gate is path-scoped and minimal.
+
+## Notes
+
+<!-- Add rollout/migration details and cross-repo links -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS
+
+## CNC Sync Guardrails
+
+For CNC mode features, contributors must follow the policy in `docs/CNC_SYNC_POLICY.md`.
+
+Required before merge:
+- 3-part delivery chain is explicit:
+  1. protocol contract
+  2. backend endpoint/command
+  3. frontend integration
+- Linked issues exist in both repos:
+  - `kaonis/woly-server`
+  - `kaonis/woly`
+- Contract gates are validated locally and in CI:
+  - mobile compatibility smoke checks
+  - protocol consumer typecheck fixture
+
+Do not de-scope standalone probe fallback until CNC parity work is complete and verified.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,18 @@ cp apps/cnc/.env.example apps/cnc/.env
 3. Run `npm run build && npm run typecheck && npm run test` to verify
 4. Push and open a PR against `master`
 
+## CNC Mode Sync Requirements
+
+For CNC feature work, follow `docs/CNC_SYNC_POLICY.md`.
+
+Before merge:
+- link issues in both repos (`kaonis/woly-server` and `kaonis/woly`)
+- keep the 3-part chain explicit:
+  1. protocol contract
+  2. backend endpoint/command
+  3. frontend integration
+- run contract gates (mobile compatibility + protocol consumer typecheck when protocol is touched)
+
 ## Working With Workspaces
 
 This is an npm workspaces monorepo with Turborepo for task orchestration.

--- a/docs/CNC_SYNC_POLICY.md
+++ b/docs/CNC_SYNC_POLICY.md
@@ -1,0 +1,57 @@
+# CNC Sync Policy
+
+## Purpose
+
+Keep CNC mode behavior in sync across:
+1. `@kaonis/woly-protocol` contracts
+2. `woly-server` backend endpoints/commands
+3. `woly` frontend integration
+
+This policy applies to CNC mode work only. Standalone probing de-scope happens only after CNC parity is complete.
+
+## Required Delivery Chain
+
+Every CNC feature ships as a 3-part chain:
+1. Protocol contract change (type/schema/version note) or explicit confirmation no contract change is needed.
+2. Backend endpoint/command implementation.
+3. Frontend integration using the same contract.
+
+Do not merge partial chain PRs that leave frontend/backend contract intent ambiguous.
+
+## Linked Issue Requirement
+
+Before merge, each CNC PR must link:
+- one `kaonis/woly-server` issue
+- one `kaonis/woly` issue
+- protocol issue when protocol surface changes
+
+If one side is already delivered, link the merged PR/issue explicitly in the active PR body.
+
+## Sequencing Rules
+
+- Capability negotiation endpoint must be the source of truth for app behavior in CNC mode.
+- Merge gates must include contract compatibility checks:
+  - backend mobile compatibility contract tests
+  - protocol consumer typecheck fixture
+  - app-side protocol export typecheck when app repo changes
+- Probe-based standalone fallback de-scope is last, after CNC parity is verified.
+
+## Merge Gates
+
+Minimum local validation for CNC backend PRs:
+- `npm run typecheck -w apps/cnc`
+- `npm run lint -w apps/cnc`
+- `npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts`
+- `npm run test:consumer-typecheck -w packages/protocol` (when protocol/contracts touched)
+
+Minimum GitHub Actions policy:
+- Keep broad CI manual-dispatch to control budget.
+- Keep only lightweight, path-scoped automatic gates for CNC contract drift.
+
+## Review Checklist
+
+Reviewers should block merge if:
+- linked issue(s) in both repos are missing
+- chain stage is missing (protocol/backend/frontend)
+- capabilities contract and route payloads drift from app expectations
+- contract gates were skipped


### PR DESCRIPTION
## Summary
- add `docs/CNC_SYNC_POLICY.md` with explicit CNC cross-repo delivery and sequencing rules
- add repo `AGENTS.md` guardrails pointing contributors to CNC sync policy requirements
- add `.github/pull_request_template.md` checklist enforcing:
  - linked issues in both repos
  - protocol -> backend -> frontend chain visibility
  - contract gate validation
  - CI budget constraints
- update `CONTRIBUTING.md` with CNC sync requirements section

## Linked Cross-Repo Issues
- Backend policy issue: #269
- Frontend policy issue: [kaonis/woly#326](https://github.com/kaonis/woly/issues/326)

## Notes
- Documentation/process change only; no runtime code path modifications.

Closes #269
