### PR TITLE
fix(cnc): support TRUST_PROXY for proxied rate limiting

### DIFF
--- a/apps/cnc/.env.example
+++ b/apps/cnc/.env.example
@@ -24,6 +24,9 @@ NODE_AUTH_TOKENS=token1,token2,token3
 JWT_SECRET=your-secret-key-change-in-production
 JWT_ISSUER=woly-cnc
 JWT_AUDIENCE=woly-api
+# Reverse proxy trust for client IP extraction in rate limiting.
+# Set to 1 when behind a single trusted proxy (nginx, cloudflared, etc).
+TRUST_PROXY=false
 WS_REQUIRE_TLS=false
 WS_ALLOW_QUERY_TOKEN_AUTH=true
 # Maximum inbound WebSocket messages accepted per connection per second

--- a/apps/cnc/.env.tunnel.example
+++ b/apps/cnc/.env.tunnel.example
@@ -24,6 +24,7 @@ NODE_AUTH_TOKENS=dev-token-home,dev-token-office,dev-token-remote
 JWT_SECRET=dev-secret-key-change-in-production-12345
 JWT_ISSUER=woly-cnc
 JWT_AUDIENCE=woly-api
+TRUST_PROXY=false
 WS_REQUIRE_TLS=false
 WS_ALLOW_QUERY_TOKEN_AUTH=true
 

--- a/apps/cnc/QUICK_REFERENCE.md
+++ b/apps/cnc/QUICK_REFERENCE.md
@@ -30,6 +30,7 @@ ws://localhost:8080/ws/node?token=<auth-token>
 ## 🔑 Environment Variables
 ```env
 PORT=8080
+TRUST_PROXY=false
 DATABASE_URL=postgresql://user:pass@host:5432/db
 NODE_AUTH_TOKENS=token1,token2,token3
 NODE_HEARTBEAT_INTERVAL=30000    # 30s

--- a/apps/cnc/README.md
+++ b/apps/cnc/README.md
@@ -223,6 +223,7 @@ Environment variables (`.env`):
 | `PORT` | HTTP server port | `8080` |
 | `NODE_ENV` | Environment | `development` |
 | `CORS_ORIGINS` | Comma-separated browser origins allowed in production (e.g. `https://woly.expo.app`) | `''` |
+| `TRUST_PROXY` | Express `trust proxy` setting. Use `1` behind one reverse proxy, or keep `false` when directly exposed | `false` |
 | `DB_TYPE` | Database type: `postgres` or `sqlite` | `postgres` |
 | `DATABASE_URL` | Database connection (PostgreSQL URL or SQLite path) | Required |
 | `NODE_AUTH_TOKENS` | Comma-separated auth tokens | Required |

--- a/apps/cnc/src/config/__tests__/index.test.ts
+++ b/apps/cnc/src/config/__tests__/index.test.ts
@@ -57,9 +57,26 @@ describe('config parsing and validation', () => {
     expect(config.corsOrigins).toEqual(['https://a.example', 'https://b.example']);
     expect(config.wsRequireTls).toBe(true);
     expect(config.wsAllowQueryTokenAuth).toBe(false);
+    expect(config.trustProxy).toBe(false);
     expect(config.scheduleWorkerEnabled).toBe(false);
     expect(config.schedulePollIntervalMs).toBe(45000);
     expect(config.scheduleBatchSize).toBe(10);
+  });
+
+  it('parses TRUST_PROXY numeric hop count', async () => {
+    const config = await loadConfig({
+      TRUST_PROXY: '1',
+    });
+
+    expect(config.trustProxy).toBe(1);
+  });
+
+  it('parses TRUST_PROXY named subnet values', async () => {
+    const config = await loadConfig({
+      TRUST_PROXY: 'loopback, linklocal, uniquelocal',
+    });
+
+    expect(config.trustProxy).toBe('loopback, linklocal, uniquelocal');
   });
 
   it('throws when NODE_TIMEOUT is less than 2x NODE_HEARTBEAT_INTERVAL', async () => {

--- a/apps/cnc/src/config/index.ts
+++ b/apps/cnc/src/config/index.ts
@@ -49,6 +49,32 @@ function getEnvBoolean(key: string, defaultValue: boolean): boolean {
   return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
 }
 
+function getEnvTrustProxy(
+  key: string,
+  defaultValue: boolean | number | string,
+): boolean | number | string {
+  const value = process.env[key];
+  if (value === undefined || value.trim() === '') {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (/^\d+$/.test(normalized)) {
+    return Number.parseInt(normalized, 10);
+  }
+
+  if (['true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  // Keep string forms supported by Express (for example "loopback" or subnet lists).
+  return value.trim();
+}
+
 export const config: ServerConfig = {
   port: getEnvNumber('PORT', 8080),
   nodeEnv: getEnvVar('NODE_ENV', 'development'),
@@ -56,6 +82,7 @@ export const config: ServerConfig = {
     .split(',')
     .map((value) => value.trim())
     .filter(Boolean),
+  trustProxy: getEnvTrustProxy('TRUST_PROXY', false),
   dbType: getEnvVar('DB_TYPE', 'postgres'),
   databaseUrl: getEnvVar('DATABASE_URL'),
   nodeAuthTokens: getEnvVar('NODE_AUTH_TOKENS', '')

--- a/apps/cnc/src/server.ts
+++ b/apps/cnc/src/server.ts
@@ -37,6 +37,7 @@ class Server {
 
   constructor() {
     this.app = express();
+    this.app.set('trust proxy', config.trustProxy);
     this.httpServer = createServer(this.app);
     this.hostAggregator = new HostAggregator();
     this.nodeManager = new NodeManager(this.hostAggregator);
@@ -202,6 +203,7 @@ class Server {
       this.httpServer.listen(config.port, () => {
         logger.info(`Server listening on port ${config.port}`);
         logger.info(`Environment: ${config.nodeEnv}`);
+        logger.info('Express trust proxy setting', { trustProxy: config.trustProxy });
         logger.info(`WebSocket endpoint: ws://localhost:${config.port}/ws/node`);
       });
 

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -125,6 +125,7 @@ export interface ServerConfig {
   port: number;
   nodeEnv: string;
   corsOrigins: string[];
+  trustProxy: boolean | number | string;
   dbType: string;
   databaseUrl: string;
   nodeAuthTokens: string[];


### PR DESCRIPTION
## Summary
Fixes a CNC production issue where `express-rate-limit` logs `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` when traffic is behind a reverse proxy.

This change adds explicit `TRUST_PROXY` config and wires it into Express so real client IPs are used by the limiter when deployed behind trusted proxies.

Closes #289

## CNC Sync Classification
- [ ] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)
- Protocol issue: N/A (not a CNC feature/protocol change)
- Backend issue: #289
- Frontend issue: N/A (no frontend integration required)

## 3-Part Chain Checklist (required for CNC feature changes)
- [ ] Protocol contract updated or verified.
- [ ] Backend endpoint/command implemented or explicitly unchanged.
- [ ] Frontend integration implemented or tracked in linked issue.

## Ordering Gates
- [ ] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [ ] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Local Validation (required for CNC feature changes)
Commands run:
```bash
npm run test -w apps/cnc -- src/config/__tests__/index.test.ts
npm run typecheck -w apps/cnc
```

Result summary:
- [x] Local validation passed
- [ ] Any known gaps are documented below

Notes:
- `TRUST_PROXY` defaults to `false`.
- For one reverse proxy hop in production, set `TRUST_PROXY=1`.
