### PR TITLE
docs: record local app-side WoL fallback as protocol no-op

### DIFF
--- a/docs/CNC_SYNC_POLICY.md
+++ b/docs/CNC_SYNC_POLICY.md
@@ -79,7 +79,15 @@ The mobile app now maintains a single shared app-level host stream connection (s
 - Reconnect behavior: clients should reconnect on transient disconnects and then refetch current host state; stream events are not guaranteed replay buffers.
 - Payload model: events are **mixed deltas/summaries** (not authoritative snapshots). Canonical state remains `GET /api/hosts`; stream events are invalidation hints.
 
-## 9. Polling Snapshot Stability (GET /api/hosts)
+## 9. Local App-Side Wake Fallback Classification (Issue #323)
+
+- Scope: mobile app LAN fallback Wake-on-LAN transport implemented in `kaonis/woly`.
+- Protocol impact: none.
+- CNC request/response contracts: unchanged.
+- Capability negotiation format/versioning: unchanged.
+- Decision: classify local app-side wake fallback as an execution-strategy change in the app, not a CNC protocol contract delta.
+
+## 10. Polling Snapshot Stability (GET /api/hosts)
 
 Backend assessment for polling clients (tracked by `kaonis/woly-server#328`):
 

--- a/docs/ROADMAP_CNC_SYNC_V1.md
+++ b/docs/ROADMAP_CNC_SYNC_V1.md
@@ -75,6 +75,9 @@
 - Cross-repo compatibility tests cover success and error envelope.
 - Migration notes are added for any behavior changes.
 
+## Decision Log Updates
+- 2026-02-18 (issue #323): Classified app-local LAN Wake-on-LAN fallback (`kaonis/woly`) as a protocol no-op with no CNC contract delta; capability negotiation and protocol request/response shapes remain unchanged.
+
 ## Rolling Manual-CI Progress
 - 2026-02-18: Completed weekly manual-first operations review for issue #280 using `npm run ci:audit:manual -- --since 2026-02-16T18:35:12Z --fail-on-unexpected` (PASS) and `npm run ci:policy:check` (PASS).
 - 2026-02-18: Logged review decision in `docs/CI_MANUAL_REVIEW_LOG.md` and checkpoint updates in `docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md`.


### PR DESCRIPTION
## Summary
- add explicit CNC sync policy guidance that app-local LAN WoL fallback is not a CNC protocol contract change
- record the same decision in the CNC roadmap decision log for traceability

Closes #323.

## CNC Sync Classification

- [ ] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: N/A
- Backend issue: N/A
- Frontend issue: N/A

## 3-Part Chain Checklist (required for CNC feature changes)

- [ ] Protocol contract updated or verified.
- [ ] Backend endpoint/command implemented or explicitly unchanged.
- [ ] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [ ] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [ ] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
npm run ci:policy:check
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- Scope is documentation-only.
