### PR TITLE
docs(ci): complete #275 operations review cycle

### DIFF
--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -125,3 +125,13 @@ Period reviewed: post-merge cycle (#251 to #273)
 - Budget and throughput assessment: Scoped audit (`npm run ci:audit:manual -- --since 2026-02-16T18:31:42Z --fail-on-unexpected`) analyzed 0 runs in scope with 0 unexpected events.
 - Decision: Continue manual-first policy
 - Follow-up actions: Execute the next weekly review cycle under issue #275.
+
+Date: 2026-02-16
+Reviewer: Codex autonomous loop
+Period reviewed: post-merge cycle (#273 to #275)
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Scoped audit (`npm run ci:audit:manual -- --since 2026-02-16T18:33:09Z --fail-on-unexpected`) analyzed 0 runs in scope with 0 unexpected events.
+- Decision: Continue manual-first policy
+- Follow-up actions: Execute the next weekly review cycle under issue #277.

--- a/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
+++ b/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
@@ -89,3 +89,5 @@ Issue #144 is complete when:
 - 2026-02-16: Policy baseline remains manual-first with one approved automation exception (path-scoped `CNC Mobile Contract Gate`), and next weekly review is queued in #273.
 - 2026-02-16: Manual-CI operations checkpoint (issue #273) confirmed no unexpected workflow events since `2026-02-16T18:31:42Z`; scoped window contained 0 runs.
 - 2026-02-16: Manual-first policy baseline remains unchanged; next weekly review is queued in #275.
+- 2026-02-16: Manual-CI operations checkpoint (issue #275) confirmed no unexpected workflow events since `2026-02-16T18:33:09Z`; scoped window contained 0 runs.
+- 2026-02-16: Manual-first policy baseline remains unchanged; next weekly review is queued in #277.

--- a/docs/ROADMAP_V11.md
+++ b/docs/ROADMAP_V11.md
@@ -6,14 +6,14 @@ Scope: Post-V10 operational cadence with manual-first CI checkpoint automation.
 ## 1. Status Audit
 
 ### Repository and branch status
-- `master` synced at merge commit `c53ace2` (PR #274).
-- Active execution branch: `codex/issue-273-weekly-manual-review`.
+- `master` synced at merge commit `0f1bea7` (PR #276).
+- Active execution branch: `codex/issue-275-weekly-manual-review`.
 
 ### Open issue snapshot (`kaonis/woly-server`)
 - #4 `Dependency Dashboard`
 - #150 `[Dependencies] Revisit ESLint 10 adoption after typescript-eslint compatibility`
-- #273 `[CI] Schedule weekly manual-only operations review (rolling follow-up after #251)`
 - #275 `[CI] Schedule weekly manual-only operations review (rolling follow-up after #273)`
+- #277 `[CI] Schedule weekly manual-only operations review (rolling follow-up after #275)`
 
 ### CI snapshot
 - Policy is manual-first:
@@ -22,10 +22,10 @@ Scope: Post-V10 operational cadence with manual-first CI checkpoint automation.
 - Local guard commands remain active:
   - `npm run ci:audit:manual`
   - `npm run ci:policy:check`
-- Latest scoped audit (`2026-02-16T18:33:09Z`) since `2026-02-16T18:31:42Z`:
+- Latest scoped audit (`2026-02-16T18:35:12Z`) since `2026-02-16T18:33:09Z`:
   - runs in scope: 0
   - unexpected non-manual runs: 0
-- Latest policy check (`2026-02-16T18:33:07Z`): PASS across all workflow files.
+- Latest policy check (`2026-02-16T18:35:10Z`): PASS across all workflow files.
 
 ## 2. Iterative Phases
 
@@ -74,7 +74,7 @@ Labels: `technical-debt`
 
 Acceptance criteria:
 - Keep dependency dashboard comment trail aligned with phase outcomes.
-- Link relevant blocker/next-step issues (#150, #273, #275).
+- Link relevant blocker/next-step issues (#150, #275, #277).
 
 Status: `Planned`
 
@@ -90,6 +90,16 @@ Status: `Completed` (2026-02-16, follow-up queued in #275)
 
 ### Phase 6: Next weekly operations review cycle
 Issue: #275  
+Labels: `priority:low`, `technical-debt`, `developer-experience`
+
+Acceptance criteria:
+- Re-run scoped audit and policy checks for the next review window.
+- Append review log and roadmap/dependency checkpoint updates.
+
+Status: `Completed` (2026-02-16, follow-up queued in #277)
+
+### Phase 7: Next weekly operations review cycle
+Issue: #277  
 Labels: `priority:low`, `technical-debt`, `developer-experience`
 
 Acceptance criteria:
@@ -113,3 +123,8 @@ Status: `Planned`
 - 2026-02-16: Ran scoped audit for #273 (`npm run ci:audit:manual -- --since 2026-02-16T18:31:42Z --fail-on-unexpected`) and observed 0 runs in scope.
 - 2026-02-16: Ran workflow policy guard for #273 (`npm run ci:policy:check`) and observed full PASS compliance.
 - 2026-02-16: Appended review/dependency checkpoints and created follow-up issue #275.
+- 2026-02-16: Merged issue #273 via PR #276.
+- 2026-02-16: Started issue #275 on branch `codex/issue-275-weekly-manual-review`.
+- 2026-02-16: Ran scoped audit for #275 (`npm run ci:audit:manual -- --since 2026-02-16T18:33:09Z --fail-on-unexpected`) and observed 0 runs in scope.
+- 2026-02-16: Ran workflow policy guard for #275 (`npm run ci:policy:check`) and observed full PASS compliance.
+- 2026-02-16: Appended review/dependency checkpoints and created follow-up issue #277.


### PR DESCRIPTION
## Summary
- complete weekly manual-first operations review for #275 with scoped audit + workflow policy check
- append review/dependency/roadmap checkpoint updates for this cycle
- queue the next review cycle in #277 and update dependency dashboard note

## Testing
- `npm run ci:audit:manual -- --since 2026-02-16T18:33:09Z --fail-on-unexpected`
- `npm run ci:policy:check`
- `npm run test:scripts`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`

Closes #275
Refs #277
