### PR TITLE
feat: stream host state changes from node-agent to mobile

### DIFF
--- a/apps/cnc/src/controllers/__tests__/capabilities.test.ts
+++ b/apps/cnc/src/controllers/__tests__/capabilities.test.ts
@@ -39,6 +39,12 @@ describe('CapabilitiesController', () => {
       protocol: '2.0.0',
     });
     expect(response.capabilities.schedules.routes).toEqual(['/api/schedules', '/api/schedules/:id']);
+    expect(response.capabilities.hostStateStreaming).toEqual({
+      supported: true,
+      transport: 'websocket',
+      routes: ['/ws/mobile/hosts'],
+      note: expect.any(String),
+    });
   });
 
   it('falls back and logs warnings when versions are invalid', () => {

--- a/apps/cnc/src/controllers/__tests__/meta.test.ts
+++ b/apps/cnc/src/controllers/__tests__/meta.test.ts
@@ -43,6 +43,15 @@ describe('buildCncCapabilitiesResponse', () => {
       wsConnectionsPerIp: expect.objectContaining({ maxCalls: expect.any(Number), windowMs: null }),
       macVendorLookup: expect.objectContaining({ maxCalls: 1, windowMs: 1000 }),
     });
+    expect(payload.capabilities.hostStateStreaming).toMatchObject({
+      supported: true,
+      transport: 'websocket',
+      routes: ['/ws/mobile/hosts'],
+    });
+    expect(payload.capabilities.commandStatusStreaming).toMatchObject({
+      supported: false,
+      transport: null,
+    });
     expect(cncCapabilitiesResponseSchema.safeParse(payload).success).toBe(true);
   });
 

--- a/apps/cnc/src/controllers/capabilities.ts
+++ b/apps/cnc/src/controllers/capabilities.ts
@@ -51,6 +51,12 @@ const capabilityMatrix: CncCapabilitiesResponse['capabilities'] = {
     persistence: 'backend',
     note: 'Host wake schedules are persisted and executed in CNC backend.',
   },
+  hostStateStreaming: {
+    supported: true,
+    transport: 'websocket',
+    routes: ['/ws/mobile/hosts'],
+    note: 'Server-initiated host state change events are streamed to authenticated mobile clients.',
+  },
   commandStatusStreaming: {
     supported: false,
     transport: null,

--- a/apps/cnc/src/controllers/meta.ts
+++ b/apps/cnc/src/controllers/meta.ts
@@ -53,6 +53,12 @@ const capabilityMatrix: CncCapabilitiesResponse['capabilities'] = {
     persistence: 'backend',
     note: 'Host wake schedules are persisted and executed in CNC backend. Legacy /api/hosts/* schedule routes remain supported.',
   },
+  hostStateStreaming: {
+    supported: true,
+    transport: 'websocket',
+    routes: ['/ws/mobile/hosts'],
+    note: 'Server-initiated host state change events are streamed to authenticated mobile clients.',
+  },
   commandStatusStreaming: {
     supported: false,
     transport: null,
@@ -121,6 +127,8 @@ export class MetaController {
    *                     notesTags:
    *                       type: object
    *                     schedules:
+   *                       type: object
+   *                     hostStateStreaming:
    *                       type: object
    *                     commandStatusStreaming:
    *                       type: object

--- a/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
@@ -95,6 +95,11 @@ describe('Capabilities Routes', () => {
           scan: expect.objectContaining({ supported: true }),
           notesTags: expect.objectContaining({ supported: true, persistence: 'backend' }),
           schedules: expect.objectContaining({ supported: true, persistence: 'backend' }),
+          hostStateStreaming: expect.objectContaining({
+            supported: true,
+            transport: 'websocket',
+            routes: ['/ws/mobile/hosts'],
+          }),
           commandStatusStreaming: expect.objectContaining({ supported: false, transport: null }),
         },
         rateLimits: {

--- a/apps/cnc/src/routes/__tests__/metaRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/metaRoutes.test.ts
@@ -111,6 +111,11 @@ describe('Capabilities Route', () => {
             supported: true,
             persistence: 'backend',
           },
+          hostStateStreaming: {
+            supported: true,
+            transport: 'websocket',
+            routes: ['/ws/mobile/hosts'],
+          },
           commandStatusStreaming: { supported: false, transport: null },
         },
         rateLimits: {

--- a/apps/cnc/src/routes/__tests__/mobileCompatibility.smoke.test.ts
+++ b/apps/cnc/src/routes/__tests__/mobileCompatibility.smoke.test.ts
@@ -481,6 +481,11 @@ describe('Mobile API compatibility smoke checks', () => {
           scan: { supported: true },
           notesTags: { supported: true, persistence: 'backend' },
           schedules: { supported: true, persistence: 'backend' },
+          hostStateStreaming: {
+            supported: true,
+            transport: 'websocket',
+            routes: ['/ws/mobile/hosts'],
+          },
           commandStatusStreaming: { supported: false, transport: null },
         },
         rateLimits: {

--- a/apps/cnc/src/services/hostStateStreamBroker.ts
+++ b/apps/cnc/src/services/hostStateStreamBroker.ts
@@ -1,0 +1,173 @@
+import WebSocket from 'ws';
+import { HostAggregator } from './hostAggregator';
+import logger from '../utils/logger';
+import type { AuthContext } from '../types/auth';
+
+type HostAddedPayload = {
+  nodeId: string;
+  fullyQualifiedName?: string;
+  host?: {
+    name?: string;
+    status?: string;
+    mac?: string;
+  };
+};
+
+type HostUpdatedPayload = {
+  nodeId: string;
+  fullyQualifiedName?: string;
+  host?: {
+    name?: string;
+    status?: string;
+    mac?: string;
+  };
+};
+
+type HostRemovedPayload = {
+  nodeId: string;
+  name: string;
+};
+
+type NodeHostsChangedPayload = {
+  nodeId: string;
+  count: number;
+};
+
+type HostStateStreamEvent = {
+  type: string;
+  changed: true;
+  timestamp: string;
+  payload?: Record<string, unknown>;
+};
+
+export class HostStateStreamBroker {
+  private readonly clients = new Set<WebSocket>();
+  private readonly onHostAdded = (payload: HostAddedPayload) => {
+    this.broadcast({
+      type: 'host.discovered',
+      changed: true,
+      timestamp: new Date().toISOString(),
+      payload: {
+        nodeId: payload.nodeId,
+        fullyQualifiedName: payload.fullyQualifiedName,
+        hostName: payload.host?.name,
+        status: payload.host?.status,
+      },
+    });
+  };
+  private readonly onHostUpdated = (payload: HostUpdatedPayload) => {
+    this.broadcast({
+      type: 'host.updated',
+      changed: true,
+      timestamp: new Date().toISOString(),
+      payload: {
+        nodeId: payload.nodeId,
+        fullyQualifiedName: payload.fullyQualifiedName,
+        hostName: payload.host?.name,
+        status: payload.host?.status,
+      },
+    });
+  };
+  private readonly onHostRemoved = (payload: HostRemovedPayload) => {
+    this.broadcast({
+      type: 'host.removed',
+      changed: true,
+      timestamp: new Date().toISOString(),
+      payload: {
+        nodeId: payload.nodeId,
+        hostName: payload.name,
+      },
+    });
+  };
+  private readonly onNodeHostsUnreachable = (payload: NodeHostsChangedPayload) => {
+    this.broadcast({
+      type: 'hosts.changed',
+      changed: true,
+      timestamp: new Date().toISOString(),
+      payload: {
+        nodeId: payload.nodeId,
+        reason: 'node_hosts_unreachable',
+        affectedHostCount: payload.count,
+      },
+    });
+  };
+  private readonly onNodeHostsRemoved = (payload: NodeHostsChangedPayload) => {
+    this.broadcast({
+      type: 'hosts.changed',
+      changed: true,
+      timestamp: new Date().toISOString(),
+      payload: {
+        nodeId: payload.nodeId,
+        reason: 'node_hosts_removed',
+        affectedHostCount: payload.count,
+      },
+    });
+  };
+
+  constructor(private readonly hostAggregator: HostAggregator) {
+    this.hostAggregator.on('host-added', this.onHostAdded);
+    this.hostAggregator.on('host-updated', this.onHostUpdated);
+    this.hostAggregator.on('host-removed', this.onHostRemoved);
+    this.hostAggregator.on('node-hosts-unreachable', this.onNodeHostsUnreachable);
+    this.hostAggregator.on('node-hosts-removed', this.onNodeHostsRemoved);
+  }
+
+  handleConnection(ws: WebSocket, auth: AuthContext): void {
+    this.clients.add(ws);
+    ws.send(
+      JSON.stringify({
+        type: 'connected',
+        timestamp: new Date().toISOString(),
+        subscriber: auth.sub,
+      })
+    );
+
+    ws.on('close', () => {
+      this.clients.delete(ws);
+    });
+
+    ws.on('error', (error) => {
+      logger.warn('Mobile host-state stream websocket error', {
+        subscriber: auth.sub,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.clients.delete(ws);
+    });
+  }
+
+  shutdown(): void {
+    this.hostAggregator.off('host-added', this.onHostAdded);
+    this.hostAggregator.off('host-updated', this.onHostUpdated);
+    this.hostAggregator.off('host-removed', this.onHostRemoved);
+    this.hostAggregator.off('node-hosts-unreachable', this.onNodeHostsUnreachable);
+    this.hostAggregator.off('node-hosts-removed', this.onNodeHostsRemoved);
+
+    for (const client of this.clients) {
+      client.close(1000, 'Server shutdown');
+    }
+    this.clients.clear();
+  }
+
+  private broadcast(event: HostStateStreamEvent): void {
+    if (this.clients.size === 0) {
+      return;
+    }
+
+    const serialized = JSON.stringify(event);
+    for (const client of this.clients) {
+      if (client.readyState !== WebSocket.OPEN) {
+        continue;
+      }
+
+      try {
+        client.send(serialized);
+      } catch (error) {
+        logger.warn('Failed to send host-state stream event', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+}
+
+export default HostStateStreamBroker;

--- a/apps/cnc/src/websocket/__tests__/auth.test.ts
+++ b/apps/cnc/src/websocket/__tests__/auth.test.ts
@@ -1,6 +1,7 @@
 import { IncomingMessage } from 'http';
 import {
   extractAuthTokenFromAuthorizationHeader,
+  extractAuthTokenFromQuery,
   extractAuthTokenFromSubprotocol,
   extractNodeAuthToken,
   isRequestTls,
@@ -61,6 +62,15 @@ describe('websocket auth helpers', () => {
     });
 
     expect(extractNodeAuthToken(request, { allowQueryTokenAuth: true })).toBe('header-token');
+  });
+
+  it('supports custom query token parameter names', () => {
+    const request = buildRequest({
+      url: '/ws/mobile/hosts?access_token=query-token',
+    });
+
+    expect(extractAuthTokenFromQuery(request, ['access_token', 'token'])).toBe('query-token');
+    expect(extractAuthTokenFromQuery(request, ['token'])).toBeNull();
   });
 
   it('detects TLS via socket encryption', () => {

--- a/apps/cnc/src/websocket/__tests__/mobileUpgradeAuth.test.ts
+++ b/apps/cnc/src/websocket/__tests__/mobileUpgradeAuth.test.ts
@@ -1,0 +1,123 @@
+import type { IncomingMessage } from 'http';
+import { verifyJwtToken } from '../../middleware/auth';
+import { authenticateMobileWsUpgrade } from '../mobileUpgradeAuth';
+
+jest.mock('../../middleware/auth', () => ({
+  verifyJwtToken: jest.fn(),
+}));
+
+function buildRequest(
+  overrides: Partial<IncomingMessage> & {
+    headers?: Record<string, string | string[] | undefined>;
+    url?: string;
+  } = {}
+): IncomingMessage {
+  return {
+    url: overrides.url || '/ws/mobile/hosts',
+    headers: overrides.headers || {},
+    socket: {} as IncomingMessage['socket'],
+  } as IncomingMessage;
+}
+
+describe('authenticateMobileWsUpgrade', () => {
+  const mockVerifyJwtToken = verifyJwtToken as jest.MockedFunction<typeof verifyJwtToken>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when no auth token is provided', () => {
+    const request = buildRequest({
+      headers: {},
+    });
+
+    expect(authenticateMobileWsUpgrade(request)).toBeNull();
+    expect(mockVerifyJwtToken).not.toHaveBeenCalled();
+  });
+
+  it('accepts bearer tokens from Authorization header for operator role', () => {
+    mockVerifyJwtToken.mockReturnValue({
+      sub: 'operator-1',
+      roles: ['operator'],
+      claims: {},
+    });
+    const request = buildRequest({
+      headers: { authorization: 'Bearer mobile-token' },
+    });
+
+    const auth = authenticateMobileWsUpgrade(request);
+    expect(mockVerifyJwtToken).toHaveBeenCalledWith('mobile-token');
+    expect(auth).toMatchObject({ sub: 'operator-1', roles: ['operator'] });
+  });
+
+  it('accepts bearer token from websocket subprotocol for admin role', () => {
+    mockVerifyJwtToken.mockReturnValue({
+      sub: 'admin-1',
+      roles: ['admin'],
+      claims: {},
+    });
+    const request = buildRequest({
+      headers: { 'sec-websocket-protocol': 'json, bearer, subprotocol-token' },
+    });
+
+    const auth = authenticateMobileWsUpgrade(request);
+    expect(mockVerifyJwtToken).toHaveBeenCalledWith('subprotocol-token');
+    expect(auth).toMatchObject({ sub: 'admin-1', roles: ['admin'] });
+  });
+
+  it('accepts access_token query fallback', () => {
+    mockVerifyJwtToken.mockReturnValue({
+      sub: 'operator-2',
+      roles: ['operator'],
+      claims: {},
+    });
+    const request = buildRequest({
+      headers: {},
+      url: '/ws/mobile/hosts?access_token=query-token',
+    });
+
+    const auth = authenticateMobileWsUpgrade(request);
+    expect(mockVerifyJwtToken).toHaveBeenCalledWith('query-token');
+    expect(auth).toMatchObject({ sub: 'operator-2' });
+  });
+
+  it('accepts token query fallback', () => {
+    mockVerifyJwtToken.mockReturnValue({
+      sub: 'operator-3',
+      roles: ['operator'],
+      claims: {},
+    });
+    const request = buildRequest({
+      headers: {},
+      url: '/ws/mobile/hosts?token=query-token',
+    });
+
+    const auth = authenticateMobileWsUpgrade(request);
+    expect(mockVerifyJwtToken).toHaveBeenCalledWith('query-token');
+    expect(auth).toMatchObject({ sub: 'operator-3' });
+  });
+
+  it('rejects non-stream roles', () => {
+    mockVerifyJwtToken.mockReturnValue({
+      sub: 'viewer-1',
+      roles: ['viewer'],
+      claims: {},
+    });
+    const request = buildRequest({
+      headers: { authorization: 'Bearer viewer-token' },
+    });
+
+    expect(authenticateMobileWsUpgrade(request)).toBeNull();
+  });
+
+  it('returns null when token verification throws', () => {
+    mockVerifyJwtToken.mockImplementation(() => {
+      throw new Error('invalid token');
+    });
+    const request = buildRequest({
+      headers: { authorization: 'Bearer invalid-token' },
+    });
+
+    expect(authenticateMobileWsUpgrade(request)).toBeNull();
+  });
+});

--- a/apps/cnc/src/websocket/auth.ts
+++ b/apps/cnc/src/websocket/auth.ts
@@ -50,15 +50,23 @@ export function extractAuthTokenFromSubprotocol(request: IncomingMessage): strin
   return null;
 }
 
-export function extractAuthTokenFromQuery(request: IncomingMessage): string | null {
+export function extractAuthTokenFromQuery(
+  request: IncomingMessage,
+  queryParamNames: string[] = ['token']
+): string | null {
   if (!request.url) {
     return null;
   }
 
   try {
     const parsed = new URL(request.url, 'http://localhost');
-    const token = parsed.searchParams.get('token');
-    return typeof token === 'string' && token.length > 0 ? token : null;
+    for (const paramName of queryParamNames) {
+      const token = parsed.searchParams.get(paramName);
+      if (typeof token === 'string' && token.length > 0) {
+        return token;
+      }
+    }
+    return null;
   } catch {
     return null;
   }
@@ -71,7 +79,7 @@ export function extractNodeAuthToken(
   return (
     extractAuthTokenFromAuthorizationHeader(request) ||
     extractAuthTokenFromSubprotocol(request) ||
-    (options.allowQueryTokenAuth ? extractAuthTokenFromQuery(request) : null)
+    (options.allowQueryTokenAuth ? extractAuthTokenFromQuery(request, ['token']) : null)
   );
 }
 

--- a/apps/cnc/src/websocket/mobileUpgradeAuth.ts
+++ b/apps/cnc/src/websocket/mobileUpgradeAuth.ts
@@ -1,0 +1,40 @@
+import { IncomingMessage } from 'http';
+import type { AuthContext } from '../types/auth';
+import { verifyJwtToken } from '../middleware/auth';
+import {
+  extractAuthTokenFromAuthorizationHeader,
+  extractAuthTokenFromQuery,
+  extractAuthTokenFromSubprotocol,
+} from './auth';
+
+function hasStreamRole(auth: AuthContext): boolean {
+  return auth.roles.includes('operator') || auth.roles.includes('admin');
+}
+
+/**
+ * Authenticate mobile websocket upgrades.
+ *
+ * Supports Authorization header/subprotocol and `access_token` query fallback
+ * to work in runtimes that cannot set websocket headers.
+ */
+export function authenticateMobileWsUpgrade(
+  request: IncomingMessage
+): AuthContext | null {
+  const token =
+    extractAuthTokenFromAuthorizationHeader(request) ||
+    extractAuthTokenFromSubprotocol(request) ||
+    extractAuthTokenFromQuery(request, ['access_token', 'token']);
+
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const auth = verifyJwtToken(token);
+    return hasStreamRole(auth) ? auth : null;
+  } catch {
+    return null;
+  }
+}
+
+export default authenticateMobileWsUpgrade;

--- a/apps/cnc/src/websocket/server.ts
+++ b/apps/cnc/src/websocket/server.ts
@@ -1,57 +1,84 @@
 /**
- * WebSocket server for node communication
+ * WebSocket server for node-agent and mobile stream communication.
  */
 
 import WebSocket from 'ws';
 import { IncomingMessage, Server as HTTPServer } from 'http';
 import { NodeManager } from '../services/nodeManager';
+import { HostStateStreamBroker } from '../services/hostStateStreamBroker';
 import config from '../config';
 import logger from '../utils/logger';
 import { isRequestTls } from './auth';
 import { authenticateWsUpgrade } from './upgradeAuth';
+import { authenticateMobileWsUpgrade } from './mobileUpgradeAuth';
+
+const NODE_WS_PATH = '/ws/node';
+const MOBILE_HOSTS_WS_PATH = '/ws/mobile/hosts';
 
 export function createWebSocketServer(
   httpServer: HTTPServer,
-  nodeManager: NodeManager
+  nodeManager: NodeManager,
+  hostStateStreamBroker: HostStateStreamBroker
 ): WebSocket.Server {
   const wss = new WebSocket.Server({ noServer: true, maxPayload: 256 * 1024 });
   const wsMaxConnectionsPerIp = Math.max(config.wsMaxConnectionsPerIp, 1);
-  const connectionsPerIp = new Map<string, number>();
+  const nodeConnectionsPerIp = new Map<string, number>();
+  const mobileConnectionsPerIp = new Map<string, number>();
 
-  const decrementConnectionCount = (ip: string): void => {
-    const count = connectionsPerIp.get(ip);
+  const decrementConnectionCount = (bucket: Map<string, number>, ip: string): void => {
+    const count = bucket.get(ip);
     if (!count) {
       return;
     }
 
     if (count <= 1) {
-      connectionsPerIp.delete(ip);
+      bucket.delete(ip);
       return;
     }
 
-    connectionsPerIp.set(ip, count - 1);
+    bucket.set(ip, count - 1);
+  };
+
+  const isRateLimited = (
+    bucket: Map<string, number>,
+    clientIp: string
+  ): boolean => {
+    const activeConnectionsForIp = bucket.get(clientIp) ?? 0;
+    return activeConnectionsForIp >= wsMaxConnectionsPerIp;
+  };
+
+  const trackUpgradedConnection = (
+    bucket: Map<string, number>,
+    clientIp: string,
+    ws: WebSocket
+  ): void => {
+    const activeConnectionsForIp = bucket.get(clientIp) ?? 0;
+    bucket.set(clientIp, activeConnectionsForIp + 1);
+    ws.once('close', () => {
+      decrementConnectionCount(bucket, clientIp);
+    });
   };
 
   // Handle upgrade requests
   httpServer.on('upgrade', (request, socket, head) => {
     const pathname = request.url?.split('?')[0];
+    const clientIp = getClientIp(request);
 
-    if (pathname === '/ws/node') {
-      const clientIp = getClientIp(request);
-      const activeConnectionsForIp = connectionsPerIp.get(clientIp) ?? 0;
-      if (activeConnectionsForIp >= wsMaxConnectionsPerIp) {
+    if (config.wsRequireTls && !isRequestTls(request)) {
+      socket.write('HTTP/1.1 426 Upgrade Required\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    if (pathname === NODE_WS_PATH) {
+      if (isRateLimited(nodeConnectionsPerIp, clientIp)) {
         logger.warn('WebSocket connection rejected: per-IP connection limit exceeded', {
           clientIp,
-          activeConnectionsForIp,
+          activeConnectionsForIp: nodeConnectionsPerIp.get(clientIp) ?? 0,
+          channel: 'node',
           wsMaxConnectionsPerIp,
         });
         socket.write('HTTP/1.1 429 Too Many Requests\r\n\r\n');
-        socket.destroy();
-        return;
-      }
-
-      if (config.wsRequireTls && !isRequestTls(request)) {
-        socket.write('HTTP/1.1 426 Upgrade Required\r\n\r\n');
         socket.destroy();
         return;
       }
@@ -64,20 +91,50 @@ export function createWebSocketServer(
       }
 
       wss.handleUpgrade(request, socket, head, (ws) => {
-        connectionsPerIp.set(clientIp, activeConnectionsForIp + 1);
-        ws.once('close', () => {
-          decrementConnectionCount(clientIp);
-        });
+        trackUpgradedConnection(nodeConnectionsPerIp, clientIp, ws);
 
         // Emit the standard connection event for any listeners, but handle node auth here
         // so we can keep authContext strongly typed without relying on extra event args.
         wss.emit('connection', ws, request);
-        logger.info('New WebSocket connection attempt', { clientIp });
+        logger.info('New node WebSocket connection', { clientIp });
         void nodeManager.handleConnection(ws, authContext);
       });
-    } else {
-      socket.destroy();
+      return;
     }
+
+    if (pathname === MOBILE_HOSTS_WS_PATH) {
+      if (isRateLimited(mobileConnectionsPerIp, clientIp)) {
+        logger.warn('WebSocket connection rejected: per-IP connection limit exceeded', {
+          clientIp,
+          activeConnectionsForIp: mobileConnectionsPerIp.get(clientIp) ?? 0,
+          channel: 'mobile-host-stream',
+          wsMaxConnectionsPerIp,
+        });
+        socket.write('HTTP/1.1 429 Too Many Requests\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      const authContext = authenticateMobileWsUpgrade(request);
+      if (!authContext) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      wss.handleUpgrade(request, socket, head, (ws) => {
+        trackUpgradedConnection(mobileConnectionsPerIp, clientIp, ws);
+        wss.emit('connection', ws, request);
+        logger.info('New mobile host-state WebSocket connection', {
+          clientIp,
+          subscriber: authContext.sub,
+        });
+        hostStateStreamBroker.handleConnection(ws, authContext);
+      });
+      return;
+    }
+
+    socket.destroy();
   });
 
   wss.on('error', (error) => {

--- a/packages/protocol/fixtures/app-consumer/index.ts
+++ b/packages/protocol/fixtures/app-consumer/index.ts
@@ -20,6 +20,7 @@ const capabilities: CncCapabilitiesResponse = {
     scan: { supported: true },
     notesTags: { supported: true, persistence: 'backend' },
     schedules: { supported: true, routes: ['/api/hosts/:fqn/schedules'] },
+    hostStateStreaming: { supported: true, transport: 'websocket', routes: ['/ws/mobile/hosts'] },
     commandStatusStreaming: { supported: false, transport: null },
   },
 };

--- a/packages/protocol/src/__tests__/schemas.test.ts
+++ b/packages/protocol/src/__tests__/schemas.test.ts
@@ -279,6 +279,7 @@ describe('cncCapabilitiesResponseSchema', () => {
           scan: capability,
           notesTags: capability,
           schedules: { supported: false },
+          hostStateStreaming: { supported: true, transport: 'websocket' },
           commandStatusStreaming: { supported: false, transport: null },
         },
         rateLimits: {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -102,6 +102,7 @@ export interface CncCapabilitiesResponse {
     scan: CncCapabilityDescriptor;
     notesTags: CncCapabilityDescriptor;
     schedules: CncCapabilityDescriptor;
+    hostStateStreaming?: CncCapabilityDescriptor;
     commandStatusStreaming: CncCapabilityDescriptor;
   };
   rateLimits?: CncRateLimits;
@@ -347,6 +348,7 @@ export const cncCapabilitiesResponseSchema: z.ZodType<CncCapabilitiesResponse> =
     scan: cncCapabilityDescriptorSchema,
     notesTags: cncCapabilityDescriptorSchema,
     schedules: cncCapabilityDescriptorSchema,
+    hostStateStreaming: cncCapabilityDescriptorSchema.optional(),
     commandStatusStreaming: cncCapabilityDescriptorSchema,
   }),
   rateLimits: cncRateLimitsSchema.optional(),


### PR DESCRIPTION
## CNC Sync Classification

- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: kaonis/woly-server#254
- Backend issue: kaonis/woly-server#220
- Frontend issue: kaonis/woly#311

## 3-Part Chain Checklist (required for CNC feature changes)

- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
npm run typecheck
npm run test --workspace=@woly-server/cnc -- src/websocket/__tests__/auth.test.ts src/websocket/__tests__/mobileUpgradeAuth.test.ts src/websocket/__tests__/server.test.ts src/controllers/__tests__/meta.test.ts src/controllers/__tests__/capabilities.test.ts src/routes/__tests__/metaRoutes.test.ts src/routes/__tests__/capabilitiesRoutes.test.ts src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run test --workspace=@woly-server/node-agent -- src/services/__tests__/agentService.unit.test.ts
npm run test --workspace=@kaonis/woly-protocol -- src/__tests__/schemas.test.ts
npm run build -w packages/protocol
npm run test -w packages/protocol -- contract.cross-repo
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run validate:standard
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- Added `hostStateStreaming` capability and mobile websocket route `/ws/mobile/hosts`.
- Added node-agent meaningful-change suppression for host update emission to avoid scan-triggered no-op event floods.
