### PR TITLE
test: self-heal app preflight by ensuring protocol artifacts

### DIFF
--- a/apps/cnc/scripts/test-preflight.js
+++ b/apps/cnc/scripts/test-preflight.js
@@ -7,6 +7,16 @@ if (major < 24) {
 }
 
 try {
+  const { ensureProtocolBuild } = require('../../../scripts/ensure-protocol-build.cjs');
+  ensureProtocolBuild();
+} catch (error) {
+  const message = error && error.message ? error.message : String(error);
+  console.error('[preflight] Protocol preflight failed.');
+  console.error(`[preflight] ${message}`);
+  process.exit(1);
+}
+
+try {
   require('better-sqlite3');
   process.stdout.write('[preflight] Runtime checks passed.\n');
 } catch (error) {

--- a/apps/node-agent/scripts/test-preflight.js
+++ b/apps/node-agent/scripts/test-preflight.js
@@ -18,6 +18,16 @@ server.once('error', (error) => {
 server.listen(0, '127.0.0.1', () => {
   server.close(() => {
     try {
+      const { ensureProtocolBuild } = require('../../../scripts/ensure-protocol-build.cjs');
+      ensureProtocolBuild();
+    } catch (error) {
+      const message = error && error.message ? error.message : String(error);
+      console.error('[preflight] Protocol preflight failed.');
+      console.error(`[preflight] ${message}`);
+      process.exit(1);
+    }
+
+    try {
       require('better-sqlite3');
       process.stdout.write('[preflight] Runtime checks passed.\n');
     } catch (error) {

--- a/docs/TEST_COVERAGE_INVESTIGATION_2026-02-18.md
+++ b/docs/TEST_COVERAGE_INVESTIGATION_2026-02-18.md
@@ -1,0 +1,79 @@
+# Test Coverage Investigation (2026-02-18)
+
+## Scope
+
+Monorepo coverage and test-chain reliability audit for:
+
+- `packages/protocol`
+- `apps/cnc`
+- `apps/node-agent`
+
+## Reproduction commands
+
+```bash
+npm ci
+npm run test:ci --workspace=@kaonis/woly-protocol -- --coverageReporters=json-summary --coverageReporters=text
+npm run test:ci --workspace=@woly-server/cnc -- --coverageReporters=json-summary --coverageReporters=text
+npm run test:ci --workspace=@woly-server/node-agent -- --coverageReporters=json-summary --coverageReporters=text
+```
+
+Note: app suite runs initially failed in a fresh clone until `npm run build -w packages/protocol` was executed.
+
+## Coverage baseline
+
+| Workspace           | Statements | Branches | Functions |   Lines |
+| ------------------- | ---------: | -------: | --------: | ------: |
+| `packages/protocol` |    100.00% |  100.00% |   100.00% | 100.00% |
+| `apps/cnc`          |     83.88% |   73.76% |    86.96% |  84.12% |
+| `apps/node-agent`   |     86.52% |   75.00% |    89.60% |  86.50% |
+
+## Key findings
+
+1. **Test-chain reliability gap**
+   - Fresh-clone app tests require built protocol artifacts but do not ensure they exist.
+   - Symptom: `TS2307 Cannot find module '@kaonis/woly-protocol'` in CNC and node-agent suites.
+2. **CNC branch hot spots**
+   - Zero-coverage bootstrap/controller files (`src/init-db.ts`, `src/server.ts`, `src/controllers/capabilities.ts`).
+   - Low branch coverage in schedule and websocket paths.
+3. **Node-agent branch hot spots**
+   - Reliability/transport modules (`src/services/agentService.ts`, `src/services/cncClient.ts`) have the largest branch gaps.
+
+## Issue tracking
+
+- #317: [Testing] Make CNC and node-agent test suites self-contained re: protocol build artifacts
+- #318: [Coverage][CNC] Raise branch coverage in bootstrap/schedule/websocket hotspots
+- #319: [Coverage][Node Agent] Raise branch coverage in command lifecycle and CNC client flows
+
+## Mitigation and implementation plan
+
+### Phase 1: Unblock and stabilize test chain (Issue #317)
+
+- Add protocol-build guard to app preflight scripts.
+- Keep preflight incremental by rebuilding protocol only when artifacts are missing or stale.
+- Verify both app suites pass from clean clone with only `npm ci`.
+
+### Phase 2: CNC coverage uplift (Issue #318)
+
+- Add tests for zero-coverage bootstrap/capabilities paths.
+- Add branch-focused tests for schedule model/controller and websocket upgrade/error paths.
+- Target CNC branches: 73.76% -> >=78%.
+
+### Phase 3: Node-agent coverage uplift (Issue #319)
+
+- Add branch-focused tests for `agentService` reliability paths and `cncClient` reconnect/auth transitions.
+- Add small utility branch tests only where meaningful.
+- Target node-agent branches: 75.00% -> >=80%.
+
+## PR sequence
+
+1. PR-A: implement Issue #317 (test-chain reliability fix).
+2. PR-B: implement first CNC uplift slice (schedule + capabilities focus).
+3. PR-C: implement node-agent reliability/transport branch uplift.
+
+Each PR should complete the required review pass:
+
+```bash
+git diff --stat origin/master...HEAD
+git diff origin/master...HEAD
+gh pr view --comments
+```

--- a/scripts/ensure-protocol-build.cjs
+++ b/scripts/ensure-protocol-build.cjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const repoRoot = path.resolve(__dirname, "..");
+const protocolRoot = path.join(repoRoot, "packages", "protocol");
+
+const protocolDistEntrypoints = [
+  path.join(protocolRoot, "dist", "index.js"),
+  path.join(protocolRoot, "dist", "index.d.ts"),
+];
+
+const protocolSourceRoots = [
+  path.join(protocolRoot, "src"),
+  path.join(protocolRoot, "package.json"),
+  path.join(protocolRoot, "tsconfig.json"),
+];
+
+function pathExists(filepath) {
+  try {
+    fs.accessSync(filepath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getLatestMtimeMs(filepath) {
+  const stats = fs.statSync(filepath);
+  if (!stats.isDirectory()) {
+    return stats.mtimeMs;
+  }
+
+  let latest = stats.mtimeMs;
+  const entries = fs.readdirSync(filepath, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(filepath, entry.name);
+    latest = Math.max(latest, getLatestMtimeMs(entryPath));
+  }
+
+  return latest;
+}
+
+function buildProtocolWorkspace() {
+  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+  const result = spawnSync(
+    npmCommand,
+    ["run", "build", "--workspace=@kaonis/woly-protocol"],
+    {
+      cwd: repoRoot,
+      stdio: "inherit",
+    }
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function shouldBuildProtocol() {
+  if (protocolDistEntrypoints.some((filepath) => !pathExists(filepath))) {
+    return true;
+  }
+
+  const newestSourceMtime = protocolSourceRoots.reduce((latest, filepath) => {
+    if (!pathExists(filepath)) {
+      return latest;
+    }
+
+    return Math.max(latest, getLatestMtimeMs(filepath));
+  }, 0);
+
+  const oldestDistMtime = protocolDistEntrypoints.reduce((oldest, filepath) => {
+    const mtime = getLatestMtimeMs(filepath);
+    return Math.min(oldest, mtime);
+  }, Number.POSITIVE_INFINITY);
+
+  return newestSourceMtime > oldestDistMtime;
+}
+
+function ensureProtocolBuild() {
+  if (!shouldBuildProtocol()) {
+    return;
+  }
+
+  process.stdout.write(
+    "[preflight] Protocol artifacts missing or stale; building @kaonis/woly-protocol...\n"
+  );
+  buildProtocolWorkspace();
+}
+
+module.exports = {
+  ensureProtocolBuild,
+};
+
+if (require.main === module) {
+  ensureProtocolBuild();
+}


### PR DESCRIPTION
## CNC Sync Classification

- [ ] This PR is a CNC feature change.

## Summary

- add a shared preflight helper (`scripts/ensure-protocol-build.cjs`) that builds `@kaonis/woly-protocol` only when protocol `dist` artifacts are missing or stale
- wire CNC and node-agent test preflight scripts to call this helper before runtime checks
- add coverage investigation + mitigation plan document with current baseline and follow-up issue tracking

## Why

Fresh-clone app test runs failed in both `apps/cnc` and `apps/node-agent` with `TS2307` errors until a manual protocol build was run. This change makes app test commands self-contained so coverage and test outcomes are reproducible from `npm ci`.

## Validation

- `node apps/cnc/scripts/test-preflight.js` (with protocol `dist` temporarily removed) -> auto-builds protocol and passes
- `node apps/node-agent/scripts/test-preflight.js` (with protocol `dist` temporarily removed) -> auto-builds protocol and passes
- `npm run test:ci --workspace=@woly-server/cnc`
- `npm run test:ci --workspace=@woly-server/node-agent`

## Review Pass

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Linked issues

- Closes #317
- Follow-up: #318
- Follow-up: #319
