### PR TITLE
chore(protocol): bump @kaonis/woly-protocol to 1.3.0

### DIFF
--- a/docs/PROTOCOL_COMPATIBILITY.md
+++ b/docs/PROTOCOL_COMPATIBILITY.md
@@ -8,14 +8,14 @@ The WoLy distributed system uses a shared protocol package (`@kaonis/woly-protoc
 
 **Package**: `@kaonis/woly-protocol`  
 **Purpose**: Shared TypeScript types and Zod runtime schemas for node ↔ C&C communication  
-**Current Package Version**: 1.2.0  
-**Current Protocol Version**: 1.2.0 (see `PROTOCOL_VERSION` constant)  
+**Current Package Version**: 1.3.0  
+**Current Protocol Version**: 1.3.0 (see `PROTOCOL_VERSION` constant)  
 **Location**: `packages/protocol/`
 
 ### Exports
 
-- **Types**: `Host`, `HostStatus`, `CommandState`, `NodeMessage`, `CncCommand`, CNC API DTOs (`CncCapabilitiesResponse`, `HostWakeSchedule`, `HostPortScanResponse`), etc.
-- **Schemas**: `outboundNodeMessageSchema`, `inboundCncCommandSchema`, CNC API schemas (`cncCapabilitiesResponseSchema`, `hostWakeScheduleSchema`, `hostPortScanResponseSchema`), etc.
+- **Types**: `Host`, `HostStatus`, `CommandState`, `NodeMessage`, `CncCommand`, CNC API DTOs (`CncCapabilitiesResponse`, `CncRateLimits`, `HostWakeSchedule`, `HostPortScanResponse`), etc.
+- **Schemas**: `outboundNodeMessageSchema`, `inboundCncCommandSchema`, CNC API schemas (`cncCapabilitiesResponseSchema`, `cncRateLimitsSchema`, `hostWakeScheduleSchema`, `hostPortScanResponseSchema`), etc.
 - **Constants**: `PROTOCOL_VERSION`, `SUPPORTED_PROTOCOL_VERSIONS`
 
 ### Consumer Migration Notes
@@ -23,6 +23,7 @@ The WoLy distributed system uses a shared protocol package (`@kaonis/woly-protoc
 - `1.0.x`: Base node ↔ C&C message contracts.
 - `1.1.x`: CNC app/backend API DTOs for capabilities + schedules.
 - `1.2.x`: host port scan/ping payload enrichments and consumer typecheck fixture parity.
+- `1.3.x`: capability-map enrichments (`hostStateStreaming`, optional `rateLimits`) and exported CNC rate-limit schemas.
 
 ## Versioning Policy
 
@@ -47,13 +48,13 @@ Protocol package follows strict semantic versioning:
 From monorepo root:
 
 ```bash
-# Bug fix (1.2.0 → 1.2.1)
+# Bug fix (1.3.0 → 1.3.1)
 npm run protocol:version:patch
 
-# New feature (1.2.0 → 1.3.0)
+# New feature (1.3.0 → 1.4.0)
 npm run protocol:version:minor
 
-# Breaking change (1.2.0 → 2.0.0)
+# Breaking change (1.3.0 → 2.0.0)
 npm run protocol:version:major
 ```
 
@@ -63,7 +64,8 @@ npm run protocol:version:major
 
 | Protocol Version | Node Agent | C&C Backend | Status |
 |------------------|------------|-------------|--------|
-| 1.2.0 | ✅ 0.0.1+ | ✅ 1.0.0+ | Current |
+| 1.3.0 | ✅ 0.0.1+ | ✅ 1.0.0+ | Current |
+| 1.2.0 | ✅ 0.0.1+ | ✅ 1.0.0+ | Transitional support |
 | 1.1.1 | ✅ 0.0.1+ | ✅ 1.0.0+ | Transitional support |
 | 1.0.0 | ✅ 0.0.1+ | ✅ 1.0.0+ | Transitional support |
 
@@ -76,8 +78,8 @@ npm run protocol:version:major
 
 ```typescript
 // In protocol package
-export const PROTOCOL_VERSION = '1.2.0';
-export const SUPPORTED_PROTOCOL_VERSIONS = ['1.2.0', '1.1.1', '1.0.0'];
+export const PROTOCOL_VERSION = '1.3.0';
+export const SUPPORTED_PROTOCOL_VERSIONS = ['1.3.0', '1.2.0', '1.1.1', '1.0.0'];
 ```
 
 ## CI Enforcement

--- a/package-lock.json
+++ b/package-lock.json
@@ -9967,7 +9967,7 @@
     },
     "packages/protocol": {
       "name": "@kaonis/woly-protocol",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^4.0.0"

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -28,7 +28,7 @@
 - `hostSchema` — Validates `Host` object
 - `commandStateSchema` — Validates `CommandState`
 - `errorResponseSchema` — Validates `ErrorResponse` object
-- `cncCapabilitiesResponseSchema` / `cncCapabilityDescriptorSchema` — Validates CNC capabilities payload
+- `cncCapabilitiesResponseSchema` / `cncCapabilityDescriptorSchema` / `cncRateLimitDescriptorSchema` / `cncRateLimitsSchema` — Validates CNC capabilities and rate-limit payloads
 - `hostPortSchema` / `hostPortScanResponseSchema` — Validates host port scan payloads
 - `hostWakeScheduleSchema` / `hostSchedulesResponseSchema` / `createHostWakeScheduleRequestSchema` / `updateHostWakeScheduleRequestSchema` — Validates schedules payloads
 - `hostStateStreamEventSchema` — Validates mobile host-state stream events
@@ -37,8 +37,8 @@
 
 ### Constants
 
-- `PROTOCOL_VERSION` — Current protocol version (`'1.2.0'`)
-- `SUPPORTED_PROTOCOL_VERSIONS` — Array of supported versions (`['1.2.0', '1.1.1', '1.0.0']`)
+- `PROTOCOL_VERSION` — Current protocol version (`'1.3.0'`)
+- `SUPPORTED_PROTOCOL_VERSIONS` — Array of supported versions (`['1.3.0', '1.2.0', '1.1.1', '1.0.0']`)
 
 ## Usage
 
@@ -98,6 +98,7 @@ Output goes to `dist/`. Both `main` and `types` in package.json point there.
 - `1.0.x`: Base node ↔ C&C message contracts (`Host`, `NodeMessage`, `CncCommand`).
 - `1.1.x`: CNC app/backend API contracts (`CncCapabilitiesResponse`, schedules, host port scan DTOs/schemas) and wire protocol negotiation update.
 - `1.2.x`: Host metadata/scan enrichments (`openPorts`, `portsScannedAt`, `portsExpireAt`), ping/port-scan command/result payloads, and consumer typecheck fixture parity.
+- `1.3.x`: CNC capability-map enrichments (`hostStateStreaming`, optional `rateLimits`) and exported CNC rate-limit descriptor schemas.
 
 ## Testing
 
@@ -126,9 +127,9 @@ From the **monorepo root**, use the provided npm scripts:
 
 ```bash
 # 1. Bump version (patch/minor/major)
-npm run protocol:version:patch   # For bug fixes (1.2.0 → 1.2.1)
-npm run protocol:version:minor   # For new features (1.2.0 → 1.3.0)
-npm run protocol:version:major   # For breaking changes (1.2.0 → 2.0.0)
+npm run protocol:version:patch   # For bug fixes (1.3.0 → 1.3.1)
+npm run protocol:version:minor   # For new features (1.3.0 → 1.4.0)
+npm run protocol:version:major   # For breaking changes (1.3.0 → 2.0.0)
 
 # 2. Publish to npm (builds automatically)
 npm run protocol:publish         # Publish with 'latest' tag

--- a/packages/protocol/fixtures/app-consumer/index.ts
+++ b/packages/protocol/fixtures/app-consumer/index.ts
@@ -14,7 +14,7 @@ const capabilities: CncCapabilitiesResponse = {
   mode: 'cnc',
   versions: {
     cncApi: '1.0.0',
-    protocol: '1.2.0',
+    protocol: '1.3.0',
   },
   capabilities: {
     scan: { supported: true },
@@ -22,6 +22,15 @@ const capabilities: CncCapabilitiesResponse = {
     schedules: { supported: true, routes: ['/api/hosts/:fqn/schedules'] },
     hostStateStreaming: { supported: true, transport: 'websocket', routes: ['/ws/mobile/hosts'] },
     commandStatusStreaming: { supported: false, transport: null },
+  },
+  rateLimits: {
+    strictAuth: { maxCalls: 5, windowMs: 900_000, scope: 'ip' },
+    auth: { maxCalls: 10, windowMs: 900_000, scope: 'ip' },
+    api: { maxCalls: 300, windowMs: 900_000, scope: 'ip' },
+    scheduleSync: { maxCalls: 3_000, windowMs: 900_000, scope: 'ip' },
+    wsInboundMessages: { maxCalls: 100, windowMs: 1_000, scope: 'connection' },
+    wsConnectionsPerIp: { maxCalls: 10, windowMs: null, scope: 'ip' },
+    macVendorLookup: { maxCalls: 1, windowMs: 1_000, scope: 'global' },
   },
 };
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaonis/woly-protocol",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Shared WoLy node <-> C&C protocol types and runtime schemas",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 // --- Protocol versioning ---
 
-export const PROTOCOL_VERSION = '1.2.0' as const;
-export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [PROTOCOL_VERSION, '1.1.1', '1.0.0'];
+export const PROTOCOL_VERSION = '1.3.0' as const;
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [PROTOCOL_VERSION, '1.2.0', '1.1.1', '1.0.0'];
 
 // --- Shared types ---
 


### PR DESCRIPTION
## Summary
- bump protocol package and exported protocol version to 1.3.0
- include 1.2.0 as transitional supported protocol version
- sync protocol docs and consumer fixture for new capability/rate-limit contract fields

## Validation
- npm run build -w packages/protocol
- npm run test -w packages/protocol -- contract.cross-repo
- npm run protocol:consumer-typecheck
- npm run test -w apps/cnc -- src/services/__tests__/protocol.contract.test.ts src/routes/__tests__/mobileCompatibility.smoke.test.ts
- npm run test -w apps/node-agent -- src/__tests__/protocol.contract.unit.test.ts
- npm run typecheck -w packages/protocol
- npm run typecheck -w apps/cnc
- npm run typecheck -w apps/node-agent

## Release
- published @kaonis/woly-protocol@1.3.0 to npm (latest)