### PR TITLE
docs(ci): complete #251 operations review cycle

### DIFF
--- a/docs/CI_MANUAL_OPERATIONS.md
+++ b/docs/CI_MANUAL_OPERATIONS.md
@@ -2,13 +2,14 @@
 
 Date: 2026-02-15
 
-This repository is currently in a temporary budget-control mode where all GitHub
-Actions workflows are manual-only.
+This repository is currently in a temporary budget-control mode with manual-first
+workflows plus one minimal automated gate.
 
 ## Current Policy
 
-- Workflow triggers are limited to `workflow_dispatch`.
-- Automatic `push`, `pull_request`, `schedule`, and tag-triggered workflow runs are disabled.
+- Workflow triggers are manual-only (`workflow_dispatch`) except for one scoped gate:
+  - `.github/workflows/cnc-mobile-contract-gate.yml` on `pull_request` for protocol/route-impact paths only.
+- Automatic `push`, `schedule`, and broad unscoped PR/tag workflow runs are disabled.
 - GitHub CodeQL default setup is disabled (`state: not-configured`) to prevent automatic dynamic runs.
 - Each workflow job has `timeout-minutes: 8` to cap manual-run spend and prevent hangs.
 
@@ -71,7 +72,7 @@ npm run ci:snippets:checkpoint -- \
   --roadmap-file docs/ROADMAP_V11.md
 ```
 
-Run policy guard to verify workflow files still enforce manual-only mode:
+Run policy guard to verify workflow files still enforce manual-first policy:
 
 ```bash
 npm run ci:policy:check
@@ -96,7 +97,8 @@ Weekly checklist:
 
 1. Confirm no unexpected automatic workflow runs since previous review:
    - `npm run ci:audit:manual -- --since <previous-review-iso> --fail-on-unexpected`
-2. Verify manual-only policy still matches budget and throughput needs:
+   - Expected exception: path-scoped `CNC Mobile Contract Gate` PR runs.
+2. Verify manual-first policy still matches budget and throughput needs:
    - count merges since last review
    - count manually dispatched runs since last review
    - `npm run ci:policy:check`
@@ -106,7 +108,7 @@ Weekly checklist:
    - `npm run test:ci`
    - `npm run build`
 4. Record decision in the review log:
-   - `Continue manual-only` or `Start rollback`
+   - `Continue manual-first policy` or `Start rollback`
 
 ## Objective Exit Criteria
 

--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -105,3 +105,13 @@ Period reviewed: post-merge cycle (#207 to #209)
 - Budget and throughput assessment: Scoped audit (`ci:audit:manual --since 2026-02-15T17:07:43Z`) analyzed 1 run and observed only `workflow_dispatch` events.
 - Decision: Continue manual-only
 - Follow-up actions: Execute the next weekly review cycle under issue #210.
+
+Date: 2026-02-16
+Reviewer: Codex autonomous loop
+Period reviewed: post-merge cycle (#210 to #251)
+
+- Unexpected automatic workflow runs observed: Yes (allowlisted `CNC Mobile Contract Gate` PR runs only)
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Scoped audit (`npm run ci:audit:manual -- --since 2026-02-15T17:07:43Z --fail-on-unexpected`) analyzed 6 runs (4 allowlisted `pull_request`, 2 `workflow_dispatch`) with 0 unexpected events.
+- Decision: Continue manual-first policy
+- Follow-up actions: Execute the next weekly review cycle under issue #273.

--- a/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
+++ b/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
@@ -82,3 +82,8 @@ Issue #144 is complete when:
 1. Decision table is documented and linked in roadmap progress.
 2. Execution/defer follow-up issues are in place (#146, #147, #148, #150).
 3. Dependency dashboard comment history references these decisions for auditability.
+
+## 6. Rolling Operations Checkpoints
+
+- 2026-02-16: Manual-CI operations checkpoint (issue #251) confirmed no unexpected workflow events since `2026-02-15T17:07:43Z`; observed 4 allowlisted `pull_request` runs for `CNC Mobile Contract Gate` and 2 `workflow_dispatch` runs.
+- 2026-02-16: Policy baseline remains manual-first with one approved automation exception (path-scoped `CNC Mobile Contract Gate`), and next weekly review is queued in #273.

--- a/docs/ROADMAP_V11.md
+++ b/docs/ROADMAP_V11.md
@@ -1,25 +1,32 @@
 # Woly-Server Roadmap V11
 
 Date: 2026-02-16
-Scope: Post-V10 operational cadence with manual-CI checkpoint automation.
+Scope: Post-V10 operational cadence with manual-first CI checkpoint automation.
 
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `fc1e022` (PR #270).
-- Active execution branch: `codex/issue-252-checkpoint-snippets`.
+- `master` synced at merge commit `53df133` (PR #272).
+- Active execution branch: `codex/issue-251-weekly-manual-review`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
 - #251 `[CI] Schedule weekly manual-only operations review (rolling follow-up after #249)`
-- #252 `[DX][Docs] Generate rolling-cycle checkpoint markdown snippets`
+- #273 `[CI] Schedule weekly manual-only operations review (rolling follow-up after #251)`
 
 ### CI snapshot
-- All GitHub Actions workflows remain in temporary manual-only mode (`workflow_dispatch` only).
+- Policy is manual-first:
+  - manual `workflow_dispatch` for general workflows
+  - one approved path-scoped `pull_request` exception for `.github/workflows/cnc-mobile-contract-gate.yml`
 - Local guard commands remain active:
   - `npm run ci:audit:manual`
   - `npm run ci:policy:check`
+- Latest scoped audit (`2026-02-16T18:29:40Z`) since `2026-02-15T17:07:43Z`:
+  - `workflow_dispatch`: 2
+  - allowlisted `pull_request` (`CNC Mobile Contract Gate`): 4
+  - unexpected non-manual runs: 0
+- Latest policy check (`2026-02-16T18:29:38Z`): PASS across all workflow files.
 
 ## 2. Iterative Phases
 
@@ -35,7 +42,7 @@ Acceptance criteria:
 - Dry-run preview only (no direct file writes).
 - Template-render tests are included.
 
-Status: `Completed` (2026-02-16)
+Status: `Completed` (2026-02-16, PR #272)
 
 ### Phase 2: Weekly manual-only operations review (rolling)
 Issue: #251  
@@ -46,9 +53,9 @@ Acceptance criteria:
   - `npm run ci:audit:manual -- --since <iso> --fail-on-unexpected`
 - Run policy guard:
   - `npm run ci:policy:check`
-- Append review entry and progress updates using the checkpoint snippet helper.
+- Append review entry and progress updates.
 
-Status: `Planned`
+Status: `Completed` (2026-02-16, follow-up queued in #273)
 
 ### Phase 3: ESLint 10 compatibility checkpoint
 Issue: #150  
@@ -68,13 +75,27 @@ Labels: `technical-debt`
 
 Acceptance criteria:
 - Keep dependency dashboard comment trail aligned with phase outcomes.
-- Link relevant blocker/next-step issues (#150, #251, #252).
+- Link relevant blocker/next-step issues (#150, #251, #273).
+
+Status: `Planned`
+
+### Phase 5: Next weekly operations review cycle
+Issue: #273  
+Labels: `priority:low`, `technical-debt`, `developer-experience`
+
+Acceptance criteria:
+- Re-run scoped audit and policy checks for the next review window.
+- Append review log and roadmap/dependency checkpoint updates.
 
 Status: `Planned`
 
 ## 3. Progress Log
 
 - 2026-02-16: Bootstrapped `ROADMAP_V11` after CNC sync-policy closeout in PR #270.
-- 2026-02-16: Started issue #252 on branch `codex/issue-252-checkpoint-snippets`.
-- 2026-02-16: Added `npm run ci:snippets:checkpoint` dry-run helper to generate weekly checkpoint markdown blocks for review log, dependency plan, and roadmap progress.
-- 2026-02-16: Added template-render tests for checkpoint snippet output (`npm run test:docs-snippets`).
+- 2026-02-16: Added `npm run ci:snippets:checkpoint` dry-run helper and template-render tests (`npm run test:docs-snippets`) in PR #272.
+- 2026-02-16: Merged issue #252 via PR #272.
+- 2026-02-16: Started issue #251 on branch `codex/issue-251-weekly-manual-review`.
+- 2026-02-16: Updated manual operations policy docs and local audit/policy scripts to support the approved minimal automation exception for `CNC Mobile Contract Gate`.
+- 2026-02-16: Ran scoped audit for #251 (`npm run ci:audit:manual -- --since 2026-02-15T17:07:43Z --fail-on-unexpected`) and observed 0 unexpected non-manual runs.
+- 2026-02-16: Ran workflow policy guard for #251 (`npm run ci:policy:check`) and observed full PASS compliance.
+- 2026-02-16: Appended review/dependency checkpoints and created follow-up issue #273.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ci:policy:check": "node scripts/manual-ci-workflow-policy-check.cjs",
     "ci:snippets:checkpoint": "node scripts/manual-cycle-checkpoint-snippets.cjs",
     "test:docs-snippets": "node --test scripts/__tests__/manual-cycle-checkpoint-snippets.test.cjs",
+    "test:scripts": "node --test scripts/__tests__/*.test.cjs",
     "protocol:build": "npm run build --workspace=@kaonis/woly-protocol",
     "protocol:publish": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol",
     "protocol:publish:next": "npm run protocol:build && npm publish --workspace=@kaonis/woly-protocol --tag next",

--- a/scripts/__tests__/manual-ci-run-audit.test.cjs
+++ b/scripts/__tests__/manual-ci-run-audit.test.cjs
@@ -1,0 +1,64 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  ALLOWLISTED_NON_MANUAL_RUNS,
+  buildSummary,
+  isAllowlistedNonManualRun,
+} = require('../manual-ci-run-audit.cjs');
+
+test('allowlist includes CNC Mobile Contract Gate pull_request runs', () => {
+  assert.equal(ALLOWLISTED_NON_MANUAL_RUNS.length, 1);
+  assert.equal(ALLOWLISTED_NON_MANUAL_RUNS[0].event, 'pull_request');
+  assert.equal(
+    ALLOWLISTED_NON_MANUAL_RUNS[0].workflowName,
+    'CNC Mobile Contract Gate'
+  );
+});
+
+test('buildSummary counts allowlisted and unexpected non-manual runs separately', () => {
+  const runs = [
+    {
+      databaseId: 1,
+      event: 'workflow_dispatch',
+      workflowName: 'CI',
+      createdAt: '2026-02-16T18:00:00Z',
+      headBranch: 'master',
+      conclusion: 'success',
+    },
+    {
+      databaseId: 2,
+      event: 'pull_request',
+      workflowName: 'CNC Mobile Contract Gate',
+      createdAt: '2026-02-16T18:01:00Z',
+      headBranch: 'feature/a',
+      conclusion: 'success',
+    },
+    {
+      databaseId: 3,
+      event: 'pull_request',
+      workflowName: 'Other Workflow',
+      createdAt: '2026-02-16T18:02:00Z',
+      headBranch: 'feature/b',
+      conclusion: 'success',
+    },
+  ];
+
+  const summary = buildSummary(runs, '2026-02-16T17:59:00Z');
+
+  assert.equal(summary.totalRuns, 3);
+  assert.equal(summary.nonManualRunCount, 2);
+  assert.equal(summary.allowlistedNonManualRunCount, 1);
+  assert.equal(summary.unexpectedRunCount, 1);
+  assert.equal(summary.allowlistedNonManualRuns[0].databaseId, 2);
+  assert.equal(summary.unexpectedRuns[0].databaseId, 3);
+});
+
+test('isAllowlistedNonManualRun returns false for non-matching workflow', () => {
+  const run = {
+    event: 'pull_request',
+    workflowName: 'Random Workflow',
+  };
+
+  assert.equal(isAllowlistedNonManualRun(run), false);
+});

--- a/scripts/__tests__/manual-ci-workflow-policy-check.test.cjs
+++ b/scripts/__tests__/manual-ci-workflow-policy-check.test.cjs
@@ -1,0 +1,77 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  getWorkflowPolicy,
+  validateWorkflow,
+} = require('../manual-ci-workflow-policy-check.cjs');
+
+function writeWorkflow(tempDir, name, source) {
+  const filePath = path.join(tempDir, name);
+  fs.writeFileSync(filePath, source, 'utf8');
+  return filePath;
+}
+
+test('getWorkflowPolicy returns contract-gate exception for cnc workflow file', () => {
+  const policy = getWorkflowPolicy('/tmp/cnc-mobile-contract-gate.yml');
+  assert.equal(policy.requireWorkflowDispatch, false);
+  assert.deepEqual(policy.requiredTriggers, ['pull_request']);
+});
+
+test('validateWorkflow accepts path-scoped pull_request contract gate workflow', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'woly-policy-'));
+  const filePath = writeWorkflow(
+    tempDir,
+    'cnc-mobile-contract-gate.yml',
+    [
+      'name: CNC Mobile Contract Gate',
+      '',
+      'on:',
+      '  pull_request:',
+      '    paths:',
+      "      - 'apps/cnc/src/routes/**'",
+      '',
+      'jobs:',
+      '  contract-gate:',
+      '    runs-on: ubuntu-latest',
+      '    timeout-minutes: 8',
+      '    steps:',
+      '      - run: echo ok',
+      '',
+    ].join('\n')
+  );
+
+  const result = validateWorkflow(filePath);
+  assert.equal(result.passed, true);
+  assert.equal(result.violations.length, 0);
+});
+
+test('validateWorkflow rejects pull_request trigger for default workflow policy', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'woly-policy-'));
+  const filePath = writeWorkflow(
+    tempDir,
+    'ci.yml',
+    [
+      'name: CI',
+      '',
+      'on:',
+      '  workflow_dispatch:',
+      '  pull_request:',
+      '',
+      'jobs:',
+      '  test:',
+      '    runs-on: ubuntu-latest',
+      '    timeout-minutes: 8',
+      '    steps:',
+      '      - run: echo ok',
+      '',
+    ].join('\n')
+  );
+
+  const result = validateWorkflow(filePath);
+  assert.equal(result.passed, false);
+  assert.match(result.violations.join('\n'), /forbidden trigger present: `pull_request`/);
+});

--- a/scripts/manual-cycle-checkpoint-snippets.cjs
+++ b/scripts/manual-cycle-checkpoint-snippets.cjs
@@ -121,24 +121,24 @@ function renderCiReviewLogSnippet(options) {
     '',
     '- Unexpected automatic workflow runs observed: No',
     '- Local gate policy followed: Yes',
-    `- Budget and throughput assessment: Scoped audit (\`npm run ci:audit:manual -- --since ${options.checkpoint} --fail-on-unexpected\`) observed only \`workflow_dispatch\` events.`,
-    '- Decision: Continue manual-only',
+    `- Budget and throughput assessment: Scoped audit (\`npm run ci:audit:manual -- --since ${options.checkpoint} --fail-on-unexpected\`) observed no unexpected workflow events while preserving minimal automation budget controls.`,
+    '- Decision: Continue manual-first policy',
     `- Follow-up actions: Execute the next weekly review cycle under issue #${options.followUpIssue}.`,
   ].join('\n');
 }
 
 function renderDependencyPlanSnippet(options) {
   return [
-    `- ${options.date}: Manual-only operations checkpoint (issue #${options.issue}) confirmed no unexpected automatic workflow events since \`${options.checkpoint}\`; continue manual-only mode and track the next review in #${options.followUpIssue}.`,
+    `- ${options.date}: Manual-CI operations checkpoint (issue #${options.issue}) confirmed no unexpected workflow events since \`${options.checkpoint}\`; continue manual-first policy and track the next review in #${options.followUpIssue}.`,
     `- ${options.date}: Logged rolling-cycle progress in \`${options.roadmapFile}\` for issue #${options.issue} and queued follow-up issue #${options.followUpIssue}.`,
   ].join('\n');
 }
 
 function renderRoadmapProgressSnippet(options) {
   return [
-    `- ${options.date}: Ran scoped manual-only workflow audit for issue #${options.issue}: \`npm run ci:audit:manual -- --since ${options.checkpoint} --fail-on-unexpected\` (PASS).`,
+    `- ${options.date}: Ran scoped manual-first workflow audit for issue #${options.issue}: \`npm run ci:audit:manual -- --since ${options.checkpoint} --fail-on-unexpected\` (PASS).`,
     `- ${options.date}: Generated copy-ready checkpoint snippets for \`docs/CI_MANUAL_REVIEW_LOG.md\`, \`docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md\`, and \`${options.roadmapFile}\`.`,
-    `- ${options.date}: Created follow-up issue #${options.followUpIssue} to queue the next weekly manual-only review cycle.`,
+    `- ${options.date}: Created follow-up issue #${options.followUpIssue} to queue the next weekly manual-first review cycle.`,
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- complete weekly operations review for #251 and append decision entries to review/dependency/roadmap docs
- align local CI policy tooling with the current manual-first baseline that allows only the path-scoped `CNC Mobile Contract Gate` PR automation
- add script tests for audit allowlist behavior and workflow-policy exception handling

## Testing
- `npm run test:scripts`
- `npm run ci:audit:manual -- --since 2026-02-15T17:07:43Z --fail-on-unexpected`
- `npm run ci:policy:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`

Closes #251
Refs #273
