### PR TITLE
feat(protocol): bump to 1.2.0 and restore consumer typecheck parity

### DIFF
--- a/docs/PROTOCOL_COMPATIBILITY.md
+++ b/docs/PROTOCOL_COMPATIBILITY.md
@@ -8,21 +8,21 @@ The WoLy distributed system uses a shared protocol package (`@kaonis/woly-protoc
 
 **Package**: `@kaonis/woly-protocol`  
 **Purpose**: Shared TypeScript types and Zod runtime schemas for node ↔ C&C communication  
-**Current Package Version**: 1.1.1  
-**Current Protocol Version**: 1.1.1 (see `PROTOCOL_VERSION` constant)  
+**Current Package Version**: 1.2.0  
+**Current Protocol Version**: 1.2.0 (see `PROTOCOL_VERSION` constant)  
 **Location**: `packages/protocol/`
 
 ### Exports
 
-- **Types**: `Host`, `HostStatus`, `CommandState`, `NodeMessage`, `CncCommand`, CNC API DTOs (`CncCapabilitiesResponse`, `WakeSchedule`, `HostPortScanResponse`), etc.
-- **Schemas**: `outboundNodeMessageSchema`, `inboundCncCommandSchema`, CNC API schemas (`cncCapabilitiesResponseSchema`, `wakeScheduleSchema`, `hostPortScanResponseSchema`), etc.
+- **Types**: `Host`, `HostStatus`, `CommandState`, `NodeMessage`, `CncCommand`, CNC API DTOs (`CncCapabilitiesResponse`, `HostWakeSchedule`, `HostPortScanResponse`), etc.
+- **Schemas**: `outboundNodeMessageSchema`, `inboundCncCommandSchema`, CNC API schemas (`cncCapabilitiesResponseSchema`, `hostWakeScheduleSchema`, `hostPortScanResponseSchema`), etc.
 - **Constants**: `PROTOCOL_VERSION`, `SUPPORTED_PROTOCOL_VERSIONS`
 
 ### Consumer Migration Notes
 
 - `1.0.x`: Base node ↔ C&C message contracts.
 - `1.1.x`: CNC app/backend API DTOs for capabilities + schedules.
-- Next minor release from this branch: host port scan DTO exports + consumer typecheck fixture.
+- `1.2.x`: host port scan/ping payload enrichments and consumer typecheck fixture parity.
 
 ## Versioning Policy
 
@@ -47,13 +47,13 @@ Protocol package follows strict semantic versioning:
 From monorepo root:
 
 ```bash
-# Bug fix (1.1.0 → 1.1.1)
+# Bug fix (1.2.0 → 1.2.1)
 npm run protocol:version:patch
 
-# New feature (1.1.0 → 1.2.0)
+# New feature (1.2.0 → 1.3.0)
 npm run protocol:version:minor
 
-# Breaking change (1.1.0 → 2.0.0)
+# Breaking change (1.2.0 → 2.0.0)
 npm run protocol:version:major
 ```
 
@@ -63,7 +63,8 @@ npm run protocol:version:major
 
 | Protocol Version | Node Agent | C&C Backend | Status |
 |------------------|------------|-------------|--------|
-| 1.1.1 | ✅ 0.0.1+ | ✅ 1.0.0+ | Current |
+| 1.2.0 | ✅ 0.0.1+ | ✅ 1.0.0+ | Current |
+| 1.1.1 | ✅ 0.0.1+ | ✅ 1.0.0+ | Transitional support |
 | 1.0.0 | ✅ 0.0.1+ | ✅ 1.0.0+ | Transitional support |
 
 ### Runtime Version Negotiation
@@ -75,8 +76,8 @@ npm run protocol:version:major
 
 ```typescript
 // In protocol package
-export const PROTOCOL_VERSION = '1.1.1';
-export const SUPPORTED_PROTOCOL_VERSIONS = ['1.1.1', '1.0.0'];
+export const PROTOCOL_VERSION = '1.2.0';
+export const SUPPORTED_PROTOCOL_VERSIONS = ['1.2.0', '1.1.1', '1.0.0'];
 ```
 
 ## CI Enforcement

--- a/package-lock.json
+++ b/package-lock.json
@@ -8767,7 +8767,7 @@
     },
     "packages/protocol": {
       "name": "@kaonis/woly-protocol",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^4.0.0"

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -11,9 +11,9 @@
 - `HostPayload` — **@deprecated** Alias for `Host`, kept for backwards compatibility
 - `CommandState` — Command lifecycle state: `'queued' | 'sent' | 'acknowledged' | 'failed' | 'timed_out'`
 - `ErrorResponse` — Standardized error response shape with `error`, `message`, optional `code` and `details`
-- `CncCapabilitiesResponse` / `CncFeatureCapabilities` — CNC mode feature negotiation response
+- `CncCapabilitiesResponse` / `CncCapabilityDescriptor` — CNC mode feature negotiation response
 - `HostPort` / `HostPortScanResponse` — CNC host port-scan API DTOs
-- `WakeSchedule`, `CreateWakeScheduleRequest`, `UpdateWakeScheduleRequest`, `ScheduleFrequency` — CNC schedules API DTOs
+- `HostWakeSchedule`, `CreateHostWakeScheduleRequest`, `UpdateHostWakeScheduleRequest`, `ScheduleFrequency` — CNC schedules API DTOs
 - `NodeMetadata` — Agent platform/version/network info
 - `NodeRegistration` — Registration payload sent by nodes
 - `NodeMessage` — Discriminated union of all node → C&C messages
@@ -27,16 +27,16 @@
 - `hostSchema` — Validates `Host` object
 - `commandStateSchema` — Validates `CommandState`
 - `errorResponseSchema` — Validates `ErrorResponse` object
-- `cncCapabilitiesResponseSchema` / `cncFeatureCapabilitiesSchema` — Validates CNC capabilities payload
+- `cncCapabilitiesResponseSchema` / `cncCapabilityDescriptorSchema` — Validates CNC capabilities payload
 - `hostPortSchema` / `hostPortScanResponseSchema` — Validates host port scan payloads
-- `wakeScheduleSchema` / `wakeScheduleListResponseSchema` / `createWakeScheduleRequestSchema` / `updateWakeScheduleRequestSchema` — Validates schedules payloads
+- `hostWakeScheduleSchema` / `hostSchedulesResponseSchema` / `createHostWakeScheduleRequestSchema` / `updateHostWakeScheduleRequestSchema` — Validates schedules payloads
 - `outboundNodeMessageSchema` — Validates `NodeMessage` at runtime
 - `inboundCncCommandSchema` — Validates `CncCommand` at runtime
 
 ### Constants
 
-- `PROTOCOL_VERSION` — Current protocol version (`'1.1.1'`)
-- `SUPPORTED_PROTOCOL_VERSIONS` — Array of supported versions (`['1.1.1', '1.0.0']`)
+- `PROTOCOL_VERSION` — Current protocol version (`'1.2.0'`)
+- `SUPPORTED_PROTOCOL_VERSIONS` — Array of supported versions (`['1.2.0', '1.1.1', '1.0.0']`)
 
 ## Usage
 
@@ -95,6 +95,7 @@ Output goes to `dist/`. Both `main` and `types` in package.json point there.
 
 - `1.0.x`: Base node ↔ C&C message contracts (`Host`, `NodeMessage`, `CncCommand`).
 - `1.1.x`: CNC app/backend API contracts (`CncCapabilitiesResponse`, schedules, host port scan DTOs/schemas) and wire protocol negotiation update.
+- `1.2.x`: Host metadata/scan enrichments (`openPorts`, `portsScannedAt`, `portsExpireAt`), ping/port-scan command/result payloads, and consumer typecheck fixture parity.
 
 ## Testing
 
@@ -122,9 +123,9 @@ From the **monorepo root**, use the provided npm scripts:
 
 ```bash
 # 1. Bump version (patch/minor/major)
-npm run protocol:version:patch   # For bug fixes (1.1.0 → 1.1.1)
-npm run protocol:version:minor   # For new features (1.1.0 → 1.2.0)
-npm run protocol:version:major   # For breaking changes (1.1.0 → 2.0.0)
+npm run protocol:version:patch   # For bug fixes (1.2.0 → 1.2.1)
+npm run protocol:version:minor   # For new features (1.2.0 → 1.3.0)
+npm run protocol:version:major   # For breaking changes (1.2.0 → 2.0.0)
 
 # 2. Publish to npm (builds automatically)
 npm run protocol:publish         # Publish with 'latest' tag

--- a/packages/protocol/fixtures/app-consumer/index.ts
+++ b/packages/protocol/fixtures/app-consumer/index.ts
@@ -2,23 +2,25 @@ import type {
   CncCapabilitiesResponse,
   Host,
   HostPortScanResponse,
-  WakeSchedule,
+  HostWakeSchedule,
 } from '@kaonis/woly-protocol';
 import {
   cncCapabilitiesResponseSchema,
   hostPortScanResponseSchema,
-  wakeScheduleSchema,
+  hostWakeScheduleSchema,
 } from '@kaonis/woly-protocol';
 
 const capabilities: CncCapabilitiesResponse = {
-  apiVersion: '1.0.0',
-  protocolVersion: '1.0.0',
-  supportedProtocolVersions: ['1.0.0'],
+  mode: 'cnc',
+  versions: {
+    cncApi: '1.0.0',
+    protocol: '1.2.0',
+  },
   capabilities: {
-    scan: true,
-    notesTagsPersistence: true,
-    schedulesApi: true,
-    commandStatusStreaming: false,
+    scan: { supported: true },
+    notesTags: { supported: true, persistence: 'backend' },
+    schedules: { supported: true, routes: ['/api/hosts/:fqn/schedules'] },
+    commandStatusStreaming: { supported: false, transport: null },
   },
 };
 
@@ -42,7 +44,7 @@ const scanResponse: HostPortScanResponse = {
   },
 };
 
-const schedule: WakeSchedule = {
+const schedule: HostWakeSchedule = {
   id: 'sched-1',
   hostName: host.name,
   hostMac: host.mac,
@@ -54,10 +56,10 @@ const schedule: WakeSchedule = {
   notifyOnWake: true,
   createdAt: '2026-02-15T08:00:00.000Z',
   updatedAt: '2026-02-15T08:00:00.000Z',
-  lastTriggered: null,
+  lastTriggered: '2026-02-16T08:00:00.000Z',
   nextTrigger: '2026-02-17T08:00:00.000Z',
 };
 
 void cncCapabilitiesResponseSchema.parse(capabilities);
 void hostPortScanResponseSchema.parse(scanResponse);
-void wakeScheduleSchema.parse(schedule);
+void hostWakeScheduleSchema.parse(schedule);

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaonis/woly-protocol",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Shared WoLy node <-> C&C protocol types and runtime schemas",
   "license": "Apache-2.0",
   "main": "dist/index.js",
@@ -21,7 +21,8 @@
     "build": "tsc",
     "test": "jest --watchman=false",
     "test:ci": "jest --watchman=false",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:consumer-typecheck": "npm run build && tsc -p fixtures/app-consumer/tsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 // --- Protocol versioning ---
 
-export const PROTOCOL_VERSION = '1.1.1' as const;
-export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [PROTOCOL_VERSION, '1.0.0'];
+export const PROTOCOL_VERSION = '1.2.0' as const;
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [PROTOCOL_VERSION, '1.1.1', '1.0.0'];
 
 // --- Shared types ---
 


### PR DESCRIPTION
## Summary
Bumps `@kaonis/woly-protocol` to `1.2.0` and fixes the protocol release/verification gaps found during audit:
- add missing `test:consumer-typecheck` workspace script
- update fixture consumer code to current exported types/schemas
- align protocol constants/docs to `1.2.0`
- keep runtime compatibility for older nodes via `SUPPORTED_PROTOCOL_VERSIONS = ['1.2.0', '1.1.1', '1.0.0']`

Closes #291

## CNC Sync Classification
- [ ] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)
- Protocol issue: #291
- Backend issue: N/A (not a CNC endpoint/command change)
- Frontend issue: N/A (no frontend integration change)

## 3-Part Chain Checklist (required for CNC feature changes)
- [ ] Protocol contract updated or verified.
- [ ] Backend endpoint/command implemented or explicitly unchanged.
- [ ] Frontend integration implemented or tracked in linked issue.

## Ordering Gates
- [ ] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [ ] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Local Validation (required for CNC feature changes)
Commands run:
```bash
npm run protocol:consumer-typecheck
npm run test -w packages/protocol -- contract.cross-repo
npm run test -w apps/node-agent -- protocol.contract
npm run test -w apps/cnc -- protocol.contract
```

Result summary:
- [x] Local validation passed
- [ ] Any known gaps are documented below

Notes:
- After merge, publish `@kaonis/woly-protocol@1.2.0` from `master`.
