### PR TITLE
#296 Mirror Worktree-First + Review Pass workflow docs from woly into woly-server

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,13 +4,19 @@
 
 Monorepo for the WoLy distributed Wake-on-LAN system. Contains two backend services and a shared protocol package, managed with npm workspaces and Turborepo.
 
-| Workspace | Description | Port | Database |
-|---|---|---|---|
-| `apps/node-agent` | Per-LAN WoL agent — ARP scanning, host discovery, magic packets | 8082 | SQLite (better-sqlite3) |
-| `apps/cnc` | C&C aggregator — multi-node management, command routing, JWT auth | 8080 | PostgreSQL or SQLite |
-| `packages/protocol` | Shared types & Zod schemas (`@kaonis/woly-protocol`) | — | — |
+| Workspace           | Description                                                       | Port | Database                |
+| ------------------- | ----------------------------------------------------------------- | ---- | ----------------------- |
+| `apps/node-agent`   | Per-LAN WoL agent — ARP scanning, host discovery, magic packets   | 8082 | SQLite (better-sqlite3) |
+| `apps/cnc`          | C&C aggregator — multi-node management, command routing, JWT auth | 8080 | PostgreSQL or SQLite    |
+| `packages/protocol` | Shared types & Zod schemas (`@kaonis/woly-protocol`)              | —    | —                       |
 
 **Stack:** Node.js 24, TypeScript 5.9 (strict), Express 5, Jest 30, Zod, Turborepo.
+
+## Mandatory Workflow Gates
+
+- Start work from a fresh worktree based on `origin/master` before any modifications or branch creation.
+- Complete a final review pass for every change before merge (peer review preferred; self-review required at minimum).
+- Address all review comments/threads with follow-up commits or explicit rationale, then re-review the updated diff.
 
 ## Workspace Layout
 
@@ -155,12 +161,12 @@ ws://  /ws/node                  WebSocket for node connections
 
 Each app has `.env.example` with all available options. Key differences:
 
-| Variable | Node Agent | C&C |
-|---|---|---|
-| Port | `PORT=8082` | `PORT=8080` |
-| Database | `DB_PATH=./db/woly.db` (SQLite) | `DB_TYPE=sqlite\|postgres`, `DATABASE_URL` |
-| Auth | `NODE_AUTH_TOKEN` (for agent mode) | `NODE_AUTH_TOKENS`, `JWT_SECRET` |
-| Network | `SCAN_INTERVAL`, `PING_TIMEOUT` | `NODE_HEARTBEAT_INTERVAL`, `NODE_TIMEOUT` |
+| Variable | Node Agent                         | C&C                                        |
+| -------- | ---------------------------------- | ------------------------------------------ |
+| Port     | `PORT=8082`                        | `PORT=8080`                                |
+| Database | `DB_PATH=./db/woly.db` (SQLite)    | `DB_TYPE=sqlite\|postgres`, `DATABASE_URL` |
+| Auth     | `NODE_AUTH_TOKEN` (for agent mode) | `NODE_AUTH_TOKENS`, `JWT_SECRET`           |
+| Network  | `SCAN_INTERVAL`, `PING_TIMEOUT`    | `NODE_HEARTBEAT_INTERVAL`, `NODE_TIMEOUT`  |
 
 ## Docker
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,41 @@
 ## CNC Sync Classification
+
 - [ ] This PR is a CNC feature change.
 
 ## Linked Issues (required when CNC feature checkbox is checked)
+
 - Protocol issue: kaonis/woly-server#REQUIRED
 - Backend issue: kaonis/woly-server#REQUIRED
 - Frontend issue: kaonis/woly#REQUIRED
 
 ## 3-Part Chain Checklist (required for CNC feature changes)
+
 - [ ] Protocol contract updated or verified.
 - [ ] Backend endpoint/command implemented or explicitly unchanged.
 - [ ] Frontend integration implemented or tracked in linked issue.
 
 ## Ordering Gates
+
 - [ ] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
 - [ ] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.
 
+## Review Pass (required for all PRs)
+
+- [ ] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
+- [ ] I reviewed the final diff for correctness, scope control, and regression risk.
+- [ ] I addressed all review comments/threads with follow-up commits or explicit rationale.
+- [ ] I re-reviewed the updated diff after applying review feedback.
+
 ## Local Validation (required for CNC feature changes)
+
 Commands run:
+
 ```bash
 # paste exact commands
 ```
 
 Result summary:
+
 - [ ] Local validation passed
 - [ ] Any known gaps are documented below
 

--- a/README.md
+++ b/README.md
@@ -81,26 +81,55 @@ npm run test -w apps/node-agent
 npm run build -w packages/protocol
 ```
 
+## Contribution Workflow (Worktree-First)
+
+Before editing files or creating an implementation branch, start from a fresh worktree based on `origin/master`:
+
+```bash
+git fetch origin
+git worktree add ../woly-server-<topic> -b codex/<issue>-<topic> origin/master
+cd ../woly-server-<topic>
+```
+
+Use that worktree for all edits, commits, and PR preparation. This keeps feature work isolated and ensures branch bases are current.
+For Codex-created branches, keep the `codex/` prefix; for manually created contributor branches, use your normal branch prefix.
+
+Before merge, run a required review pass for every change (peer review preferred; self-review required at minimum):
+
+```bash
+git diff --stat origin/master...HEAD
+git diff origin/master...HEAD
+gh pr view --comments
+```
+
+Address every review comment/thread with follow-up commits or an explicit rationale, then re-run the review pass on the updated diff.
+
+After merge, clean up the temporary worktree:
+
+```bash
+git worktree remove ../woly-server-<topic>
+```
+
 ## Commands
 
-| Command | Description |
-|---|---|
-| `npm run build` | Build all workspaces (protocol → apps) |
-| `npm run test` | Run all tests |
-| `npm run test:ci` | CI mode with coverage |
-| `npm run test:e2e:smoke` | Run cross-service C&C <-> node-agent E2E smoke suite |
-| `npm run validate:standard` | Run standard repo validation gate (`lint`, `typecheck`, `test:ci`, `build`, smoke) |
-| `npm run typecheck` | Type-check all workspaces |
-| `npm run lint` | Lint all workspaces |
-| `npm run dev:node-agent` | Start node agent in dev mode |
-| `npm run dev:cnc` | Start C&C backend in dev mode |
-| `npm run format` | Format all files with Prettier |
-| `npm run protocol:build` | Build the protocol package |
-| `npm run protocol:publish` | Build and publish protocol to npm (latest tag) |
-| `npm run protocol:publish:next` | Build and publish protocol to npm (next tag) |
-| `npm run protocol:version:patch` | Bump protocol version (patch) |
-| `npm run protocol:version:minor` | Bump protocol version (minor) |
-| `npm run protocol:version:major` | Bump protocol version (major) |
+| Command                          | Description                                                                        |
+| -------------------------------- | ---------------------------------------------------------------------------------- |
+| `npm run build`                  | Build all workspaces (protocol → apps)                                             |
+| `npm run test`                   | Run all tests                                                                      |
+| `npm run test:ci`                | CI mode with coverage                                                              |
+| `npm run test:e2e:smoke`         | Run cross-service C&C <-> node-agent E2E smoke suite                               |
+| `npm run validate:standard`      | Run standard repo validation gate (`lint`, `typecheck`, `test:ci`, `build`, smoke) |
+| `npm run typecheck`              | Type-check all workspaces                                                          |
+| `npm run lint`                   | Lint all workspaces                                                                |
+| `npm run dev:node-agent`         | Start node agent in dev mode                                                       |
+| `npm run dev:cnc`                | Start C&C backend in dev mode                                                      |
+| `npm run format`                 | Format all files with Prettier                                                     |
+| `npm run protocol:build`         | Build the protocol package                                                         |
+| `npm run protocol:publish`       | Build and publish protocol to npm (latest tag)                                     |
+| `npm run protocol:publish:next`  | Build and publish protocol to npm (next tag)                                       |
+| `npm run protocol:version:patch` | Bump protocol version (patch)                                                      |
+| `npm run protocol:version:minor` | Bump protocol version (minor)                                                      |
+| `npm run protocol:version:major` | Bump protocol version (major)                                                      |
 
 ## Node Agent
 
@@ -139,17 +168,20 @@ Runs on port 8080 by default. See [apps/cnc/README.md](apps/cnc/README.md) for f
 Both apps consume it via npm workspace link. It's also published to npm for the mobile app. See [packages/protocol/README.md](packages/protocol/README.md).
 
 Upgrade sequencing and compatibility requirements are documented in:
+
 - [docs/compatibility.md](docs/compatibility.md)
 - [docs/PROTOCOL_COMPATIBILITY.md](docs/PROTOCOL_COMPATIBILITY.md)
 
 ## CNC Sync Policy (Budget Mode)
 
 This repo and the mobile app (`kaonis/woly`) follow a shared CNC sync process:
+
 1. Protocol contract
 2. Backend endpoint/command
 3. Frontend integration
 
 Policy docs:
+
 - [docs/CNC_SYNC_POLICY.md](docs/CNC_SYNC_POLICY.md)
 - [docs/ROADMAP_CNC_SYNC_V1.md](docs/ROADMAP_CNC_SYNC_V1.md)
 - [woly/docs/CNC_SYNC_POLICY.md](https://github.com/kaonis/woly/blob/master/docs/CNC_SYNC_POLICY.md)
@@ -192,12 +224,14 @@ docker run -d --net host \
 ```
 
 For full production rollout guidance (topology, secrets, TLS, backup/restore, and rollback):
+
 - [docs/PRODUCTION_DEPLOYMENT_GUIDE.md](docs/PRODUCTION_DEPLOYMENT_GUIDE.md)
 - [docs/COMMAND_OUTCOME_METRICS.md](docs/COMMAND_OUTCOME_METRICS.md)
 
 ## CI
 
 GitHub Actions is budget-scoped:
+
 - Heavy validation workflow (`.github/workflows/ci.yml`) runs manual-only.
 - Lightweight policy workflow (`.github/workflows/cnc-sync-policy.yml`) runs automatically on PR updates.
 
@@ -209,6 +243,7 @@ Current validation flow:
 4. Upload coverage reports as artifacts when `ci.yml` is manually dispatched
 
 Required local gate before PR merge:
+
 - `npm ci`
 - `npm run build -w packages/protocol`
 - `npm run test -w packages/protocol -- contract.cross-repo`
@@ -216,14 +251,17 @@ Required local gate before PR merge:
 - `npm run validate:standard`
 
 Manual operations and rollback criteria are documented in:
+
 - [docs/CI_MANUAL_OPERATIONS.md](docs/CI_MANUAL_OPERATIONS.md)
 - [docs/CI_MANUAL_REVIEW_LOG.md](docs/CI_MANUAL_REVIEW_LOG.md)
 - [docs/CROSS_SERVICE_E2E_SMOKE.md](docs/CROSS_SERVICE_E2E_SMOKE.md)
 
 Main workflow definition:
+
 - [.github/workflows/ci.yml](.github/workflows/ci.yml)
 
 Dependency update review cadence and decision rules are documented in:
+
 - [docs/DEPENDENCY_TRIAGE_WORKFLOW.md](docs/DEPENDENCY_TRIAGE_WORKFLOW.md)
 - [docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md](docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md)
 
@@ -231,15 +269,15 @@ Dependency update review cadence and decision rules are documented in:
 
 ## Tech Stack
 
-| Layer | Technology |
-|---|---|
-| Runtime | Node.js 24, TypeScript 5.9 |
-| Framework | Express 5 |
-| Databases | SQLite (better-sqlite3), PostgreSQL |
-| Testing | Jest 30, Supertest |
-| Validation | Zod, Joi |
-| Build | Turborepo, tsc |
-| CI | GitHub Actions |
+| Layer      | Technology                          |
+| ---------- | ----------------------------------- |
+| Runtime    | Node.js 24, TypeScript 5.9          |
+| Framework  | Express 5                           |
+| Databases  | SQLite (better-sqlite3), PostgreSQL |
+| Testing    | Jest 30, Supertest                  |
+| Validation | Zod, Joi                            |
+| Build      | Turborepo, tsc                      |
+| CI         | GitHub Actions                      |
 
 ## Contributing
 

--- a/docs/CNC_SYNC_POLICY.md
+++ b/docs/CNC_SYNC_POLICY.md
@@ -3,18 +3,23 @@
 This policy keeps `woly` and `woly-server` synchronized in CNC mode while minimizing GitHub Actions spend.
 
 ## 1. Mandatory Feature Chain
+
 Every CNC feature must be shipped as a linked 3-part chain:
+
 1. Protocol contract (`packages/protocol`)
 2. Backend endpoint/command (`apps/cnc`)
 3. Frontend integration (`kaonis/woly`)
 
 ## 2. Mandatory Linked Issues
+
 Each CNC feature PR must link all of the following:
+
 - Protocol issue: `kaonis/woly-server#...`
 - Backend issue: `kaonis/woly-server#...`
 - Frontend issue: `kaonis/woly#...`
 
 ## 3. Ordering Rules
+
 - Capability negotiation first: `kaonis/woly-server#254`.
 - Do not remove/de-scope standalone probing (`kaonis/woly#307`) until parity issues are complete:
   - `kaonis/woly-server#253`
@@ -26,11 +31,14 @@ Each CNC feature PR must link all of the following:
   - `kaonis/woly-server#257`
 
 ## 4. CI Budget Rule
+
 GitHub Actions runs only bare-minimum policy checks on pull requests.
 Heavy validation runs locally before merge.
 
 ## 5. Required Local Pre-Merge Gates
+
 ### In `woly-server`
+
 ```bash
 npm ci
 npm run build -w packages/protocol
@@ -40,6 +48,7 @@ npm run validate:standard
 ```
 
 ### In `woly`
+
 ```bash
 npm ci --legacy-peer-deps
 npm run typecheck
@@ -47,8 +56,15 @@ npm run test:ci:coverage
 ```
 
 ## 6. Evidence Required in PR
+
 Each CNC feature PR must include:
+
 - Linked protocol/backend/frontend issue refs
 - Checked 3-part chain checklist
+- Checked Review Pass checklist
 - Exact local commands run
 - Pass/fail summary from local validation
+
+## 7. Review Pass Requirement
+
+Every PR must complete a final review pass before merge (peer review preferred; self-review required at minimum), and all review comments/threads must be resolved with follow-up commits or explicit rationale.


### PR DESCRIPTION
Implements #296 by mirroring the Worktree-First and required Review Pass workflow documentation into woly-server docs/policy surfaces.

## CNC Sync Classification
- [ ] This PR is a CNC feature change.

## Review Pass (required for all PRs)
- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Notes
- Non-CNC docs/policy update.
