### PR TITLE
docs(protocol): clarify CNC polling identity/stability expectations

### DIFF
--- a/docs/PROTOCOL_COMPATIBILITY.md
+++ b/docs/PROTOCOL_COMPATIBILITY.md
@@ -82,6 +82,32 @@ export const PROTOCOL_VERSION = '1.3.0';
 export const SUPPORTED_PROTOCOL_VERSIONS = ['1.3.0', '1.2.0', '1.1.1', '1.0.0'];
 ```
 
+## Polling Snapshot Contract (CNC Clients)
+
+This section clarifies host-list polling expectations for clients consuming `GET /api/hosts` in CNC mode.
+
+### Identity and Diffing
+
+- Preferred host identity key: `fullyQualifiedName` from the aggregated host payload.
+- If a client needs a fallback key, use a composite key (`nodeId`, `mac`) rather than array index.
+- Host rename or location move can change `fullyQualifiedName`; clients should treat that as an identity transition (remove old key, add new key).
+
+### Stability Guarantees
+
+- The protocol guarantees field shapes and required/optional semantics, not object-reference stability.
+- Clients must not assume stable in-memory object identity across polls.
+- Clients should perform key-based diffing and selective field comparison for render optimization.
+
+### Explicit Non-Guarantees
+
+- The protocol does not guarantee array ordering semantics for host snapshots across implementations.
+- The protocol does not require "unchanged host" snapshots to preserve property insertion order or JSON text identity.
+
+### Practical Guidance
+
+- Use conditional requests (`ETag` + `If-None-Match`) where available to avoid unnecessary full-list processing.
+- Treat host-state stream events as invalidation hints; `GET /api/hosts` remains the authoritative polling snapshot source.
+
 ## CI Enforcement
 
 ### Protocol Compatibility Job

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -100,6 +100,16 @@ Output goes to `dist/`. Both `main` and `types` in package.json point there.
 - `1.2.x`: Host metadata/scan enrichments (`openPorts`, `portsScannedAt`, `portsExpireAt`), ping/port-scan command/result payloads, and consumer typecheck fixture parity.
 - `1.3.x`: CNC capability-map enrichments (`hostStateStreaming`, optional `rateLimits`) and exported CNC rate-limit descriptor schemas.
 
+## CNC Polling Identity Notes
+
+For CNC polling consumers (`GET /api/hosts`), treat host identity as a key-based contract, not an object-reference contract:
+
+- Prefer `fullyQualifiedName` as the row identity key in UI/state layers.
+- Use (`nodeId`, `mac`) as a fallback key strategy when needed.
+- Do not rely on array index, object reference equality, or JSON property ordering for change detection.
+
+Detailed stability guarantees and non-guarantees are documented in [`docs/PROTOCOL_COMPATIBILITY.md`](../../docs/PROTOCOL_COMPATIBILITY.md#polling-snapshot-contract-cnc-clients).
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Summary
- document explicit polling identity and stability guidance for CNC clients in `docs/PROTOCOL_COMPATIBILITY.md`
- add protocol package consumer notes in `packages/protocol/README.md` so app/backend consumers have a single reference point
- clarify guarantees vs non-guarantees for unchanged host snapshots (key-based diffing, no object-reference/order guarantees)

## Linked issues
- Protocol issue: kaonis/woly-server#329
- Backend issue: kaonis/woly-server#328
- Frontend issue: kaonis/woly#397

## Validation
- Docs-only change (no runtime/schema changes)
