### PR TITLE
docs: mark local app-side WoL fallback as backend-neutral

### DIFF
--- a/docs/CNC_SYNC_POLICY.md
+++ b/docs/CNC_SYNC_POLICY.md
@@ -87,7 +87,14 @@ The mobile app now maintains a single shared app-level host stream connection (s
 - Capability negotiation format/versioning: unchanged.
 - Decision: classify local app-side wake fallback as an execution-strategy change in the app, not a CNC protocol contract delta.
 
-## 10. Polling Snapshot Stability (GET /api/hosts)
+## 10. Backend Impact for Local App-Side Wake Fallback (Issue #324)
+
+- Backend API/endpoints remain unchanged for this increment.
+- Existing remote wake path remains unchanged (`POST /api/hosts/wakeup/:fqn`).
+- No node-agent protocol or command-surface changes are required.
+- Decision: treat this frontend fallback as backend-neutral for CNC sync chain tracking.
+
+## 11. Polling Snapshot Stability (GET /api/hosts)
 
 Backend assessment for polling clients (tracked by `kaonis/woly-server#328`):
 

--- a/docs/ROADMAP_CNC_SYNC_V1.md
+++ b/docs/ROADMAP_CNC_SYNC_V1.md
@@ -77,6 +77,7 @@
 
 ## Decision Log Updates
 - 2026-02-18 (issue #323): Classified app-local LAN Wake-on-LAN fallback (`kaonis/woly`) as a protocol no-op with no CNC contract delta; capability negotiation and protocol request/response shapes remain unchanged.
+- 2026-02-18 (issue #324): Verified backend impact is unchanged for app-local LAN Wake-on-LAN fallback; existing remote wake endpoint (`POST /api/hosts/wakeup/:fqn`) and command flow remain unchanged.
 
 ## Rolling Manual-CI Progress
 - 2026-02-18: Completed weekly manual-first operations review for issue #280 using `npm run ci:audit:manual -- --since 2026-02-16T18:35:12Z --fail-on-unexpected` (PASS) and `npm run ci:policy:check` (PASS).


### PR DESCRIPTION
## Summary
- document backend impact review for app-local LAN Wake-on-LAN fallback
- record explicit decision that backend API/remote wake command path is unchanged
- add roadmap decision-log traceability for issue linkage

Closes #324.

## CNC Sync Classification

- [ ] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: N/A
- Backend issue: N/A
- Frontend issue: N/A

## 3-Part Chain Checklist (required for CNC feature changes)

- [ ] Protocol contract updated or verified.
- [ ] Backend endpoint/command implemented or explicitly unchanged.
- [ ] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [ ] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [ ] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
npm run ci:policy:check
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- Scope is documentation-only.
