### PR TITLE
CNC host-state stream: contract semantics + broker telemetry

### DIFF
--- a/apps/cnc/src/controllers/capabilities.ts
+++ b/apps/cnc/src/controllers/capabilities.ts
@@ -55,7 +55,7 @@ const capabilityMatrix: CncCapabilitiesResponse['capabilities'] = {
     supported: true,
     transport: 'websocket',
     routes: ['/ws/mobile/hosts'],
-    note: 'Server-initiated host state change events are streamed to authenticated mobile clients.',
+    note: 'Server-initiated host and node state deltas stream over WebSocket (`host.*`, `hosts.*`, `node.*`). Non-mutating `connected`/`heartbeat` style events MUST NOT trigger host refetch.',
   },
   commandStatusStreaming: {
     supported: false,

--- a/apps/cnc/src/controllers/meta.ts
+++ b/apps/cnc/src/controllers/meta.ts
@@ -57,7 +57,7 @@ const capabilityMatrix: CncCapabilitiesResponse['capabilities'] = {
     supported: true,
     transport: 'websocket',
     routes: ['/ws/mobile/hosts'],
-    note: 'Server-initiated host state change events are streamed to authenticated mobile clients.',
+    note: 'Server-initiated host and node state deltas stream over WebSocket (`host.*`, `hosts.*`, `node.*`). Non-mutating `connected`/`heartbeat` style events MUST NOT trigger host refetch.',
   },
   commandStatusStreaming: {
     supported: false,

--- a/apps/cnc/src/routes/index.ts
+++ b/apps/cnc/src/routes/index.ts
@@ -12,6 +12,7 @@ import { MetaController } from '../controllers/meta';
 import { NodeManager } from '../services/nodeManager';
 import { HostAggregator } from '../services/hostAggregator';
 import { CommandRouter } from '../services/commandRouter';
+import type { HostStateStreamBroker } from '../services/hostStateStreamBroker';
 import { runtimeMetrics } from '../services/runtimeMetrics';
 import { authenticateJwt, authorizeRoles } from '../middleware/auth';
 import { apiLimiter, scheduleSyncLimiter, strictAuthLimiter } from '../middleware/rateLimiter';
@@ -23,13 +24,19 @@ export function createRoutes(
   nodeManager: NodeManager,
   hostAggregator: HostAggregator,
   commandRouter: CommandRouter,
+  hostStateStreamBroker?: HostStateStreamBroker,
 ): Router {
   const router = Router();
   router.use(assignCorrelationId);
 
   // Controllers
   const nodesController = new NodesController(nodeManager);
-  const adminController = new AdminController(hostAggregator, nodeManager, commandRouter);
+  const adminController = new AdminController(
+    hostAggregator,
+    nodeManager,
+    commandRouter,
+    hostStateStreamBroker,
+  );
   const hostsController = new HostsController(hostAggregator, commandRouter);
   const schedulesController = new SchedulesController(hostAggregator);
   const authController = new AuthController();

--- a/apps/cnc/src/server.ts
+++ b/apps/cnc/src/server.ts
@@ -161,7 +161,12 @@ class Server {
     });
 
     // Mount API routes
-    this.app.use('/api', createRoutes(this.nodeManager, this.hostAggregator, this.commandRouter));
+    this.app.use('/api', createRoutes(
+      this.nodeManager,
+      this.hostAggregator,
+      this.commandRouter,
+      this.hostStateStreamBroker,
+    ));
 
     // 404 handler
     this.app.use((req, res) => {

--- a/apps/cnc/src/services/__tests__/hostStateStreamBroker.test.ts
+++ b/apps/cnc/src/services/__tests__/hostStateStreamBroker.test.ts
@@ -1,0 +1,182 @@
+import { EventEmitter } from 'events';
+import WebSocket from 'ws';
+import type { AuthContext } from '../../types/auth';
+import { HostStateStreamBroker } from '../hostStateStreamBroker';
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+type MockWs = {
+  readyState: number;
+  on: jest.Mock;
+  send: jest.Mock;
+  close: jest.Mock;
+};
+
+function createMockWs(): {
+  ws: WebSocket;
+  mock: MockWs;
+  handlers: Record<string, (...args: unknown[]) => void>;
+} {
+  const handlers: Record<string, (...args: unknown[]) => void> = {};
+  const mock: MockWs = {
+    readyState: WebSocket.OPEN,
+    on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers[event] = handler;
+    }),
+    send: jest.fn(),
+    close: jest.fn(),
+  };
+
+  return { ws: mock as unknown as WebSocket, mock, handlers };
+}
+
+function parseSentPayload(sendCallArg: unknown): Record<string, unknown> {
+  if (typeof sendCallArg !== 'string') {
+    return {};
+  }
+
+  return JSON.parse(sendCallArg) as Record<string, unknown>;
+}
+
+describe('HostStateStreamBroker', () => {
+  const auth: AuthContext = {
+    sub: 'mobile-client',
+    roles: ['operator'],
+    claims: {},
+  };
+
+  it('sends non-mutating connected event and tracks connection close metadata', () => {
+    const hostAggregator = new EventEmitter();
+    const broker = new HostStateStreamBroker(hostAggregator as unknown as never);
+    const { ws, mock, handlers } = createMockWs();
+
+    broker.handleConnection(ws, auth);
+
+    expect(mock.send).toHaveBeenCalledTimes(1);
+    const connectedPayload = parseSentPayload(mock.send.mock.calls[0]?.[0]);
+    expect(connectedPayload).toMatchObject({
+      type: 'connected',
+      changed: false,
+      payload: { subscriber: 'mobile-client' },
+    });
+
+    handlers.close?.(1006, Buffer.from('abnormal closure', 'utf8'));
+
+    expect(broker.getStats()).toMatchObject({
+      activeClients: 0,
+      totalConnections: 1,
+      totalDisconnects: 1,
+      closeCodes: { '1006': 1 },
+      closeReasons: { 'abnormal closure': 1 },
+    });
+  });
+
+  it('broadcasts host mutation events in source order for connected clients', () => {
+    const hostAggregator = new EventEmitter();
+    const broker = new HostStateStreamBroker(hostAggregator as unknown as never);
+    const { ws, mock } = createMockWs();
+
+    broker.handleConnection(ws, auth);
+
+    hostAggregator.emit('host-added', {
+      nodeId: 'node-1',
+      fullyQualifiedName: 'office-pc@home',
+      host: { name: 'office-pc', status: 'awake' },
+    });
+    hostAggregator.emit('host-updated', {
+      nodeId: 'node-1',
+      fullyQualifiedName: 'office-pc@home',
+      host: { name: 'office-pc', status: 'asleep' },
+    });
+    hostAggregator.emit('host-removed', {
+      nodeId: 'node-1',
+      name: 'office-pc',
+    });
+
+    const eventTypes = mock.send.mock.calls
+      .slice(1)
+      .map((call) => parseSentPayload(call[0]).type);
+
+    expect(eventTypes).toEqual(['host.discovered', 'host.updated', 'host.removed']);
+    expect(broker.getStats()).toMatchObject({
+      events: {
+        totalBroadcasts: 3,
+        deliveries: 3,
+        byType: {
+          'host.discovered': 1,
+          'host.updated': 1,
+          'host.removed': 1,
+        },
+      },
+    });
+  });
+
+  it('tracks dropped broadcasts when no subscribers are connected', () => {
+    const hostAggregator = new EventEmitter();
+    const broker = new HostStateStreamBroker(hostAggregator as unknown as never);
+
+    hostAggregator.emit('node-hosts-unreachable', {
+      nodeId: 'node-1',
+      count: 2,
+    });
+
+    expect(broker.getStats()).toMatchObject({
+      events: {
+        totalBroadcasts: 1,
+        droppedNoSubscribers: 1,
+        deliveries: 0,
+      },
+    });
+  });
+
+  it('records websocket errors and send failures', () => {
+    const hostAggregator = new EventEmitter();
+    const broker = new HostStateStreamBroker(hostAggregator as unknown as never);
+    const { ws, mock, handlers } = createMockWs();
+
+    broker.handleConnection(ws, auth);
+
+    mock.send.mockImplementation(() => {
+      throw new Error('send failed');
+    });
+
+    hostAggregator.emit('host-updated', {
+      nodeId: 'node-2',
+      fullyQualifiedName: 'studio-pc@hq',
+      host: { name: 'studio-pc', status: 'awake' },
+    });
+    handlers.error?.(new Error('socket failure'));
+
+    expect(broker.getStats()).toMatchObject({
+      activeClients: 0,
+      totalErrors: 1,
+      events: {
+        totalBroadcasts: 1,
+        sendFailures: 1,
+      },
+    });
+  });
+
+  it('closes all clients and detaches listeners on shutdown', () => {
+    const hostAggregator = new EventEmitter();
+    const broker = new HostStateStreamBroker(hostAggregator as unknown as never);
+    const first = createMockWs();
+    const second = createMockWs();
+
+    broker.handleConnection(first.ws, auth);
+    broker.handleConnection(second.ws, auth);
+    broker.shutdown();
+
+    expect(first.mock.close).toHaveBeenCalledWith(1000, 'Server shutdown');
+    expect(second.mock.close).toHaveBeenCalledWith(1000, 'Server shutdown');
+    expect(broker.getStats().activeClients).toBe(0);
+  });
+});

--- a/apps/cnc/src/services/hostStateStreamBroker.ts
+++ b/apps/cnc/src/services/hostStateStreamBroker.ts
@@ -1,4 +1,10 @@
 import WebSocket from 'ws';
+import type {
+  HostStateStreamEvent,
+  HostStateStreamEventType,
+  HostStateStreamMutatingEventType,
+  HostStateStreamNonMutatingEventType,
+} from '@kaonis/woly-protocol';
 import { HostAggregator } from './hostAggregator';
 import logger from '../utils/logger';
 import type { AuthContext } from '../types/auth';
@@ -33,75 +39,84 @@ type NodeHostsChangedPayload = {
   count: number;
 };
 
-type HostStateStreamEvent = {
-  type: string;
-  changed: true;
-  timestamp: string;
-  payload?: Record<string, unknown>;
+type HostStateStreamBrokerStats = {
+  activeClients: number;
+  totalConnections: number;
+  totalDisconnects: number;
+  totalErrors: number;
+  closeCodes: Record<string, number>;
+  closeReasons: Record<string, number>;
+  events: {
+    totalBroadcasts: number;
+    byType: Record<string, number>;
+    deliveries: number;
+    droppedNoSubscribers: number;
+    sendFailures: number;
+  };
 };
 
 export class HostStateStreamBroker {
   private readonly clients = new Set<WebSocket>();
+  private totalConnections = 0;
+  private totalDisconnects = 0;
+  private totalErrors = 0;
+  private totalBroadcasts = 0;
+  private totalBroadcastDeliveries = 0;
+  private totalBroadcastDroppedNoSubscribers = 0;
+  private totalBroadcastSendFailures = 0;
+  private readonly closeCodeCounts = new Map<string, number>();
+  private readonly closeReasonCounts = new Map<string, number>();
+  private readonly broadcastEventCounts = new Map<HostStateStreamEventType, number>();
+
   private readonly onHostAdded = (payload: HostAddedPayload) => {
-    this.broadcast({
-      type: 'host.discovered',
-      changed: true,
-      timestamp: new Date().toISOString(),
-      payload: {
+    this.broadcast(
+      this.createMutatingEvent('host.discovered', {
         nodeId: payload.nodeId,
         fullyQualifiedName: payload.fullyQualifiedName,
         hostName: payload.host?.name,
         status: payload.host?.status,
-      },
-    });
+      })
+    );
   };
+
   private readonly onHostUpdated = (payload: HostUpdatedPayload) => {
-    this.broadcast({
-      type: 'host.updated',
-      changed: true,
-      timestamp: new Date().toISOString(),
-      payload: {
+    this.broadcast(
+      this.createMutatingEvent('host.updated', {
         nodeId: payload.nodeId,
         fullyQualifiedName: payload.fullyQualifiedName,
         hostName: payload.host?.name,
         status: payload.host?.status,
-      },
-    });
+      })
+    );
   };
+
   private readonly onHostRemoved = (payload: HostRemovedPayload) => {
-    this.broadcast({
-      type: 'host.removed',
-      changed: true,
-      timestamp: new Date().toISOString(),
-      payload: {
+    this.broadcast(
+      this.createMutatingEvent('host.removed', {
         nodeId: payload.nodeId,
         hostName: payload.name,
-      },
-    });
+      })
+    );
   };
+
   private readonly onNodeHostsUnreachable = (payload: NodeHostsChangedPayload) => {
-    this.broadcast({
-      type: 'hosts.changed',
-      changed: true,
-      timestamp: new Date().toISOString(),
-      payload: {
+    this.broadcast(
+      this.createMutatingEvent('hosts.changed', {
         nodeId: payload.nodeId,
         reason: 'node_hosts_unreachable',
         affectedHostCount: payload.count,
-      },
-    });
+      })
+    );
   };
+
   private readonly onNodeHostsRemoved = (payload: NodeHostsChangedPayload) => {
-    this.broadcast({
-      type: 'hosts.changed',
-      changed: true,
-      timestamp: new Date().toISOString(),
-      payload: {
+    this.broadcast(
+      this.createMutatingEvent('hosts.changed', {
         nodeId: payload.nodeId,
         reason: 'node_hosts_removed',
         affectedHostCount: payload.count,
-      },
-    });
+      })
+    );
   };
 
   constructor(private readonly hostAggregator: HostAggregator) {
@@ -114,25 +129,66 @@ export class HostStateStreamBroker {
 
   handleConnection(ws: WebSocket, auth: AuthContext): void {
     this.clients.add(ws);
-    ws.send(
-      JSON.stringify({
-        type: 'connected',
-        timestamp: new Date().toISOString(),
+    this.totalConnections += 1;
+    this.sendDirect(
+      ws,
+      this.createNonMutatingEvent('connected', {
         subscriber: auth.sub,
       })
     );
 
-    ws.on('close', () => {
+    ws.on('close', (code: number, reason: Buffer) => {
       this.clients.delete(ws);
+      this.totalDisconnects += 1;
+
+      const normalizedReason = this.normalizeCloseReason(reason);
+      this.incrementCounter(this.closeCodeCounts, String(code));
+      this.incrementCounter(this.closeReasonCounts, normalizedReason);
+
+      if (code === 1000) {
+        logger.info('Mobile host-state stream websocket closed', {
+          subscriber: auth.sub,
+          code,
+          reason: normalizedReason,
+          activeClients: this.clients.size,
+        });
+        return;
+      }
+
+      logger.warn('Mobile host-state stream websocket closed unexpectedly', {
+        subscriber: auth.sub,
+        code,
+        reason: normalizedReason,
+        activeClients: this.clients.size,
+      });
     });
 
     ws.on('error', (error) => {
+      this.totalErrors += 1;
       logger.warn('Mobile host-state stream websocket error', {
         subscriber: auth.sub,
         error: error instanceof Error ? error.message : String(error),
       });
       this.clients.delete(ws);
     });
+  }
+
+  getStats(): HostStateStreamBrokerStats {
+    return {
+      activeClients: this.clients.size,
+      totalConnections: this.totalConnections,
+      totalDisconnects: this.totalDisconnects,
+      totalErrors: this.totalErrors,
+      closeCodes: this.mapToRecord(this.closeCodeCounts),
+      closeReasons: this.mapToRecord(this.closeReasonCounts),
+      events: {
+        totalBroadcasts: this.totalBroadcasts,
+        byType: this.mapToRecord(this.broadcastEventCounts),
+        deliveries: this.totalBroadcastDeliveries,
+        droppedNoSubscribers: this.totalBroadcastDroppedNoSubscribers,
+        sendFailures: this.totalBroadcastSendFailures,
+      },
+    };
   }
 
   shutdown(): void {
@@ -148,8 +204,48 @@ export class HostStateStreamBroker {
     this.clients.clear();
   }
 
+  private createMutatingEvent(
+    type: HostStateStreamMutatingEventType,
+    payload?: Record<string, unknown>
+  ): HostStateStreamEvent {
+    return {
+      type,
+      changed: true,
+      timestamp: new Date().toISOString(),
+      payload,
+    };
+  }
+
+  private createNonMutatingEvent(
+    type: HostStateStreamNonMutatingEventType,
+    payload?: Record<string, unknown>
+  ): HostStateStreamEvent {
+    return {
+      type,
+      changed: false,
+      timestamp: new Date().toISOString(),
+      payload,
+    };
+  }
+
+  private sendDirect(ws: WebSocket, event: HostStateStreamEvent): void {
+    try {
+      ws.send(JSON.stringify(event));
+    } catch (error) {
+      this.totalBroadcastSendFailures += 1;
+      logger.warn('Failed to send direct host-state stream event', {
+        type: event.type,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   private broadcast(event: HostStateStreamEvent): void {
+    this.totalBroadcasts += 1;
+    this.incrementCounter(this.broadcastEventCounts, event.type);
+
     if (this.clients.size === 0) {
+      this.totalBroadcastDroppedNoSubscribers += 1;
       return;
     }
 
@@ -161,12 +257,31 @@ export class HostStateStreamBroker {
 
       try {
         client.send(serialized);
+        this.totalBroadcastDeliveries += 1;
       } catch (error) {
+        this.totalBroadcastSendFailures += 1;
         logger.warn('Failed to send host-state stream event', {
+          type: event.type,
           error: error instanceof Error ? error.message : String(error),
         });
       }
     }
+  }
+
+  private incrementCounter<T>(counter: Map<T, number>, key: T): void {
+    counter.set(key, (counter.get(key) || 0) + 1);
+  }
+
+  private mapToRecord<T extends string>(counter: Map<T, number>): Record<string, number> {
+    return Object.fromEntries(counter.entries());
+  }
+
+  private normalizeCloseReason(reason: Buffer): string {
+    const trimmed = reason.toString('utf8').trim();
+    if (trimmed.length === 0) {
+      return 'none';
+    }
+    return trimmed;
   }
 }
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -14,6 +14,7 @@
 - `CncCapabilitiesResponse` / `CncCapabilityDescriptor` — CNC mode feature negotiation response
 - `HostPort` / `HostPortScanResponse` — CNC host port-scan API DTOs
 - `HostWakeSchedule`, `CreateHostWakeScheduleRequest`, `UpdateHostWakeScheduleRequest`, `ScheduleFrequency` — CNC schedules API DTOs
+- `HostStateStreamEvent` and related event-type unions/constants — mobile host-state stream event contract (`mutating` vs `non-mutating` classes)
 - `NodeMetadata` — Agent platform/version/network info
 - `NodeRegistration` — Registration payload sent by nodes
 - `NodeMessage` — Discriminated union of all node → C&C messages
@@ -30,6 +31,7 @@
 - `cncCapabilitiesResponseSchema` / `cncCapabilityDescriptorSchema` — Validates CNC capabilities payload
 - `hostPortSchema` / `hostPortScanResponseSchema` — Validates host port scan payloads
 - `hostWakeScheduleSchema` / `hostSchedulesResponseSchema` / `createHostWakeScheduleRequestSchema` / `updateHostWakeScheduleRequestSchema` — Validates schedules payloads
+- `hostStateStreamEventSchema` — Validates mobile host-state stream events
 - `outboundNodeMessageSchema` — Validates `NodeMessage` at runtime
 - `inboundCncCommandSchema` — Validates `CncCommand` at runtime
 
@@ -115,6 +117,7 @@ The package includes schema validation tests in `src/__tests__/schemas.test.ts`.
 This package is published to npm only when external consumers (for example, mobile app releases) require updated protocol contracts.
 
 Before publishing, follow the readiness and rollback runbook:
+
 - [`docs/PROTOCOL_PUBLISH_WORKFLOW.md`](../../docs/PROTOCOL_PUBLISH_WORKFLOW.md)
 
 ### Quick Start (Recommended)
@@ -164,6 +167,7 @@ This package includes comprehensive contract tests to ensure protocol compatibil
 ### Documentation
 
 See [docs/PROTOCOL_COMPATIBILITY.md](../../docs/PROTOCOL_COMPATIBILITY.md) for:
+
 - Versioning policy and semantic versioning rules
 - Runtime version negotiation
 - Breaking change workflow


### PR DESCRIPTION
## Summary
- formalize mobile host-state stream protocol contract in `@kaonis/woly-protocol` with explicit mutating vs non-mutating event classes (`hostStateStreamEventSchema`)
- harden CNC host stream broker with singleton-client telemetry (connections, disconnect/error reasons, broadcast/delivery/send-failure counters)
- expose `mobileHostStateStream` stats in admin observability payload
- document singleton stream semantics/reconnect guidance in CNC sync policy

## Linked Issues
- Protocol: closes #332
- Backend: closes #331
- Frontend reference: kaonis/woly#401 (implemented via kaonis/woly#402)

## Required 3-Part Chain
- [x] Protocol contract (`packages/protocol`)
- [x] Backend endpoint/command (`apps/cnc`)
- [x] Frontend integration linkage (`kaonis/woly#401` / `#402`)

## Review Pass
- [x] `git diff --stat origin/master...HEAD`
- [x] `git diff origin/master...HEAD`
- [x] self-review completed

## Local Validation (Required)
- `npm ci`
- `npm run build -w packages/protocol`
- `npm run test -w packages/protocol -- contract.cross-repo`
- `npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts`
- `npm run validate:standard`

All commands passed in the worktree.
