### PR TITLE
feat: async WoL success verification

### DIFF
--- a/apps/cnc/src/controllers/__tests__/capabilities.test.ts
+++ b/apps/cnc/src/controllers/__tests__/capabilities.test.ts
@@ -47,6 +47,15 @@ describe('CapabilitiesController', () => {
     });
   });
 
+  it('includes wakeVerification capability in capabilities response', () => {
+    const response = buildCncCapabilitiesResponse();
+    expect(response.capabilities.wakeVerification).toEqual({
+      supported: true,
+      transport: 'websocket',
+      note: expect.any(String),
+    });
+  });
+
   it('falls back and logs warnings when versions are invalid', () => {
     const fallbackProtocol = Array.isArray(SUPPORTED_PROTOCOL_VERSIONS)
       ? (SUPPORTED_PROTOCOL_VERSIONS.find((version) => typeof version === 'string' && version.trim()) ?? '1.0.0')

--- a/apps/cnc/src/controllers/__tests__/hosts.additional.test.ts
+++ b/apps/cnc/src/controllers/__tests__/hosts.additional.test.ts
@@ -215,6 +215,7 @@ describe('HostsController additional branches', () => {
       expect(commandRouter.routeWakeCommand).toHaveBeenCalledWith('desktop@lab', {
         idempotencyKey: 'wake-1',
         correlationId: 'cid-request',
+        verify: null,
       });
       expect(res.json).toHaveBeenCalledWith({
         success: true,
@@ -245,6 +246,7 @@ describe('HostsController additional branches', () => {
       expect(commandRouter.routeWakeCommand).toHaveBeenCalledWith('desktop@lab', {
         idempotencyKey: null,
         correlationId: 'cid-request',
+        verify: null,
       });
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ correlationId: 'cid-request' })

--- a/apps/cnc/src/controllers/capabilities.ts
+++ b/apps/cnc/src/controllers/capabilities.ts
@@ -62,6 +62,11 @@ const capabilityMatrix: CncCapabilitiesResponse['capabilities'] = {
     transport: null,
     note: 'Dedicated frontend-facing stream is planned alongside kaonis/woly#311.',
   },
+  wakeVerification: {
+    supported: true,
+    transport: 'websocket',
+    note: 'Post-WoL verification results stream as wake.verified events on /ws/mobile/hosts. Request with ?verify=true on the wake endpoint.',
+  },
 };
 
 export function buildCncCapabilitiesResponse(

--- a/apps/cnc/src/controllers/hosts.ts
+++ b/apps/cnc/src/controllers/hosts.ts
@@ -361,8 +361,19 @@ export class HostsController {
           ? idempotencyKeyHeader.trim()
           : null;
 
-      const routeOptions: { idempotencyKey: string | null; correlationId?: string } = {
+      // Parse optional wake verification request from query string or body
+      const verifyParam = req.query.verify ?? (req.body as Record<string, unknown> | undefined)?.verify;
+      const verify = verifyParam === 'true' || verifyParam === true
+        ? { timeoutMs: 120_000, pollIntervalMs: 3_000 }
+        : null;
+
+      const routeOptions: {
+        idempotencyKey: string | null;
+        correlationId?: string;
+        verify?: { timeoutMs: number; pollIntervalMs: number } | null;
+      } = {
         idempotencyKey,
+        verify,
       };
       if (correlationId) {
         routeOptions.correlationId = correlationId;

--- a/apps/cnc/src/server.ts
+++ b/apps/cnc/src/server.ts
@@ -45,6 +45,7 @@ class Server {
     this.nodeManager = new NodeManager(this.hostAggregator);
     this.commandRouter = new CommandRouter(this.nodeManager, this.hostAggregator);
     this.hostStateStreamBroker = new HostStateStreamBroker(this.hostAggregator);
+    this.hostStateStreamBroker.subscribeToCommandRouter(this.commandRouter);
     this.setupMiddleware();
     this.setupRoutes();
     this.setupWebSocket();

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -13,6 +13,7 @@ import type {
   HostPortScanResponse as ProtocolHostPortScanResponse,
   NodeMetadata as ProtocolNodeMetadata,
   ScheduleFrequency as ProtocolScheduleFrequency,
+  WakeVerificationResult as ProtocolWakeVerificationResult,
 } from '@kaonis/woly-protocol';
 
 // Node Types
@@ -61,6 +62,7 @@ export interface CommandResult {
   error?: string;
   hostPing?: ProtocolHostPingResult;
   hostPortScan?: ProtocolHostPortScanResult;
+  wakeVerification?: ProtocolWakeVerificationResult;
   timestamp: Date;
   correlationId?: string;
 }
@@ -86,6 +88,7 @@ export type HostPingResult = ProtocolHostPingResult;
 export type HostPortScanResponse = ProtocolHostPortScanResponse;
 export type ScheduleFrequency = ProtocolScheduleFrequency;
 export type HostWakeSchedule = ProtocolHostWakeSchedule;
+export type WakeVerificationResult = ProtocolWakeVerificationResult;
 
 export interface HostPingResponse {
   target: string;
@@ -103,6 +106,10 @@ export interface WakeupResponse {
   nodeId: string;
   location: string;
   correlationId?: string;
+  wakeVerification?: {
+    status: 'pending';
+    startedAt: string;
+  };
 }
 
 export interface CommandRecord {

--- a/apps/node-agent/src/config/index.ts
+++ b/apps/node-agent/src/config/index.ts
@@ -50,4 +50,9 @@ export const config = {
     timeoutMs: parseInt(process.env.WAKE_VERIFY_TIMEOUT_MS || '10000', 10),
     pollIntervalMs: parseInt(process.env.WAKE_VERIFY_POLL_INTERVAL_MS || '1000', 10),
   },
+  /** Wake verification settings used when a CNC-routed wake command includes verify options. */
+  wakeVerificationCnc: {
+    timeoutMs: parseInt(process.env.WAKE_VERIFY_CNC_TIMEOUT_MS || '120000', 10), // 2 minutes
+    pollIntervalMs: parseInt(process.env.WAKE_VERIFY_CNC_POLL_INTERVAL_MS || '3000', 10), // 3 seconds
+  },
 };


### PR DESCRIPTION
## CNC Sync Classification

- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: kaonis/woly-server#333
- Backend issue: kaonis/woly-server#333
- Frontend issue: kaonis/woly#422

## 3-Part Chain Checklist (required for CNC feature changes)

- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
npm run lint
npm run typecheck
npm run test:ci
npm run build
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- No known functional gaps in this backend/protocol slice.
- Frontend follow-up is tracked in kaonis/woly#422.

## Summary

- **Protocol 1.3.0**: Add `WakeVerificationResult`, `WakeVerifyOptions` types + Zod schemas; extend `CommandResultPayload` and `CncCommand` wake variant; add `wake.verified` to host-state stream events
- **Node-agent**: Background ARP/ping polling after WoL packet send with configurable timeout (120s) and poll interval (3s); sends follow-up command-result with verification outcome
- **C&C**: CommandRouter tracks wake commands awaiting verification; emits `wake-verification-complete` on follow-up; HostStateStreamBroker broadcasts `wake.verified` events to mobile clients; wake endpoint accepts `?verify=true`

Closes #333

## Test plan

- [x] Protocol: WakeVerificationResult/WakeVerifyOptions schema validation (8 new tests)
- [x] Protocol: wake command with verify options validates
- [x] Protocol: wake.verified event type accepted as mutating stream event
- [x] Protocol: command-result with wakeVerification payload validates
- [x] Protocol: capabilities with optional wakeVerification validates
- [x] C&C: follow-up command-result emits wake-verification-complete event
- [x] C&C: untracked follow-up commands do not emit events
- [x] C&C: cleanup clears wake verification tracking
- [x] C&C: HostStateStreamBroker broadcasts wake.verified on command router event
- [x] C&C: HostStateStreamBroker detaches from command router on shutdown
- [x] C&C: capabilities includes wakeVerification descriptor
- [x] Full validation pass: lint ✅ typecheck ✅ test:ci (167+539 tests) ✅ build ✅
