### PR TITLE
feat(cnc): add aggregated schedule sync endpoint and conditional polling

### DIFF
--- a/apps/cnc/src/controllers/meta.ts
+++ b/apps/cnc/src/controllers/meta.ts
@@ -49,9 +49,9 @@ const capabilityMatrix: CncCapabilitiesResponse['capabilities'] = {
   },
   schedules: {
     supported: true,
-    routes: ['/api/hosts/:fqn/schedules', '/api/hosts/schedules/:id'],
+    routes: ['/api/schedules', '/api/schedules/:id'],
     persistence: 'backend',
-    note: 'Host wake schedules are persisted and executed in CNC backend.',
+    note: 'Host wake schedules are persisted and executed in CNC backend. Legacy /api/hosts/* schedule routes remain supported.',
   },
   commandStatusStreaming: {
     supported: false,

--- a/apps/cnc/src/controllers/schedules.ts
+++ b/apps/cnc/src/controllers/schedules.ts
@@ -5,10 +5,194 @@ import {
 } from '@kaonis/woly-protocol';
 import { HostAggregator } from '../services/hostAggregator';
 import HostScheduleModel from '../models/HostSchedule';
+import { createJsonEtag, isIfNoneMatchSatisfied } from '../utils/httpCache';
 import logger from '../utils/logger';
+
+function parseEnabledQuery(value: unknown): boolean | undefined | null {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'true') return true;
+  if (normalized === 'false') return false;
+  return null;
+}
+
+function buildAllowedFqnSet(hosts: unknown[]): Set<string> {
+  const allowed = new Set<string>();
+
+  for (const host of hosts) {
+    if (!host || typeof host !== 'object') {
+      continue;
+    }
+
+    const record = host as Record<string, unknown>;
+    if (typeof record.fullyQualifiedName === 'string' && record.fullyQualifiedName.trim().length > 0) {
+      allowed.add(record.fullyQualifiedName);
+      continue;
+    }
+
+    if (typeof record.name === 'string' && typeof record.location === 'string') {
+      allowed.add(`${record.name}@${record.location}`);
+    }
+  }
+
+  return allowed;
+}
 
 export class SchedulesController {
   constructor(private readonly hostAggregator: HostAggregator) {}
+
+  /**
+   * @swagger
+   * /api/schedules:
+   *   get:
+   *     summary: List wake schedules across all hosts
+   *     tags: [Hosts]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: enabled
+   *         schema:
+   *           type: boolean
+   *         required: false
+   *         description: Optional filter for enabled/disabled schedules.
+   *       - in: query
+   *         name: nodeId
+   *         schema:
+   *           type: string
+   *         required: false
+   *         description: Optional node id filter.
+   *     responses:
+   *       200:
+   *         description: Aggregated schedules list
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 schedules:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/HostWakeSchedule'
+   *             examples:
+   *               default:
+   *                 summary: Example aggregated schedules response
+   *                 value:
+   *                   schedules:
+   *                     - id: "schedule-1"
+   *                       hostFqn: "office@home"
+   *                       hostName: "office"
+   *                       hostMac: "AA:BB:CC:DD:EE:FF"
+   *                       scheduledTime: "2026-02-20T10:00:00.000Z"
+   *                       frequency: "daily"
+   *                       enabled: true
+   *                       notifyOnWake: true
+   *                       timezone: "UTC"
+   *                       createdAt: "2026-02-18T00:00:00.000Z"
+   *                       updatedAt: "2026-02-18T00:00:00.000Z"
+   *       304:
+   *         description: Not Modified (If-None-Match matched current ETag)
+   *       400:
+   *         $ref: '#/components/responses/BadRequest'
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   */
+  async listSchedules(req: Request, res: Response): Promise<void> {
+    try {
+      const enabled = parseEnabledQuery(req.query.enabled);
+      if (enabled === null) {
+        res.status(400).json({
+          error: 'Bad Request',
+          message: 'Invalid enabled query. Use enabled=true or enabled=false',
+        });
+        return;
+      }
+
+      const baseSchedules = await HostScheduleModel.listAll(
+        enabled === undefined ? {} : { enabled },
+      );
+
+      let schedules = baseSchedules;
+      const nodeId = req.query.nodeId;
+      if (typeof nodeId === 'string') {
+        const hosts = await this.hostAggregator.getHostsByNode(nodeId);
+        const allowedFqns = buildAllowedFqnSet(hosts as unknown[]);
+        schedules = baseSchedules.filter((schedule) => allowedFqns.has(schedule.hostFqn));
+      }
+
+      const payload = { schedules };
+      const etag = createJsonEtag(payload);
+      res.setHeader('ETag', etag);
+
+      if (isIfNoneMatchSatisfied(req.header('if-none-match'), etag)) {
+        res.status(304).end();
+        return;
+      }
+
+      res.json(payload);
+    } catch (error) {
+      logger.error('Failed to list schedules', { error });
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to list schedules',
+      });
+    }
+  }
+
+  /**
+   * @swagger
+   * /api/schedules/{id}:
+   *   get:
+   *     summary: Get wake schedule by id
+   *     tags: [Hosts]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Schedule entry
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/HostWakeSchedule'
+   *       401:
+   *         $ref: '#/components/responses/Unauthorized'
+   *       404:
+   *         $ref: '#/components/responses/NotFound'
+   */
+  async getSchedule(req: Request, res: Response): Promise<void> {
+    try {
+      const id = req.params.id as string;
+      const schedule = await HostScheduleModel.findById(id);
+      if (!schedule) {
+        res.status(404).json({
+          error: 'Not Found',
+          message: `Schedule ${id} not found`,
+        });
+        return;
+      }
+
+      res.json(schedule);
+    } catch (error) {
+      logger.error('Failed to get schedule', { id: req.params.id, error });
+      res.status(500).json({
+        error: 'Internal Server Error',
+        message: 'Failed to retrieve schedule',
+      });
+    }
+  }
 
   /**
    * @swagger

--- a/apps/cnc/src/middleware/__tests__/rateLimiter.test.ts
+++ b/apps/cnc/src/middleware/__tests__/rateLimiter.test.ts
@@ -136,6 +136,10 @@ describe('cnc rateLimiter middleware', () => {
     const scheduleSecond = await request(app).get('/api/hosts/office%40home/schedules');
     expect(scheduleFirst.status).toBe(200);
     expect(scheduleSecond.status).toBe(200);
+    const aggregatedScheduleFirst = await request(app).get('/api/schedules?enabled=true');
+    const aggregatedScheduleSecond = await request(app).get('/api/schedules?enabled=true');
+    expect(aggregatedScheduleFirst.status).toBe(200);
+    expect(aggregatedScheduleSecond.status).toBe(200);
 
     const hostsFirst = await request(app).get('/api/hosts');
     const hostsSecond = await request(app).get('/api/hosts');

--- a/apps/cnc/src/middleware/rateLimiter.ts
+++ b/apps/cnc/src/middleware/rateLimiter.ts
@@ -57,8 +57,9 @@ function isHealthEndpoint(path: string): boolean {
 }
 
 function isHostScheduleRoute(req: Request): boolean {
-  const path = req.originalUrl || req.path || '';
-  return /\/api\/hosts\/(?:[^/]+\/schedules|schedules\/[^/]+)\/?$/.test(path);
+  const rawPath = req.originalUrl || req.path || '';
+  const path = rawPath.split('?')[0];
+  return /\/api\/(?:hosts\/(?:[^/]+\/schedules|schedules\/[^/]+)|schedules(?:\/[^/]+)?)\/?$/.test(path);
 }
 
 /**

--- a/apps/cnc/src/models/HostSchedule.ts
+++ b/apps/cnc/src/models/HostSchedule.ts
@@ -207,6 +207,29 @@ export class HostScheduleModel {
     }
   }
 
+  static async listAll(options: { enabled?: boolean } = {}): Promise<HostWakeSchedule[]> {
+    await this.ensureTable();
+
+    if (options.enabled === undefined) {
+      const result = await db.query<HostScheduleRow>(
+        `SELECT *
+         FROM host_wake_schedules
+         ORDER BY created_at DESC`,
+      );
+      return result.rows.map(mapRow);
+    }
+
+    const result = await db.query<HostScheduleRow>(
+      `SELECT *
+       FROM host_wake_schedules
+       WHERE enabled = $1
+       ORDER BY created_at DESC`,
+      [isSqlite ? (options.enabled ? 1 : 0) : options.enabled],
+    );
+
+    return result.rows.map(mapRow);
+  }
+
   static async listByHostFqn(hostFqn: string): Promise<HostWakeSchedule[]> {
     await this.ensureTable();
     const result = await db.query<HostScheduleRow>(

--- a/apps/cnc/src/models/__tests__/HostSchedule.test.ts
+++ b/apps/cnc/src/models/__tests__/HostSchedule.test.ts
@@ -155,6 +155,39 @@ describe('HostScheduleModel', () => {
     expect(found?.notifyOnWake).toBe(true);
   });
 
+  it('lists all schedules and supports enabled filtering', async () => {
+    const enabled = await HostScheduleModel.create({
+      hostFqn: 'enabled@dc',
+      hostName: 'enabled',
+      hostMac: '80:81:82:83:84:85',
+      scheduledTime: '2026-02-20T08:00:00.000Z',
+      frequency: 'daily',
+      enabled: true,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+    const disabled = await HostScheduleModel.create({
+      hostFqn: 'disabled@dc',
+      hostName: 'disabled',
+      hostMac: '90:91:92:93:94:95',
+      scheduledTime: '2026-02-20T08:00:00.000Z',
+      frequency: 'daily',
+      enabled: false,
+      notifyOnWake: true,
+      timezone: 'UTC',
+    });
+
+    const all = await HostScheduleModel.listAll();
+    const onlyEnabled = await HostScheduleModel.listAll({ enabled: true });
+    const onlyDisabled = await HostScheduleModel.listAll({ enabled: false });
+
+    expect(all.map((schedule) => schedule.id)).toEqual(expect.arrayContaining([enabled.id, disabled.id]));
+    expect(onlyEnabled).toHaveLength(1);
+    expect(onlyEnabled[0].id).toBe(enabled.id);
+    expect(onlyDisabled).toHaveLength(1);
+    expect(onlyDisabled[0].id).toBe(disabled.id);
+  });
+
   it('returns null when findById does not exist', async () => {
     const schedule = await HostScheduleModel.findById('missing-id');
     expect(schedule).toBeNull();

--- a/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
@@ -397,6 +397,38 @@ describe('Host Routes Authentication and Authorization', () => {
     });
   });
 
+  describe('GET /api/schedules', () => {
+    it('returns 401 when no authorization header is provided', async () => {
+      const response = await request(app).get('/api/schedules');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for unsupported role', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .get('/api/schedules')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+  });
+
   describe('GET /api/hosts/:fqn/schedules', () => {
     it('returns 401 when no authorization header is provided', async () => {
       const response = await request(app).get('/api/hosts/node1.example.com/schedules');

--- a/apps/cnc/src/routes/index.ts
+++ b/apps/cnc/src/routes/index.ts
@@ -44,12 +44,27 @@ export function createRoutes(
   // Route group protection
   router.use('/nodes', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
   router.use('/hosts', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
+  router.use('/schedules', apiLimiter, authenticateJwt, authorizeRoles('operator', 'admin'));
   router.use('/admin', apiLimiter, authenticateJwt, authorizeRoles('admin'));
 
   // Node API routes (protected)
   router.get('/nodes', (req, res) => nodesController.listNodes(req, res));
   router.get('/nodes/:id', (req, res) => nodesController.getNode(req, res));
   router.get('/nodes/:id/health', (req, res) => nodesController.getNodeHealth(req, res));
+
+  // Aggregated schedule API routes
+  router.get('/schedules', scheduleSyncLimiter, (req, res) =>
+    schedulesController.listSchedules(req, res),
+  );
+  router.get('/schedules/:id', scheduleSyncLimiter, (req, res) =>
+    schedulesController.getSchedule(req, res),
+  );
+  router.put('/schedules/:id', scheduleSyncLimiter, (req, res) =>
+    schedulesController.updateSchedule(req, res),
+  );
+  router.delete('/schedules/:id', scheduleSyncLimiter, (req, res) =>
+    schedulesController.deleteSchedule(req, res),
+  );
 
   // Host API routes
   // IMPORTANT: mac-vendor must be registered before the :fqn catch-all

--- a/apps/cnc/src/services/capabilityRateLimits.ts
+++ b/apps/cnc/src/services/capabilityRateLimits.ts
@@ -55,7 +55,12 @@ export function buildCncRateLimits(): CncRateLimits {
       maxCalls: SCHEDULE_RATE_LIMIT_MAX,
       windowMs: SCHEDULE_RATE_LIMIT_WINDOW_MS,
       scope: 'ip',
-      appliesTo: ['/api/hosts/:fqn/schedules', '/api/hosts/schedules/:id'],
+      appliesTo: [
+        '/api/schedules',
+        '/api/schedules/:id',
+        '/api/hosts/:fqn/schedules',
+        '/api/hosts/schedules/:id',
+      ],
     },
     wsInboundMessages: {
       maxCalls: parsePositiveIntFromEnv(

--- a/apps/cnc/src/utils/__tests__/httpCache.test.ts
+++ b/apps/cnc/src/utils/__tests__/httpCache.test.ts
@@ -1,0 +1,29 @@
+import { createJsonEtag, isIfNoneMatchSatisfied } from '../httpCache';
+
+describe('httpCache', () => {
+  it('creates deterministic etags for equivalent payloads', () => {
+    const a = createJsonEtag({ hosts: [{ name: 'office' }], stats: { total: 1 } });
+    const b = createJsonEtag({ hosts: [{ name: 'office' }], stats: { total: 1 } });
+
+    expect(a).toBe(b);
+    expect(a.startsWith('"')).toBe(true);
+    expect(a.endsWith('"')).toBe(true);
+  });
+
+  it('matches If-None-Match candidates including weak etags', () => {
+    const etag = createJsonEtag({ schedules: [{ id: 'schedule-1' }] });
+
+    expect(isIfNoneMatchSatisfied(etag, etag)).toBe(true);
+    expect(isIfNoneMatchSatisfied(`W/${etag}`, etag)).toBe(true);
+    expect(isIfNoneMatchSatisfied(`"other", W/${etag}`, etag)).toBe(true);
+    expect(isIfNoneMatchSatisfied('"other"', etag)).toBe(false);
+  });
+
+  it('supports wildcard If-None-Match and ignores missing values', () => {
+    const etag = createJsonEtag({ value: 1 });
+
+    expect(isIfNoneMatchSatisfied('*', etag)).toBe(true);
+    expect(isIfNoneMatchSatisfied(undefined, etag)).toBe(false);
+    expect(isIfNoneMatchSatisfied('', etag)).toBe(false);
+  });
+});

--- a/apps/cnc/src/utils/httpCache.ts
+++ b/apps/cnc/src/utils/httpCache.ts
@@ -1,0 +1,37 @@
+import { createHash } from 'crypto';
+
+function normalizeEtag(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.toUpperCase().startsWith('W/')) {
+    return trimmed.slice(2).trim();
+  }
+  return trimmed;
+}
+
+export function createJsonEtag(payload: unknown): string {
+  const json = JSON.stringify(payload);
+  const digest = createHash('sha256').update(json).digest('base64url');
+  return `"${digest}"`;
+}
+
+export function isIfNoneMatchSatisfied(ifNoneMatchHeader: string | undefined, etag: string): boolean {
+  if (!ifNoneMatchHeader) {
+    return false;
+  }
+
+  const candidates = ifNoneMatchHeader
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  if (!candidates.length) {
+    return false;
+  }
+
+  if (candidates.includes('*')) {
+    return true;
+  }
+
+  const normalizedEtag = normalizeEtag(etag);
+  return candidates.some((candidate) => normalizeEtag(candidate) === normalizedEtag);
+}


### PR DESCRIPTION
## CNC Sync Classification

- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: kaonis/woly-server#325
- Backend issue: kaonis/woly-server#326
- Frontend issue: kaonis/woly#393

## 3-Part Chain Checklist (required for CNC feature changes)

- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
npm ci
npm run build -w packages/protocol
npm run test -w packages/protocol -- contract.cross-repo
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run validate:standard
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- Added aggregated schedule APIs (`GET /api/schedules`, `GET/PUT/DELETE /api/schedules/:id`) while preserving legacy `/api/hosts/*/schedules` routes.
- Added ETag + `If-None-Match` handling for `GET /api/hosts` and `GET /api/schedules` (returns `304 Not Modified` when unchanged).
- Added schedule filters for `enabled` and `nodeId` on `GET /api/schedules`.
- Added/updated controller, route, middleware, model, and smoke tests for success/auth/error/conditional caching paths.
