### PR TITLE
docs: require worktree cleanup in AGENTS and copilot policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,7 @@ Monorepo for the WoLy distributed Wake-on-LAN system. Contains two backend servi
 - Start work from a fresh worktree based on `origin/master` before any modifications or branch creation.
 - Complete a final review pass for every change before merge (peer review preferred; self-review required at minimum).
 - Address all review comments/threads with follow-up commits or explicit rationale, then re-review the updated diff.
+- After merge/completion, remove temporary worktrees to avoid stale local clones (for example: `git worktree remove ../woly-server-<topic>`).
 
 ## Workspace Layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Rules:
 - Do not create implementation branches from stale local refs.
 - Perform all edits, commits, and PR prep from the new worktree.
 - Use `codex/` branch prefixes for Codex-authored branches; non-Codex contributors should use the repo's standard branch prefixes.
+- After merge/completion, remove the temporary worktree to avoid stale local clones:
+  - `git worktree remove ../woly-server-<topic>`
 
 ## Review Pass (Required)
 


### PR DESCRIPTION
Closes #314.

Adds explicit cleanup-after-merge/completion requirements to all relevant worktree-policy surfaces that were missing it.

Updated:
- `AGENTS.md`
- `.github/copilot-instructions.md`

Existing coverage already present:
- `README.md` (already had `git worktree remove ...` guidance)

## CNC Sync Classification
- [ ] This PR is a CNC feature change.

## Review Pass (required for all PRs)
- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.
