### PR TITLE
feat(docs): generate rolling-cycle checkpoint snippets

### DIFF
--- a/docs/CI_MANUAL_OPERATIONS.md
+++ b/docs/CI_MANUAL_OPERATIONS.md
@@ -61,6 +61,16 @@ npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --fail-on-unexpected
 npm run ci:audit:manual -- --since 2026-02-15T15:11:32Z --json
 ```
 
+Generate copy-ready markdown snippets for weekly checkpoint docs (dry-run only):
+
+```bash
+npm run ci:snippets:checkpoint -- \
+  --issue 251 \
+  --follow-up 252 \
+  --checkpoint 2026-02-15T17:07:43Z \
+  --roadmap-file docs/ROADMAP_V11.md
+```
+
 Run policy guard to verify workflow files still enforce manual-only mode:
 
 ```bash

--- a/docs/ROADMAP_V11.md
+++ b/docs/ROADMAP_V11.md
@@ -1,0 +1,80 @@
+# Woly-Server Roadmap V11
+
+Date: 2026-02-16
+Scope: Post-V10 operational cadence with manual-CI checkpoint automation.
+
+## 1. Status Audit
+
+### Repository and branch status
+- `master` synced at merge commit `fc1e022` (PR #270).
+- Active execution branch: `codex/issue-252-checkpoint-snippets`.
+
+### Open issue snapshot (`kaonis/woly-server`)
+- #4 `Dependency Dashboard`
+- #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
+- #251 `[CI] Schedule weekly manual-only operations review (rolling follow-up after #249)`
+- #252 `[DX][Docs] Generate rolling-cycle checkpoint markdown snippets`
+
+### CI snapshot
+- All GitHub Actions workflows remain in temporary manual-only mode (`workflow_dispatch` only).
+- Local guard commands remain active:
+  - `npm run ci:audit:manual`
+  - `npm run ci:policy:check`
+
+## 2. Iterative Phases
+
+### Phase 1: Rolling-cycle checkpoint snippet helper
+Issue: #252  
+Labels: `priority:low`, `technical-debt`, `developer-experience`
+
+Acceptance criteria:
+- One command outputs copy-ready markdown snippets for:
+  - `docs/CI_MANUAL_REVIEW_LOG.md`
+  - `docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md`
+  - roadmap progress bullets in active roadmap file
+- Dry-run preview only (no direct file writes).
+- Template-render tests are included.
+
+Status: `Completed` (2026-02-16)
+
+### Phase 2: Weekly manual-only operations review (rolling)
+Issue: #251  
+Labels: `priority:low`, `technical-debt`, `developer-experience`
+
+Acceptance criteria:
+- Run scoped audit since previous checkpoint:
+  - `npm run ci:audit:manual -- --since <iso> --fail-on-unexpected`
+- Run policy guard:
+  - `npm run ci:policy:check`
+- Append review entry and progress updates using the checkpoint snippet helper.
+
+Status: `Planned`
+
+### Phase 3: ESLint 10 compatibility checkpoint
+Issue: #150  
+Labels: `priority:low`, `technical-debt`, `testing`
+
+Acceptance criteria:
+- Re-run compatibility check:
+  - `npm run deps:check-eslint10`
+- If support is unblocked, open implementation issue and execute full local gates.
+- If still blocked, record current evidence and continue monitoring.
+
+Status: `Blocked` (last checkpoint 2026-02-15: latest `@typescript-eslint/*` peer range excludes ESLint 10)
+
+### Phase 4: Dependency dashboard checkpoint consistency
+Issue: #4  
+Labels: `technical-debt`
+
+Acceptance criteria:
+- Keep dependency dashboard comment trail aligned with phase outcomes.
+- Link relevant blocker/next-step issues (#150, #251, #252).
+
+Status: `Planned`
+
+## 3. Progress Log
+
+- 2026-02-16: Bootstrapped `ROADMAP_V11` after CNC sync-policy closeout in PR #270.
+- 2026-02-16: Started issue #252 on branch `codex/issue-252-checkpoint-snippets`.
+- 2026-02-16: Added `npm run ci:snippets:checkpoint` dry-run helper to generate weekly checkpoint markdown blocks for review log, dependency plan, and roadmap progress.
+- 2026-02-16: Added template-render tests for checkpoint snippet output (`npm run test:docs-snippets`).

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "deps:check-eslint10": "node scripts/eslint10-compat-watchdog.cjs",
     "ci:audit:manual": "node scripts/manual-ci-run-audit.cjs",
     "ci:policy:check": "node scripts/manual-ci-workflow-policy-check.cjs",
+    "ci:snippets:checkpoint": "node scripts/manual-cycle-checkpoint-snippets.cjs",
+    "test:docs-snippets": "node --test scripts/__tests__/manual-cycle-checkpoint-snippets.test.cjs",
     "protocol:build": "npm run build --workspace=@kaonis/woly-protocol",
     "protocol:publish": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol",
     "protocol:publish:next": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol --tag next",

--- a/scripts/__tests__/manual-cycle-checkpoint-snippets.test.cjs
+++ b/scripts/__tests__/manual-cycle-checkpoint-snippets.test.cjs
@@ -1,0 +1,93 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  DEFAULT_REVIEWER,
+  buildSnippets,
+  parseArgs,
+  renderOutput,
+} = require('../manual-cycle-checkpoint-snippets.cjs');
+
+test('parseArgs validates and normalizes required values', () => {
+  const parsed = parseArgs([
+    '--issue',
+    '251',
+    '--follow-up',
+    '252',
+    '--checkpoint',
+    '2026-02-16T20:00:00Z',
+    '--roadmap-file',
+    'docs/ROADMAP_V11.md',
+  ]);
+
+  assert.equal(parsed.issue, 251);
+  assert.equal(parsed.followUpIssue, 252);
+  assert.equal(parsed.checkpoint, '2026-02-16T20:00:00.000Z');
+  assert.equal(parsed.roadmapFile, 'docs/ROADMAP_V11.md');
+  assert.equal(parsed.reviewer, DEFAULT_REVIEWER);
+  assert.equal(parsed.date, '2026-02-16');
+});
+
+test('parseArgs rejects missing required flags', () => {
+  assert.throws(
+    () =>
+      parseArgs([
+        '--issue',
+        '251',
+        '--follow-up',
+        '252',
+        '--roadmap-file',
+        'docs/ROADMAP_V11.md',
+      ]),
+    /Missing required argument: --checkpoint/
+  );
+});
+
+test('buildSnippets renders copy-ready content with key values', () => {
+  const parsed = parseArgs([
+    '--issue',
+    '251',
+    '--follow-up',
+    '253',
+    '--checkpoint',
+    '2026-02-16T21:30:00Z',
+    '--roadmap-file',
+    'docs/ROADMAP_V11.md',
+    '--reviewer',
+    'Platform Rotation',
+    '--date',
+    '2026-02-17',
+  ]);
+  const snippets = buildSnippets(parsed);
+
+  assert.match(snippets.ciReviewLog, /Date: 2026-02-17/);
+  assert.match(snippets.ciReviewLog, /Reviewer: Platform Rotation/);
+  assert.match(snippets.ciReviewLog, /post-merge cycle \(#251 to #253\)/);
+  assert.match(
+    snippets.ciReviewLog,
+    /npm run ci:audit:manual -- --since 2026-02-16T21:30:00.000Z --fail-on-unexpected/
+  );
+  assert.match(snippets.dependencyPlan, /issue #251/);
+  assert.match(snippets.dependencyPlan, /follow-up issue #253/);
+  assert.match(snippets.roadmapProgress, /docs\/ROADMAP_V11\.md/);
+});
+
+test('renderOutput includes all three markdown sections', () => {
+  const parsed = parseArgs([
+    '--issue',
+    '251',
+    '--follow-up',
+    '253',
+    '--checkpoint',
+    '2026-02-16T21:30:00Z',
+    '--roadmap-file',
+    'docs/ROADMAP_V11.md',
+  ]);
+  const rendered = renderOutput(parsed, buildSnippets(parsed));
+
+  assert.match(rendered, /Rolling-Cycle Checkpoint Snippets \(Dry Run\)/);
+  assert.match(rendered, /## docs\/CI_MANUAL_REVIEW_LOG\.md/);
+  assert.match(rendered, /## docs\/DEPENDENCY_MAJOR_UPGRADE_PLAN\.md/);
+  assert.match(rendered, /## docs\/ROADMAP_V11\.md/);
+  assert.match(rendered, /```md/);
+});

--- a/scripts/manual-cycle-checkpoint-snippets.cjs
+++ b/scripts/manual-cycle-checkpoint-snippets.cjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+'use strict';
+
+const DEFAULT_REVIEWER = 'Codex autonomous loop';
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseIssueNumber(raw, flagName) {
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flagName} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseTimestamp(raw) {
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('--checkpoint must be a valid ISO-8601 timestamp');
+  }
+  return parsed.toISOString();
+}
+
+function parseArgs(argv) {
+  const options = {
+    issue: null,
+    followUpIssue: null,
+    checkpoint: null,
+    roadmapFile: null,
+    reviewer: DEFAULT_REVIEWER,
+    date: null,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    const value = argv[i + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === '--issue') {
+      options.issue = parseIssueNumber(value, '--issue');
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--follow-up') {
+      options.followUpIssue = parseIssueNumber(value, '--follow-up');
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--checkpoint') {
+      options.checkpoint = parseTimestamp(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--roadmap-file') {
+      options.roadmapFile = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--reviewer') {
+      options.reviewer = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--date') {
+      if (!DATE_PATTERN.test(value)) {
+        throw new Error('--date must use YYYY-MM-DD format');
+      }
+      options.date = value;
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (options.help) {
+    return options;
+  }
+
+  if (options.issue === null) {
+    throw new Error('Missing required argument: --issue');
+  }
+
+  if (options.followUpIssue === null) {
+    throw new Error('Missing required argument: --follow-up');
+  }
+
+  if (options.checkpoint === null) {
+    throw new Error('Missing required argument: --checkpoint');
+  }
+
+  if (options.roadmapFile === null) {
+    throw new Error('Missing required argument: --roadmap-file');
+  }
+
+  if (options.date === null) {
+    options.date = options.checkpoint.slice(0, 10);
+  }
+
+  return options;
+}
+
+function renderCiReviewLogSnippet(options) {
+  return [
+    `Date: ${options.date}`,
+    `Reviewer: ${options.reviewer}`,
+    `Period reviewed: post-merge cycle (#${options.issue} to #${options.followUpIssue})`,
+    '',
+    '- Unexpected automatic workflow runs observed: No',
+    '- Local gate policy followed: Yes',
+    `- Budget and throughput assessment: Scoped audit (\`npm run ci:audit:manual -- --since ${options.checkpoint} --fail-on-unexpected\`) observed only \`workflow_dispatch\` events.`,
+    '- Decision: Continue manual-only',
+    `- Follow-up actions: Execute the next weekly review cycle under issue #${options.followUpIssue}.`,
+  ].join('\n');
+}
+
+function renderDependencyPlanSnippet(options) {
+  return [
+    `- ${options.date}: Manual-only operations checkpoint (issue #${options.issue}) confirmed no unexpected automatic workflow events since \`${options.checkpoint}\`; continue manual-only mode and track the next review in #${options.followUpIssue}.`,
+    `- ${options.date}: Logged rolling-cycle progress in \`${options.roadmapFile}\` for issue #${options.issue} and queued follow-up issue #${options.followUpIssue}.`,
+  ].join('\n');
+}
+
+function renderRoadmapProgressSnippet(options) {
+  return [
+    `- ${options.date}: Ran scoped manual-only workflow audit for issue #${options.issue}: \`npm run ci:audit:manual -- --since ${options.checkpoint} --fail-on-unexpected\` (PASS).`,
+    `- ${options.date}: Generated copy-ready checkpoint snippets for \`docs/CI_MANUAL_REVIEW_LOG.md\`, \`docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md\`, and \`${options.roadmapFile}\`.`,
+    `- ${options.date}: Created follow-up issue #${options.followUpIssue} to queue the next weekly manual-only review cycle.`,
+  ].join('\n');
+}
+
+function buildSnippets(options) {
+  return {
+    ciReviewLog: renderCiReviewLogSnippet(options),
+    dependencyPlan: renderDependencyPlanSnippet(options),
+    roadmapProgress: renderRoadmapProgressSnippet(options),
+  };
+}
+
+function renderOutput(options, snippets) {
+  return [
+    '# Rolling-Cycle Checkpoint Snippets (Dry Run)',
+    '',
+    'No files were written. Copy the sections below into the target documents.',
+    '',
+    '## Inputs',
+    `- Cycle issue: #${options.issue}`,
+    `- Follow-up issue: #${options.followUpIssue}`,
+    `- Checkpoint timestamp: \`${options.checkpoint}\``,
+    `- Roadmap file: \`${options.roadmapFile}\``,
+    `- Reviewer: ${options.reviewer}`,
+    `- Date: ${options.date}`,
+    '',
+    '## docs/CI_MANUAL_REVIEW_LOG.md',
+    '```md',
+    snippets.ciReviewLog,
+    '```',
+    '',
+    '## docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md',
+    '```md',
+    snippets.dependencyPlan,
+    '```',
+    '',
+    `## ${options.roadmapFile}`,
+    '```md',
+    snippets.roadmapProgress,
+    '```',
+    '',
+  ].join('\n');
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'Usage: node scripts/manual-cycle-checkpoint-snippets.cjs [options]',
+      '',
+      'Required:',
+      '  --issue <number>          Current cycle issue number',
+      '  --follow-up <number>      Next cycle follow-up issue number',
+      '  --checkpoint <iso-8601>   Previous review or audit checkpoint timestamp',
+      '  --roadmap-file <path>     Active roadmap markdown file path',
+      '',
+      'Optional:',
+      '  --reviewer <name>         Reviewer value for review-log snippet',
+      '  --date <YYYY-MM-DD>       Override snippet date (default: checkpoint date)',
+      '  -h, --help                Show this help text',
+      '',
+      'This command is dry-run only and never writes files directly.',
+      '',
+    ].join('\n')
+  );
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const snippets = buildSnippets(options);
+  process.stdout.write(renderOutput(options, snippets));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(
+      `manual-cycle-checkpoint-snippets failed: ${error.message || String(error)}\n`
+    );
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  DEFAULT_REVIEWER,
+  buildSnippets,
+  parseArgs,
+  renderCiReviewLogSnippet,
+  renderDependencyPlanSnippet,
+  renderOutput,
+  renderRoadmapProgressSnippet,
+};


### PR DESCRIPTION
## Summary
- add a dry-run helper command (`ci:snippets:checkpoint`) to render copy-ready markdown snippets for weekly checkpoint docs
- cover template rendering and argument parsing with `node:test`
- document usage in manual CI operations docs and bootstrap `ROADMAP_V11` with issue #252 progress

## Testing
- `npm run test:docs-snippets`
- `npm run ci:snippets:checkpoint -- --issue 251 --follow-up 252 --checkpoint 2026-02-16T20:00:00Z --roadmap-file docs/ROADMAP_V11.md`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`

Closes #252
