### PR TITLE
feat(cnc): implement /api/hosts/scan endpoint and capability parity

### DIFF
--- a/apps/cnc/src/controllers/__tests__/capabilities.test.ts
+++ b/apps/cnc/src/controllers/__tests__/capabilities.test.ts
@@ -38,6 +38,11 @@ describe('CapabilitiesController', () => {
       cncApi: '1.2.3',
       protocol: '2.0.0',
     });
+    expect(response.capabilities.scan.routes).toEqual([
+      '/api/hosts/scan',
+      '/api/hosts/ports/:fqn',
+      '/api/hosts/scan-ports/:fqn',
+    ]);
     expect(response.capabilities.schedules.routes).toEqual(['/api/schedules', '/api/schedules/:id']);
     expect(response.capabilities.hostStateStreaming).toEqual({
       supported: true,

--- a/apps/cnc/src/controllers/__tests__/meta.test.ts
+++ b/apps/cnc/src/controllers/__tests__/meta.test.ts
@@ -48,6 +48,11 @@ describe('buildCncCapabilitiesResponse', () => {
       transport: 'websocket',
       routes: ['/ws/mobile/hosts'],
     });
+    expect(payload.capabilities.scan.routes).toEqual([
+      '/api/hosts/scan',
+      '/api/hosts/ports/:fqn',
+      '/api/hosts/scan-ports/:fqn',
+    ]);
     expect(payload.capabilities.commandStatusStreaming).toMatchObject({
       supported: false,
       transport: null,

--- a/apps/cnc/src/controllers/capabilities.ts
+++ b/apps/cnc/src/controllers/capabilities.ts
@@ -37,7 +37,7 @@ function resolveCapabilityVersion(
 const capabilityMatrix: CncCapabilitiesResponse['capabilities'] = {
   scan: {
     supported: true,
-    routes: ['/api/hosts/ports/:fqn', '/api/hosts/scan-ports/:fqn'],
+    routes: ['/api/hosts/scan', '/api/hosts/ports/:fqn', '/api/hosts/scan-ports/:fqn'],
     note: 'Per-host open-port telemetry is available through node-side TCP probing and cached in host payloads for short-lived reuse.',
   },
   notesTags: {

--- a/apps/cnc/src/controllers/meta.ts
+++ b/apps/cnc/src/controllers/meta.ts
@@ -39,7 +39,7 @@ function resolveCapabilityVersion(
 const capabilityMatrix: CncCapabilitiesResponse['capabilities'] = {
   scan: {
     supported: true,
-    routes: ['/api/hosts/ports/:fqn', '/api/hosts/scan-ports/:fqn'],
+    routes: ['/api/hosts/scan', '/api/hosts/ports/:fqn', '/api/hosts/scan-ports/:fqn'],
     note: 'Per-host open-port telemetry is available through node-side TCP probing and cached in host payloads for short-lived reuse.',
   },
   notesTags: {

--- a/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/capabilitiesRoutes.test.ts
@@ -92,7 +92,10 @@ describe('Capabilities Routes', () => {
           protocol: PROTOCOL_VERSION,
         },
         capabilities: {
-          scan: expect.objectContaining({ supported: true }),
+          scan: expect.objectContaining({
+            supported: true,
+            routes: ['/api/hosts/scan', '/api/hosts/ports/:fqn', '/api/hosts/scan-ports/:fqn'],
+          }),
           notesTags: expect.objectContaining({ supported: true, persistence: 'backend' }),
           schedules: expect.objectContaining({ supported: true, persistence: 'backend' }),
           hostStateStreaming: expect.objectContaining({

--- a/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
@@ -48,6 +48,10 @@ describe('Host Routes Authentication and Authorization', () => {
 
     const commandRouter = {
       routeWakeCommand: jest.fn().mockRejectedValue(new Error('Node not connected')),
+      routeScanHostsCommand: jest.fn().mockResolvedValue({
+        state: 'acknowledged',
+        queuedAt: '2026-02-18T00:00:00.000Z',
+      }),
       routePingHostCommand: jest.fn().mockRejectedValue(new Error('Host not found: node1.example.com')),
       routeScanHostPortsCommand: jest
         .fn()
@@ -344,6 +348,58 @@ describe('Host Routes Authentication and Authorization', () => {
 
       // Will be 404 since host doesn't exist in mock, but auth passed
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/hosts/scan', () => {
+    it('returns 401 when no authorization header is provided', async () => {
+      const response = await request(app).post('/api/hosts/scan');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for unsupported role', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .post('/api/hosts/scan')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+
+    it('allows access with valid operator token', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'operator',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .post('/api/hosts/scan')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        state: 'acknowledged',
+      });
     });
   });
 

--- a/apps/cnc/src/routes/__tests__/metaRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/metaRoutes.test.ts
@@ -105,7 +105,10 @@ describe('Capabilities Route', () => {
           protocol: PROTOCOL_VERSION,
         },
         capabilities: {
-          scan: { supported: true },
+          scan: {
+            supported: true,
+            routes: ['/api/hosts/scan', '/api/hosts/ports/:fqn', '/api/hosts/scan-ports/:fqn'],
+          },
           notesTags: { supported: true, persistence: 'backend' },
           schedules: {
             supported: true,

--- a/apps/cnc/src/routes/index.ts
+++ b/apps/cnc/src/routes/index.ts
@@ -82,6 +82,7 @@ export function createRoutes(
   router.get('/hosts/ping/:fqn', (req, res) => hostsController.pingHost(req, res));
   router.get('/hosts/ports/:fqn', (req, res) => hostsController.getHostPorts(req, res));
   router.get('/hosts/scan-ports/:fqn', (req, res) => hostsController.scanHostPorts(req, res));
+  router.post('/hosts/scan', (req, res) => hostsController.scanHosts(req, res));
   // IMPORTANT: schedule routes must be registered before the :fqn catch-all
   router.get('/hosts/:fqn/schedules', scheduleSyncLimiter, (req, res) =>
     schedulesController.listHostSchedules(req, res),


### PR DESCRIPTION
## Summary
- add `POST /api/hosts/scan` route and controller handler for CNC deployments
- dispatch scan commands across connected nodes and return normalized scan lifecycle payloads
- include `/api/hosts/scan` in `capabilities.scan.routes` to keep endpoint/capability negotiation in sync
- extend route/controller/command-router/mobile-compat tests to cover the new path and parity behavior

## Linked issues
- Protocol issue: kaonis/woly-server#254
- Backend issue: kaonis/woly-server#288
- Frontend issue: kaonis/woly#354

## Validation
- npm run build -w packages/protocol
- npm run test -w packages/protocol -- contract.cross-repo
- npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
- npm run test -w apps/cnc -- src/controllers/__tests__/hosts.additional.test.ts src/services/__tests__/commandRouter.unit.test.ts src/routes/__tests__/hostRoutes.test.ts src/routes/__tests__/mobileCompatibility.smoke.test.ts src/controllers/__tests__/meta.test.ts src/controllers/__tests__/capabilities.test.ts src/routes/__tests__/metaRoutes.test.ts src/routes/__tests__/capabilitiesRoutes.test.ts
- npm run validate:standard
