### PR TITLE
test(cnc): raise coverage in schedules/capabilities/websocket paths

### DIFF
--- a/apps/cnc/src/controllers/__tests__/capabilities.test.ts
+++ b/apps/cnc/src/controllers/__tests__/capabilities.test.ts
@@ -1,0 +1,140 @@
+import type { Request, Response } from 'express';
+import { SUPPORTED_PROTOCOL_VERSIONS } from '@kaonis/woly-protocol';
+import { buildCncCapabilitiesResponse, CapabilitiesController } from '../capabilities';
+import logger from '../../utils/logger';
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+function createMockResponse(): Response {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('CapabilitiesController', () => {
+  const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds a valid capabilities response with explicit versions', () => {
+    const response = buildCncCapabilitiesResponse({
+      cncApi: '1.2.3',
+      protocol: '2.0.0',
+    });
+
+    expect(response.mode).toBe('cnc');
+    expect(response.versions).toEqual({
+      cncApi: '1.2.3',
+      protocol: '2.0.0',
+    });
+    expect(response.capabilities.schedules.routes).toEqual(['/api/schedules', '/api/schedules/:id']);
+  });
+
+  it('falls back and logs warnings when versions are invalid', () => {
+    const fallbackProtocol = Array.isArray(SUPPORTED_PROTOCOL_VERSIONS)
+      ? (SUPPORTED_PROTOCOL_VERSIONS.find((version) => typeof version === 'string' && version.trim()) ?? '1.0.0')
+      : '1.0.0';
+    const response = buildCncCapabilitiesResponse({
+      cncApi: '   ',
+      protocol: 7,
+    });
+
+    expect(response.versions.cncApi).toBe('0.0.0');
+    expect(response.versions.protocol).toBe(fallbackProtocol);
+    expect(mockedLogger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a 200 capabilities payload for successful requests', async () => {
+    const controller = new CapabilitiesController();
+    const req = {} as Request;
+    const res = createMockResponse();
+
+    await controller.getCapabilities(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(buildCncCapabilitiesResponse());
+  });
+
+  it('returns a 500 response with correlation id when serialization fails', async () => {
+    const controller = new CapabilitiesController();
+    const finalJson = jest.fn();
+    const res = {
+      status: jest.fn((code: number) => {
+        if (code === 200) {
+          return {
+            json: () => {
+              throw new Error('serialization failed');
+            },
+          };
+        }
+        return {
+          json: finalJson,
+        };
+      }),
+    } as unknown as Response;
+    const req = {
+      correlationId: 'corr-capability-failure',
+    } as Request;
+
+    await controller.getCapabilities(req, res);
+
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      'Failed to get capabilities',
+      expect.objectContaining({
+        correlationId: 'corr-capability-failure',
+        error: 'serialization failed',
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(finalJson).toHaveBeenCalledWith({
+      error: 'Internal Server Error',
+      message: 'Failed to retrieve capabilities',
+      correlationId: 'corr-capability-failure',
+    });
+  });
+
+  it('returns a 500 response without correlation id for non-Error failures', async () => {
+    const controller = new CapabilitiesController();
+    const finalJson = jest.fn();
+    const res = {
+      status: jest.fn((code: number) => {
+        if (code === 200) {
+          return {
+            json: () => {
+              throw 'string-failure';
+            },
+          };
+        }
+        return {
+          json: finalJson,
+        };
+      }),
+    } as unknown as Response;
+    const req = {} as Request;
+
+    await controller.getCapabilities(req, res);
+
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      'Failed to get capabilities',
+      expect.objectContaining({
+        correlationId: undefined,
+        error: 'string-failure',
+      }),
+    );
+    expect(finalJson).toHaveBeenCalledWith({
+      error: 'Internal Server Error',
+      message: 'Failed to retrieve capabilities',
+    });
+  });
+});

--- a/apps/cnc/src/controllers/__tests__/schedules.test.ts
+++ b/apps/cnc/src/controllers/__tests__/schedules.test.ts
@@ -1,0 +1,299 @@
+import type { Request, Response } from 'express';
+import type { HostWakeSchedule } from '@kaonis/woly-protocol';
+import { SchedulesController } from '../schedules';
+import HostScheduleModel from '../../models/HostSchedule';
+
+jest.mock('../../models/HostSchedule', () => ({
+  __esModule: true,
+  default: {
+    listByHostFqn: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+function createMockResponse(): Response {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function createMockRequest(options?: {
+  params?: Record<string, string>;
+  body?: Record<string, unknown>;
+}): Request {
+  return {
+    params: options?.params ?? {},
+    body: options?.body ?? {},
+  } as unknown as Request;
+}
+
+function sampleSchedule(overrides: Partial<HostWakeSchedule> = {}): HostWakeSchedule {
+  return {
+    id: 'schedule-1',
+    hostFqn: 'office@home',
+    hostName: 'office',
+    hostMac: 'AA:BB:CC:DD:EE:FF',
+    scheduledTime: '2026-02-20T10:00:00.000Z',
+    frequency: 'daily',
+    enabled: true,
+    notifyOnWake: true,
+    timezone: 'UTC',
+    createdAt: '2026-02-18T00:00:00.000Z',
+    updatedAt: '2026-02-18T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('SchedulesController', () => {
+  const mockedHostScheduleModel = HostScheduleModel as jest.Mocked<typeof HostScheduleModel>;
+
+  let hostAggregator: {
+    getHostByFQN: jest.Mock;
+  };
+  let controller: SchedulesController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hostAggregator = {
+      getHostByFQN: jest.fn(),
+    };
+    controller = new SchedulesController(hostAggregator as unknown as never);
+  });
+
+  describe('listHostSchedules', () => {
+    it('returns 404 when host is not found', async () => {
+      hostAggregator.getHostByFQN.mockResolvedValue(null);
+      const req = createMockRequest({ params: { fqn: 'missing@home' } });
+      const res = createMockResponse();
+
+      await controller.listHostSchedules(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Not Found',
+        message: 'Host missing@home not found',
+      });
+      expect(mockedHostScheduleModel.listByHostFqn).not.toHaveBeenCalled();
+    });
+
+    it('returns schedules for an existing host', async () => {
+      hostAggregator.getHostByFQN.mockResolvedValue({ name: 'office', mac: 'AA:BB:CC:DD:EE:FF' });
+      mockedHostScheduleModel.listByHostFqn.mockResolvedValue([sampleSchedule()]);
+      const req = createMockRequest({ params: { fqn: 'office@home' } });
+      const res = createMockResponse();
+
+      await controller.listHostSchedules(req, res);
+
+      expect(mockedHostScheduleModel.listByHostFqn).toHaveBeenCalledWith('office@home');
+      expect(res.json).toHaveBeenCalledWith({
+        schedules: [sampleSchedule()],
+      });
+    });
+
+    it('returns 500 when listing schedules fails', async () => {
+      hostAggregator.getHostByFQN.mockResolvedValue({ name: 'office', mac: 'AA:BB:CC:DD:EE:FF' });
+      mockedHostScheduleModel.listByHostFqn.mockRejectedValue(new Error('db failure'));
+      const req = createMockRequest({ params: { fqn: 'office@home' } });
+      const res = createMockResponse();
+
+      await controller.listHostSchedules(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Internal Server Error',
+        message: 'Failed to list host schedules',
+      });
+    });
+  });
+
+  describe('createHostSchedule', () => {
+    it('returns 404 when host is not found', async () => {
+      hostAggregator.getHostByFQN.mockResolvedValue(null);
+      const req = createMockRequest({
+        params: { fqn: 'missing@home' },
+        body: { scheduledTime: '2026-02-20T10:00:00.000Z', frequency: 'daily' },
+      });
+      const res = createMockResponse();
+
+      await controller.createHostSchedule(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Not Found',
+        message: 'Host missing@home not found',
+      });
+      expect(mockedHostScheduleModel.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for invalid request payload', async () => {
+      hostAggregator.getHostByFQN.mockResolvedValue({ name: 'office', mac: 'AA:BB:CC:DD:EE:FF' });
+      const req = createMockRequest({
+        params: { fqn: 'office@home' },
+        body: { scheduledTime: 'not-a-time', frequency: 'hourly' },
+      });
+      const res = createMockResponse();
+
+      await controller.createHostSchedule(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'Bad Request',
+          message: 'Invalid request body',
+        }),
+      );
+      expect(mockedHostScheduleModel.create).not.toHaveBeenCalled();
+    });
+
+    it('creates a schedule with protocol defaults for optional fields', async () => {
+      hostAggregator.getHostByFQN.mockResolvedValue({ name: 'office', mac: 'AA:BB:CC:DD:EE:FF' });
+      mockedHostScheduleModel.create.mockResolvedValue(sampleSchedule());
+      const req = createMockRequest({
+        params: { fqn: 'office@home' },
+        body: {
+          scheduledTime: '2026-02-20T10:00:00.000Z',
+          frequency: 'daily',
+        },
+      });
+      const res = createMockResponse();
+
+      await controller.createHostSchedule(req, res);
+
+      expect(mockedHostScheduleModel.create).toHaveBeenCalledWith({
+        hostFqn: 'office@home',
+        hostName: 'office',
+        hostMac: 'AA:BB:CC:DD:EE:FF',
+        scheduledTime: '2026-02-20T10:00:00.000Z',
+        frequency: 'daily',
+        enabled: true,
+        notifyOnWake: true,
+        timezone: 'UTC',
+      });
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(sampleSchedule());
+    });
+  });
+
+  describe('updateSchedule', () => {
+    it('returns 400 for invalid request payload', async () => {
+      const req = createMockRequest({
+        params: { id: 'schedule-1' },
+        body: { frequency: 'invalid' },
+      });
+      const res = createMockResponse();
+
+      await controller.updateSchedule(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'Bad Request',
+          message: 'Invalid request body',
+        }),
+      );
+      expect(mockedHostScheduleModel.update).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when schedule does not exist', async () => {
+      mockedHostScheduleModel.update.mockResolvedValue(null);
+      const req = createMockRequest({
+        params: { id: 'missing-id' },
+        body: { enabled: false },
+      });
+      const res = createMockResponse();
+
+      await controller.updateSchedule(req, res);
+
+      expect(mockedHostScheduleModel.update).toHaveBeenCalledWith('missing-id', { enabled: false });
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Not Found',
+        message: 'Schedule missing-id not found',
+      });
+    });
+
+    it('returns updated schedule when update succeeds', async () => {
+      mockedHostScheduleModel.update.mockResolvedValue(sampleSchedule({ enabled: false }));
+      const req = createMockRequest({
+        params: { id: 'schedule-1' },
+        body: { enabled: false },
+      });
+      const res = createMockResponse();
+
+      await controller.updateSchedule(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(sampleSchedule({ enabled: false }));
+    });
+
+    it('returns 500 when update throws', async () => {
+      mockedHostScheduleModel.update.mockRejectedValue(new Error('update failure'));
+      const req = createMockRequest({
+        params: { id: 'schedule-1' },
+        body: { enabled: false },
+      });
+      const res = createMockResponse();
+
+      await controller.updateSchedule(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Internal Server Error',
+        message: 'Failed to update schedule',
+      });
+    });
+  });
+
+  describe('deleteSchedule', () => {
+    it('returns 404 when schedule does not exist', async () => {
+      mockedHostScheduleModel.delete.mockResolvedValue(false);
+      const req = createMockRequest({ params: { id: 'missing-id' } });
+      const res = createMockResponse();
+
+      await controller.deleteSchedule(req, res);
+
+      expect(mockedHostScheduleModel.delete).toHaveBeenCalledWith('missing-id');
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Not Found',
+        message: 'Schedule missing-id not found',
+      });
+    });
+
+    it('returns success response when delete succeeds', async () => {
+      mockedHostScheduleModel.delete.mockResolvedValue(true);
+      const req = createMockRequest({ params: { id: 'schedule-1' } });
+      const res = createMockResponse();
+
+      await controller.deleteSchedule(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ success: true, id: 'schedule-1' });
+    });
+
+    it('returns 500 when delete throws', async () => {
+      mockedHostScheduleModel.delete.mockRejectedValue(new Error('delete failure'));
+      const req = createMockRequest({ params: { id: 'schedule-1' } });
+      const res = createMockResponse();
+
+      await controller.deleteSchedule(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Internal Server Error',
+        message: 'Failed to delete schedule',
+      });
+    });
+  });
+});

--- a/apps/cnc/src/models/__tests__/HostSchedule.test.ts
+++ b/apps/cnc/src/models/__tests__/HostSchedule.test.ts
@@ -112,4 +112,163 @@ describe('HostScheduleModel', () => {
     expect(updated?.lastTriggered).toBe(executedAt);
     expect(updated?.nextTrigger).toBe('2026-02-16T09:00:00.000Z');
   });
+
+  it('lists schedules by host FQN in reverse creation order and supports lookup by id', async () => {
+    const first = await HostScheduleModel.create({
+      hostFqn: 'rack@dc',
+      hostName: 'rack',
+      hostMac: '10:11:12:13:14:15',
+      scheduledTime: '2026-02-20T08:00:00.000Z',
+      frequency: 'daily',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+    const second = await HostScheduleModel.create({
+      hostFqn: 'rack@dc',
+      hostName: 'rack',
+      hostMac: '10:11:12:13:14:16',
+      scheduledTime: '2026-02-20T09:00:00.000Z',
+      frequency: 'daily',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    await db.query('UPDATE host_wake_schedules SET created_at = $1 WHERE id = $2', [
+      '2026-01-01T00:00:00.000Z',
+      first.id,
+    ]);
+    await db.query('UPDATE host_wake_schedules SET created_at = $1 WHERE id = $2', [
+      '2026-01-02T00:00:00.000Z',
+      second.id,
+    ]);
+
+    const byHost = await HostScheduleModel.listByHostFqn('rack@dc');
+    expect(byHost).toHaveLength(2);
+    expect(byHost[0].id).toBe(second.id);
+    expect(byHost[1].id).toBe(first.id);
+
+    const found = await HostScheduleModel.findById(first.id);
+    expect(found).not.toBeNull();
+    expect(found?.hostFqn).toBe('rack@dc');
+    expect(found?.notifyOnWake).toBe(true);
+  });
+
+  it('returns null when findById does not exist', async () => {
+    const schedule = await HostScheduleModel.findById('missing-id');
+    expect(schedule).toBeNull();
+  });
+
+  it('updates schedule fields and removes next trigger when disabled', async () => {
+    const schedule = await HostScheduleModel.create({
+      hostFqn: 'ops@dc',
+      hostName: 'ops',
+      hostMac: '20:21:22:23:24:25',
+      scheduledTime: '2026-02-20T08:00:00.000Z',
+      frequency: 'daily',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    const updated = await HostScheduleModel.update(schedule.id, {
+      scheduledTime: '2026-02-20T10:00:00.000Z',
+      enabled: false,
+      notifyOnWake: false,
+      timezone: 'America/Los_Angeles',
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated?.enabled).toBe(false);
+    expect(updated?.notifyOnWake).toBe(false);
+    expect(updated?.timezone).toBe('America/Los_Angeles');
+    expect(updated?.nextTrigger).toBeUndefined();
+  });
+
+  it('returns null when update target does not exist', async () => {
+    const updated = await HostScheduleModel.update('missing-id', { enabled: false });
+    expect(updated).toBeNull();
+  });
+
+  it('deletes schedules and reports missing deletions', async () => {
+    const schedule = await HostScheduleModel.create({
+      hostFqn: 'cleanup@dc',
+      hostName: 'cleanup',
+      hostMac: '30:31:32:33:34:35',
+      scheduledTime: '2026-02-20T08:00:00.000Z',
+      frequency: 'daily',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    const deletedExisting = await HostScheduleModel.delete(schedule.id);
+    const deletedMissing = await HostScheduleModel.delete(schedule.id);
+
+    expect(deletedExisting).toBe(true);
+    expect(deletedMissing).toBe(false);
+  });
+
+  it('returns null when recording execution attempt for unknown schedule', async () => {
+    const updated = await HostScheduleModel.recordExecutionAttempt('missing-id', '2026-02-20T10:00:00.000Z');
+    expect(updated).toBeNull();
+  });
+
+  it('supports weekly and weekday/weekend next-trigger calculations', async () => {
+    const weekly = await HostScheduleModel.create({
+      hostFqn: 'weekly@dc',
+      hostName: 'weekly',
+      hostMac: '40:41:42:43:44:45',
+      scheduledTime: '2030-01-14T07:30:00.000Z',
+      frequency: 'weekly',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+    const weekdays = await HostScheduleModel.create({
+      hostFqn: 'weekdays@dc',
+      hostName: 'weekdays',
+      hostMac: '50:51:52:53:54:55',
+      scheduledTime: '2030-01-15T07:30:00.000Z',
+      frequency: 'weekdays',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+    const weekends = await HostScheduleModel.create({
+      hostFqn: 'weekends@dc',
+      hostName: 'weekends',
+      hostMac: '60:61:62:63:64:65',
+      scheduledTime: '2030-01-12T07:30:00.000Z',
+      frequency: 'weekends',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    expect(weekly.nextTrigger).toEqual(expect.any(String));
+    expect(weekdays.nextTrigger).toEqual(expect.any(String));
+    expect(weekends.nextTrigger).toEqual(expect.any(String));
+
+    const weekdayDay = new Date(weekdays.nextTrigger as string).getUTCDay();
+    const weekendDay = new Date(weekends.nextTrigger as string).getUTCDay();
+    expect([1, 2, 3, 4, 5]).toContain(weekdayDay);
+    expect([0, 6]).toContain(weekendDay);
+  });
+
+  it('omits next trigger for one-time schedules scheduled in the past', async () => {
+    const schedule = await HostScheduleModel.create({
+      hostFqn: 'past-once@dc',
+      hostName: 'past-once',
+      hostMac: '70:71:72:73:74:75',
+      scheduledTime: '2000-01-01T00:00:00.000Z',
+      frequency: 'once',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    expect(schedule.nextTrigger).toBeUndefined();
+  });
 });

--- a/apps/cnc/src/websocket/__tests__/sessionTokens.test.ts
+++ b/apps/cnc/src/websocket/__tests__/sessionTokens.test.ts
@@ -1,4 +1,32 @@
+import { createHmac } from 'crypto';
 import { mintWsSessionToken, verifyWsSessionToken } from '../sessionTokens';
+
+function mutateToken(
+  token: string,
+  mutate: (input: {
+    header: Record<string, unknown>;
+    payload: Record<string, unknown>;
+  }) => void,
+  signingSecret = 'secret-1'
+): string {
+  const [encodedHeader, encodedPayload] = token.split('.');
+  const header = JSON.parse(Buffer.from(encodedHeader, 'base64url').toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+  const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+
+  mutate({ header, payload });
+
+  const mutatedHeader = Buffer.from(JSON.stringify(header), 'utf8').toString('base64url');
+  const mutatedPayload = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  const signingInput = `${mutatedHeader}.${mutatedPayload}`;
+  const signature = createHmac('sha256', signingSecret).update(signingInput).digest('base64url');
+  return `${signingInput}.${signature}`;
+}
 
 describe('WebSocket session tokens', () => {
   const config = {
@@ -34,5 +62,89 @@ describe('WebSocket session tokens', () => {
     const { token } = mintWsSessionToken('node-2', { ...config, secrets: ['secret-1'] });
     const claims = verifyWsSessionToken(token, rotatedConfig);
     expect(claims.nodeId).toBe('node-2');
+  });
+
+  it('rejects malformed tokens', () => {
+    expect(() => verifyWsSessionToken('not.a.jwt.with.extra', config)).toThrow('Malformed session token');
+  });
+
+  it('rejects unsupported token algorithms', () => {
+    const { token } = mintWsSessionToken('node-1', config);
+    const tampered = mutateToken(token, ({ header }) => {
+      header.alg = 'none';
+    });
+
+    expect(() => verifyWsSessionToken(tampered, config)).toThrow('Unsupported session token algorithm');
+  });
+
+  it('rejects invalid token signatures', () => {
+    const { token } = mintWsSessionToken('node-1', config);
+    const [encodedHeader, encodedPayload] = token.split('.');
+    const tampered = `${encodedHeader}.${encodedPayload}.invalid-signature`;
+
+    expect(() => verifyWsSessionToken(tampered, config)).toThrow('Invalid session token signature');
+  });
+
+  it('rejects invalid session token type', () => {
+    const { token } = mintWsSessionToken('node-1', config);
+    const tampered = mutateToken(token, ({ payload }) => {
+      payload.typ = 'unexpected-type';
+    });
+
+    expect(() => verifyWsSessionToken(tampered, config)).toThrow('Invalid session token type');
+  });
+
+  it('rejects future issued-at claims', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const { token } = mintWsSessionToken('node-1', config);
+    const tampered = mutateToken(token, ({ payload }) => {
+      payload.iat = now + 30;
+      payload.exp = now + 35;
+    });
+
+    expect(() => verifyWsSessionToken(tampered, config)).toThrow(
+      'Session token issued-at is in the future'
+    );
+  });
+
+  it('rejects invalid and excessive token lifetimes', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const { token } = mintWsSessionToken('node-1', config);
+    const invalidLifetime = mutateToken(token, ({ payload }) => {
+      payload.iat = now;
+      payload.exp = now;
+    });
+    const excessiveLifetime = mutateToken(token, ({ payload }) => {
+      payload.iat = now;
+      payload.exp = now + config.ttlSeconds + 10;
+    });
+
+    expect(() => verifyWsSessionToken(invalidLifetime, config)).toThrow(
+      'Session token lifetime is invalid'
+    );
+    expect(() => verifyWsSessionToken(excessiveLifetime, config)).toThrow(
+      'Session token lifetime exceeds maximum'
+    );
+  });
+
+  it('rejects expired tokens with otherwise valid lifetimes', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const { token } = mintWsSessionToken('node-1', config);
+    const expired = mutateToken(token, ({ payload }) => {
+      payload.iat = now - 10;
+      payload.exp = now - 1;
+    });
+
+    expect(() => verifyWsSessionToken(expired, config)).toThrow('Session token expired');
+  });
+
+  it('validates minting inputs', () => {
+    expect(() => mintWsSessionToken('', config)).toThrow('nodeId is required');
+    expect(() => mintWsSessionToken('node-1', { ...config, secrets: [] })).toThrow(
+      'At least one session token secret is required'
+    );
+    expect(() => mintWsSessionToken('node-1', { ...config, ttlSeconds: 0 })).toThrow(
+      'ttlSeconds must be > 0'
+    );
   });
 });


### PR DESCRIPTION
## CNC Sync Classification

- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: kaonis/woly-server#318
- Backend issue: kaonis/woly-server#318
- Frontend issue: kaonis/woly#307

## 3-Part Chain Checklist (required for CNC feature changes)

- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
npm run test --workspace=@woly-server/cnc -- src/controllers/__tests__/capabilities.test.ts src/controllers/__tests__/schedules.test.ts src/models/__tests__/HostSchedule.test.ts src/websocket/__tests__/server.test.ts src/websocket/__tests__/sessionTokens.test.ts --watchman=false --runInBand
npm run test:ci --workspace=@woly-server/cnc -- --coverageReporters=json-summary --coverageReporters=text
npm run test:ci --workspace=@woly-server/node-agent -- --coverageReporters=json-summary --coverageReporters=text
npm run test:ci --workspace=@kaonis/woly-protocol -- --coverage --coverageReporters=json-summary --coverageReporters=text
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- Coverage-only PR for CNC backend tests; no API contract changes.
- CNC coverage metrics improved from 83.88/73.76/86.96/84.12 to 87.52/78.11/89.09/87.75 (stmts/branches/funcs/lines).
- Refs #318.
