### PR TITLE
feat(cnc): expose effective limiter budgets in capabilities

### DIFF
--- a/apps/cnc/src/controllers/__tests__/meta.test.ts
+++ b/apps/cnc/src/controllers/__tests__/meta.test.ts
@@ -31,6 +31,18 @@ describe('buildCncCapabilitiesResponse', () => {
     expect(payload.versions.cncApi).toEqual(expect.any(String));
     expect(payload.versions.cncApi.trim().length).toBeGreaterThan(0);
     expect(payload.versions.protocol).toBe(PROTOCOL_VERSION);
+    expect(payload.rateLimits).toMatchObject({
+      strictAuth: expect.objectContaining({ maxCalls: expect.any(Number), windowMs: expect.any(Number) }),
+      auth: expect.objectContaining({ maxCalls: expect.any(Number), windowMs: expect.any(Number) }),
+      api: expect.objectContaining({ maxCalls: expect.any(Number), windowMs: expect.any(Number) }),
+      scheduleSync: expect.objectContaining({ maxCalls: expect.any(Number), windowMs: expect.any(Number) }),
+      wsInboundMessages: expect.objectContaining({
+        maxCalls: expect.any(Number),
+        windowMs: 1000,
+      }),
+      wsConnectionsPerIp: expect.objectContaining({ maxCalls: expect.any(Number), windowMs: null }),
+      macVendorLookup: expect.objectContaining({ maxCalls: 1, windowMs: 1000 }),
+    });
     expect(cncCapabilitiesResponseSchema.safeParse(payload).success).toBe(true);
   });
 

--- a/apps/cnc/src/controllers/meta.ts
+++ b/apps/cnc/src/controllers/meta.ts
@@ -7,6 +7,7 @@ import { PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from '@kaonis/woly-prot
 import { CncCapabilitiesResponse } from '../types';
 import { CNC_VERSION } from '../utils/cncVersion';
 import logger from '../utils/logger';
+import { buildCncRateLimits } from '../services/capabilityRateLimits';
 
 const FALLBACK_CNC_API_VERSION = '0.0.0';
 const FALLBACK_PROTOCOL_VERSION = (() => {
@@ -80,6 +81,7 @@ export function buildCncCapabilitiesResponse(
       protocol,
     },
     capabilities: capabilityMatrix,
+    rateLimits: buildCncRateLimits(),
   };
 }
 

--- a/apps/cnc/src/middleware/rateLimiter.ts
+++ b/apps/cnc/src/middleware/rateLimiter.ts
@@ -23,28 +23,31 @@ const parsePositiveInt = (
   return parsed;
 };
 
-const AUTH_RATE_LIMIT_WINDOW_MS = parsePositiveInt(
+export const AUTH_RATE_LIMIT_WINDOW_MS = parsePositiveInt(
   process.env.AUTH_RATE_LIMIT_WINDOW_MS,
   900000,
 ); // 15 minutes default
-const AUTH_RATE_LIMIT_MAX = parsePositiveInt(
+export const AUTH_RATE_LIMIT_MAX = parsePositiveInt(
   process.env.AUTH_RATE_LIMIT_MAX,
   5,
 ); // 5 attempts default
 
-const API_RATE_LIMIT_WINDOW_MS = parsePositiveInt(
+export const LEGACY_AUTH_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+export const LEGACY_AUTH_RATE_LIMIT_MAX = isDevelopment ? 100 : 10;
+
+export const API_RATE_LIMIT_WINDOW_MS = parsePositiveInt(
   process.env.API_RATE_LIMIT_WINDOW_MS,
   15 * 60 * 1000,
 );
-const API_RATE_LIMIT_MAX = parsePositiveInt(
+export const API_RATE_LIMIT_MAX = parsePositiveInt(
   process.env.API_RATE_LIMIT_MAX,
   isDevelopment ? 10000 : 300,
 );
-const SCHEDULE_RATE_LIMIT_WINDOW_MS = parsePositiveInt(
+export const SCHEDULE_RATE_LIMIT_WINDOW_MS = parsePositiveInt(
   process.env.SCHEDULE_RATE_LIMIT_WINDOW_MS,
   15 * 60 * 1000,
 );
-const SCHEDULE_RATE_LIMIT_MAX = parsePositiveInt(
+export const SCHEDULE_RATE_LIMIT_MAX = parsePositiveInt(
   process.env.SCHEDULE_RATE_LIMIT_MAX,
   isDevelopment ? 20000 : 3000,
 );
@@ -86,8 +89,8 @@ export const strictAuthLimiter = rateLimit({
  * Production: 10 requests per 15 minutes per IP
  */
 export const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: isDevelopment ? 100 : 10, // Higher limit in development
+  windowMs: LEGACY_AUTH_RATE_LIMIT_WINDOW_MS,
+  max: LEGACY_AUTH_RATE_LIMIT_MAX,
   standardHeaders: true, // Return rate limit info in `RateLimit-*` headers
   legacyHeaders: false, // Disable `X-RateLimit-*` headers
   skip: (req) => {

--- a/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
@@ -97,6 +97,15 @@ describe('Capabilities Routes', () => {
           schedules: expect.objectContaining({ supported: true, persistence: 'backend' }),
           commandStatusStreaming: expect.objectContaining({ supported: false, transport: null }),
         },
+        rateLimits: {
+          strictAuth: expect.objectContaining({ scope: 'ip' }),
+          auth: expect.objectContaining({ scope: 'ip' }),
+          api: expect.objectContaining({ scope: 'ip' }),
+          scheduleSync: expect.objectContaining({ scope: 'ip' }),
+          wsInboundMessages: expect.objectContaining({ scope: 'connection', windowMs: 1000 }),
+          wsConnectionsPerIp: expect.objectContaining({ scope: 'ip', windowMs: null }),
+          macVendorLookup: expect.objectContaining({ scope: 'global', windowMs: 1000 }),
+        },
       });
       expect(response.body.versions.cncApi.toLowerCase()).not.toBe('unknown');
     });

--- a/apps/cnc/src/routes/__tests__/metaRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/metaRoutes.test.ts
@@ -113,6 +113,15 @@ describe('Capabilities Route', () => {
           },
           commandStatusStreaming: { supported: false, transport: null },
         },
+        rateLimits: {
+          strictAuth: { scope: 'ip' },
+          auth: { scope: 'ip' },
+          api: { scope: 'ip' },
+          scheduleSync: { scope: 'ip' },
+          wsInboundMessages: { scope: 'connection', windowMs: 1000 },
+          wsConnectionsPerIp: { scope: 'ip', windowMs: null },
+          macVendorLookup: { scope: 'global', windowMs: 1000 },
+        },
       });
     });
 

--- a/apps/cnc/src/routes/__tests__/mobileCompatibility.smoke.test.ts
+++ b/apps/cnc/src/routes/__tests__/mobileCompatibility.smoke.test.ts
@@ -433,6 +433,15 @@ describe('Mobile API compatibility smoke checks', () => {
           schedules: { supported: true, persistence: 'backend' },
           commandStatusStreaming: { supported: false, transport: null },
         },
+        rateLimits: {
+          strictAuth: { scope: 'ip' },
+          auth: { scope: 'ip' },
+          api: { scope: 'ip' },
+          scheduleSync: { scope: 'ip' },
+          wsInboundMessages: { scope: 'connection', windowMs: 1000 },
+          wsConnectionsPerIp: { scope: 'ip', windowMs: null },
+          macVendorLookup: { scope: 'global', windowMs: 1000 },
+        },
       });
     });
 

--- a/apps/cnc/src/services/__tests__/capabilityRateLimits.test.ts
+++ b/apps/cnc/src/services/__tests__/capabilityRateLimits.test.ts
@@ -1,0 +1,99 @@
+import {
+  API_RATE_LIMIT_MAX,
+  API_RATE_LIMIT_WINDOW_MS,
+  AUTH_RATE_LIMIT_MAX,
+  AUTH_RATE_LIMIT_WINDOW_MS,
+  LEGACY_AUTH_RATE_LIMIT_MAX,
+  LEGACY_AUTH_RATE_LIMIT_WINDOW_MS,
+  SCHEDULE_RATE_LIMIT_MAX,
+  SCHEDULE_RATE_LIMIT_WINDOW_MS,
+} from '../../middleware/rateLimiter';
+import {
+  MAC_VENDOR_RATE_LIMIT_MAX_CALLS,
+  MAC_VENDOR_RATE_LIMIT_MS,
+} from '../macVendorService';
+import { buildCncRateLimits } from '../capabilityRateLimits';
+
+describe('buildCncRateLimits', () => {
+  const originalWsMessageLimit = process.env.WS_MESSAGE_RATE_LIMIT_PER_SECOND;
+  const originalWsConnectionLimit = process.env.WS_MAX_CONNECTIONS_PER_IP;
+
+  beforeEach(() => {
+    delete process.env.WS_MESSAGE_RATE_LIMIT_PER_SECOND;
+    delete process.env.WS_MAX_CONNECTIONS_PER_IP;
+  });
+
+  afterAll(() => {
+    if (originalWsMessageLimit === undefined) {
+      delete process.env.WS_MESSAGE_RATE_LIMIT_PER_SECOND;
+    } else {
+      process.env.WS_MESSAGE_RATE_LIMIT_PER_SECOND = originalWsMessageLimit;
+    }
+
+    if (originalWsConnectionLimit === undefined) {
+      delete process.env.WS_MAX_CONNECTIONS_PER_IP;
+    } else {
+      process.env.WS_MAX_CONNECTIONS_PER_IP = originalWsConnectionLimit;
+    }
+  });
+
+  it('builds rate-limit descriptors for all CNC limiters', () => {
+    const limits = buildCncRateLimits();
+
+    expect(limits.strictAuth).toMatchObject({
+      maxCalls: AUTH_RATE_LIMIT_MAX,
+      windowMs: AUTH_RATE_LIMIT_WINDOW_MS,
+      scope: 'ip',
+    });
+    expect(limits.auth).toMatchObject({
+      maxCalls: LEGACY_AUTH_RATE_LIMIT_MAX,
+      windowMs: LEGACY_AUTH_RATE_LIMIT_WINDOW_MS,
+      scope: 'ip',
+    });
+    expect(limits.api).toMatchObject({
+      maxCalls: API_RATE_LIMIT_MAX,
+      windowMs: API_RATE_LIMIT_WINDOW_MS,
+      scope: 'ip',
+    });
+    expect(limits.scheduleSync).toMatchObject({
+      maxCalls: SCHEDULE_RATE_LIMIT_MAX,
+      windowMs: SCHEDULE_RATE_LIMIT_WINDOW_MS,
+      scope: 'ip',
+    });
+    expect(limits.wsInboundMessages).toMatchObject({
+      maxCalls: 100,
+      windowMs: 1000,
+      scope: 'connection',
+    });
+    expect(limits.wsConnectionsPerIp).toMatchObject({
+      maxCalls: 10,
+      windowMs: null,
+      scope: 'ip',
+    });
+    expect(limits.macVendorLookup).toMatchObject({
+      maxCalls: MAC_VENDOR_RATE_LIMIT_MAX_CALLS,
+      windowMs: MAC_VENDOR_RATE_LIMIT_MS,
+      scope: 'global',
+    });
+  });
+
+  it('uses explicit WS env values when provided', () => {
+    process.env.WS_MESSAGE_RATE_LIMIT_PER_SECOND = '250';
+    process.env.WS_MAX_CONNECTIONS_PER_IP = '42';
+
+    const limits = buildCncRateLimits();
+
+    expect(limits.wsInboundMessages.maxCalls).toBe(250);
+    expect(limits.wsConnectionsPerIp.maxCalls).toBe(42);
+  });
+
+  it('falls back to defaults when WS env values are invalid', () => {
+    process.env.WS_MESSAGE_RATE_LIMIT_PER_SECOND = '-1';
+    process.env.WS_MAX_CONNECTIONS_PER_IP = 'not-a-number';
+
+    const limits = buildCncRateLimits();
+
+    expect(limits.wsInboundMessages.maxCalls).toBe(100);
+    expect(limits.wsConnectionsPerIp.maxCalls).toBe(10);
+  });
+});

--- a/apps/cnc/src/services/capabilityRateLimits.ts
+++ b/apps/cnc/src/services/capabilityRateLimits.ts
@@ -1,0 +1,84 @@
+import type { CncRateLimits } from '@kaonis/woly-protocol';
+import {
+  API_RATE_LIMIT_MAX,
+  API_RATE_LIMIT_WINDOW_MS,
+  AUTH_RATE_LIMIT_MAX,
+  AUTH_RATE_LIMIT_WINDOW_MS,
+  LEGACY_AUTH_RATE_LIMIT_MAX,
+  LEGACY_AUTH_RATE_LIMIT_WINDOW_MS,
+  SCHEDULE_RATE_LIMIT_MAX,
+  SCHEDULE_RATE_LIMIT_WINDOW_MS,
+} from '../middleware/rateLimiter';
+import {
+  MAC_VENDOR_RATE_LIMIT_MAX_CALLS,
+  MAC_VENDOR_RATE_LIMIT_MS,
+} from './macVendorService';
+
+const DEFAULT_WS_MESSAGE_RATE_LIMIT_PER_SECOND = 100;
+const DEFAULT_WS_MAX_CONNECTIONS_PER_IP = 10;
+
+function parsePositiveIntFromEnv(key: string, fallback: number): number {
+  const rawValue = process.env[key];
+  if (!rawValue || rawValue.trim().length === 0) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export function buildCncRateLimits(): CncRateLimits {
+  return {
+    strictAuth: {
+      maxCalls: AUTH_RATE_LIMIT_MAX,
+      windowMs: AUTH_RATE_LIMIT_WINDOW_MS,
+      scope: 'ip',
+      appliesTo: ['/api/auth/token'],
+    },
+    auth: {
+      maxCalls: LEGACY_AUTH_RATE_LIMIT_MAX,
+      windowMs: LEGACY_AUTH_RATE_LIMIT_WINDOW_MS,
+      scope: 'ip',
+      note: 'Defined in middleware for legacy auth route patterns; strictAuth is currently applied to /api/auth/token.',
+    },
+    api: {
+      maxCalls: API_RATE_LIMIT_MAX,
+      windowMs: API_RATE_LIMIT_WINDOW_MS,
+      scope: 'ip',
+      appliesTo: ['/api/capabilities', '/api/nodes/*', '/api/hosts/*', '/api/admin/*'],
+    },
+    scheduleSync: {
+      maxCalls: SCHEDULE_RATE_LIMIT_MAX,
+      windowMs: SCHEDULE_RATE_LIMIT_WINDOW_MS,
+      scope: 'ip',
+      appliesTo: ['/api/hosts/:fqn/schedules', '/api/hosts/schedules/:id'],
+    },
+    wsInboundMessages: {
+      maxCalls: parsePositiveIntFromEnv(
+        'WS_MESSAGE_RATE_LIMIT_PER_SECOND',
+        DEFAULT_WS_MESSAGE_RATE_LIMIT_PER_SECOND,
+      ),
+      windowMs: 1000,
+      scope: 'connection',
+      appliesTo: ['/ws/node'],
+    },
+    wsConnectionsPerIp: {
+      maxCalls: parsePositiveIntFromEnv('WS_MAX_CONNECTIONS_PER_IP', DEFAULT_WS_MAX_CONNECTIONS_PER_IP),
+      windowMs: null,
+      scope: 'ip',
+      appliesTo: ['/ws/node'],
+      note: 'Concurrent connection cap per source IP.',
+    },
+    macVendorLookup: {
+      maxCalls: MAC_VENDOR_RATE_LIMIT_MAX_CALLS,
+      windowMs: MAC_VENDOR_RATE_LIMIT_MS,
+      scope: 'global',
+      appliesTo: ['/api/hosts/mac-vendor/:mac'],
+      note: 'Serialized outbound provider requests to avoid macvendors.com free-tier throttling.',
+    },
+  };
+}

--- a/apps/cnc/src/services/macVendorService.ts
+++ b/apps/cnc/src/services/macVendorService.ts
@@ -47,7 +47,8 @@ function normalizeMac(mac: string): string {
 
 // --- Rate limiting ---
 
-const RATE_LIMIT_MS = 1000; // 1 second between external API calls
+export const MAC_VENDOR_RATE_LIMIT_MS = 1000; // 1 second between external API calls
+export const MAC_VENDOR_RATE_LIMIT_MAX_CALLS = 1;
 let lastRequestTime = 0;
 let requestQueue: Promise<unknown> = Promise.resolve();
 
@@ -80,8 +81,8 @@ export async function lookupMacVendor(mac: string): Promise<MacVendorResponse> {
     // Rate limiting
     const now = Date.now();
     const timeSinceLast = now - lastRequestTime;
-    if (timeSinceLast < RATE_LIMIT_MS) {
-      const waitTime = RATE_LIMIT_MS - timeSinceLast;
+    if (timeSinceLast < MAC_VENDOR_RATE_LIMIT_MS) {
+      const waitTime = MAC_VENDOR_RATE_LIMIT_MS - timeSinceLast;
       logger.debug('Throttling MAC vendor request', { mac, waitTime });
       await new Promise((resolve) => setTimeout(resolve, waitTime));
     }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -72,6 +72,26 @@ export interface CncCapabilityDescriptor {
   note?: string;
 }
 
+export type CncRateLimitScope = 'ip' | 'connection' | 'global';
+
+export interface CncRateLimitDescriptor {
+  maxCalls: number;
+  windowMs: number | null;
+  scope: CncRateLimitScope;
+  appliesTo?: string[];
+  note?: string;
+}
+
+export interface CncRateLimits {
+  strictAuth: CncRateLimitDescriptor;
+  auth: CncRateLimitDescriptor;
+  api: CncRateLimitDescriptor;
+  scheduleSync: CncRateLimitDescriptor;
+  wsInboundMessages: CncRateLimitDescriptor;
+  wsConnectionsPerIp: CncRateLimitDescriptor;
+  macVendorLookup: CncRateLimitDescriptor;
+}
+
 export interface CncCapabilitiesResponse {
   mode: 'cnc';
   versions: {
@@ -84,6 +104,7 @@ export interface CncCapabilitiesResponse {
     schedules: CncCapabilityDescriptor;
     commandStatusStreaming: CncCapabilityDescriptor;
   };
+  rateLimits?: CncRateLimits;
 }
 
 export interface HostPort {
@@ -298,6 +319,24 @@ export const cncCapabilityDescriptorSchema: z.ZodType<CncCapabilityDescriptor> =
   note: z.string().min(1).optional(),
 });
 
+export const cncRateLimitDescriptorSchema: z.ZodType<CncRateLimitDescriptor> = z.object({
+  maxCalls: z.number().int().positive(),
+  windowMs: z.number().int().positive().nullable(),
+  scope: z.enum(['ip', 'connection', 'global']),
+  appliesTo: z.array(z.string().min(1)).optional(),
+  note: z.string().min(1).optional(),
+});
+
+export const cncRateLimitsSchema: z.ZodType<CncRateLimits> = z.object({
+  strictAuth: cncRateLimitDescriptorSchema,
+  auth: cncRateLimitDescriptorSchema,
+  api: cncRateLimitDescriptorSchema,
+  scheduleSync: cncRateLimitDescriptorSchema,
+  wsInboundMessages: cncRateLimitDescriptorSchema,
+  wsConnectionsPerIp: cncRateLimitDescriptorSchema,
+  macVendorLookup: cncRateLimitDescriptorSchema,
+});
+
 export const cncCapabilitiesResponseSchema: z.ZodType<CncCapabilitiesResponse> = z.object({
   mode: z.literal('cnc'),
   versions: z.object({
@@ -310,6 +349,7 @@ export const cncCapabilitiesResponseSchema: z.ZodType<CncCapabilitiesResponse> =
     schedules: cncCapabilityDescriptorSchema,
     commandStatusStreaming: cncCapabilityDescriptorSchema,
   }),
+  rateLimits: cncRateLimitsSchema.optional(),
 });
 
 export const hostPortScanResultSchema: z.ZodType<HostPortScanResult> = z.object({


### PR DESCRIPTION
## Summary
- add protocol contract support for CNC `rateLimits` descriptors in `CncCapabilitiesResponse`
- expose effective CNC limiter budgets through `/api/capabilities` via `MetaController`
- include HTTP, websocket, and MAC-vendor throttling descriptors (count + window, with `windowMs: null` for concurrent caps)
- add protocol/backend test coverage for schema + capabilities payload compatibility

## CNC Sync Classification
- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)
- Protocol issue: kaonis/woly-server#293
- Backend issue: kaonis/woly-server#294
- Frontend issue: kaonis/woly#365

## 3-Part Chain Checklist (required for CNC feature changes)
- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates
- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Local Validation (required for CNC feature changes)
Commands run:
```bash
npm ci
npm run build -w packages/protocol
npm run test -w packages/protocol -- contract.cross-repo
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run validate:standard
```

Result summary:
- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- `authLimiter` is currently defined but not mounted on active CNC routes; it is still exposed in `rateLimits` with an explanatory note to make the limiter inventory explicit.
