### PR TITLE
#301 [Security] Add staged secret scanning in pre-commit with Gitleaks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npm run secrets:scan:staged
+lint-staged --stash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,20 @@ cp apps/cnc/.env.example apps/cnc/.env
 3. Run `npm run build && npm run typecheck && npm run test` to verify
 4. Push and open a PR against `master`
 
+## Git Hooks and Commit Policy
+
+Local hooks are managed by Husky (`npm install` runs `npm run prepare`):
+
+- `pre-commit`: staged secret scan (`gitleaks`) + `lint-staged`.
+- `pre-push`: `npm run prepush:checks` (`typecheck` + related Jest tests).
+- `commit-msg`: commit message linting via `commitlint` (Conventional Commits).
+
+Install `gitleaks` locally so `pre-commit` can run:
+
+```bash
+brew install gitleaks
+```
+
 ## CNC Mode Sync Requirements
 
 For CNC feature work, follow `docs/CNC_SYNC_POLICY.md`.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "prepush:checks": "node scripts/pre-push-checks.mjs",
+    "secrets:scan:staged": "sh ./scripts/run-gitleaks-staged.sh",
     "dev:node-agent": "turbo run dev --filter=@woly-server/node-agent",
     "dev:cnc": "turbo run dev --filter=@woly-server/cnc",
     "format": "prettier --write .",

--- a/scripts/run-gitleaks-staged.sh
+++ b/scripts/run-gitleaks-staged.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+set -eu
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "gitleaks is required for pre-commit secret scanning."
+  echo "Install gitleaks (example on macOS): brew install gitleaks"
+  exit 1
+fi
+
+if gitleaks protect --help >/dev/null 2>&1; then
+  exec gitleaks protect --staged --redact
+fi
+
+if gitleaks git --help >/dev/null 2>&1; then
+  exec gitleaks git --staged --redact .
+fi
+
+echo "Unable to run gitleaks: supported subcommand not found (expected 'protect' or 'git')."
+exit 1


### PR DESCRIPTION
Implements #301 by adding a staged Gitleaks scan in the Husky pre-commit workflow.

## CNC Sync Classification
- [ ] This PR is a CNC feature change.

## Review Pass (required for all PRs)
- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.
