### PR TITLE
docs: clarify end-to-end worktree flow in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,35 @@ Rules:
 - After merge/completion, remove the temporary worktree to avoid stale local clones:
   - `git worktree remove ../woly-server-<topic>`
 
+## End-to-End Worktree Flow (Required)
+
+Use this full lifecycle for every change:
+
+1. Create a fresh worktree from `origin/master`:
+   ```bash
+   git fetch origin
+   git worktree add ../woly-server-<topic> -b codex/<issue>-<topic> origin/master
+   cd ../woly-server-<topic>
+   ```
+2. Implement and validate in that worktree only.
+3. Complete the required review pass on the final diff:
+   ```bash
+   git diff --stat origin/master...HEAD
+   git diff origin/master...HEAD
+   gh pr view --comments
+   ```
+4. Push branch and open/update PR from that same worktree.
+5. Address review feedback in the same worktree, then re-run the review pass.
+6. After merge or explicit cancellation, clean up worktree from the primary checkout:
+   ```bash
+   cd /Users/phantom/projects/woly-server
+   git worktree remove ../woly-server-<topic>
+   ```
+7. Delete leftover local branch only after cleanup if it still exists:
+   ```bash
+   git branch -D codex/<issue>-<topic>
+   ```
+
 ## Review Pass (Required)
 
 Every change (code, docs, config, workflows) must complete a review pass before merge.


### PR DESCRIPTION
Updates `AGENTS.md` to document the complete required worktree lifecycle end-to-end:
- create fresh worktree from `origin/master`
- implement/validate in that worktree
- run review pass
- push/open PR
- address feedback in same worktree
- cleanup worktree after merge/cancellation
- delete leftover local branch

This makes cleanup explicit as part of the required flow and reduces stale/leftover worktrees.

## CNC Sync Classification
- [ ] This PR is a CNC feature change.

## Review Pass (required for all PRs)
- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.
