### PR TITLE
[Coverage][CNC] cover bootstrap entrypoints and raise branch coverage (#318)

### DIFF
--- a/apps/cnc/src/__tests__/server.bootstrap.test.ts
+++ b/apps/cnc/src/__tests__/server.bootstrap.test.ts
@@ -1,0 +1,324 @@
+import request from 'supertest';
+
+jest.mock('../config', () => ({
+  __esModule: true,
+  default: {
+    port: 8080,
+    nodeEnv: 'test',
+    trustProxy: false,
+    corsOrigins: ['http://allowed.local'],
+    commandTimeout: 30000,
+    commandRetentionDays: 30,
+    scheduleWorkerEnabled: true,
+    schedulePollIntervalMs: 1000,
+    scheduleBatchSize: 10,
+  },
+}));
+
+jest.mock('../database/connection', () => ({
+  __esModule: true,
+  default: {
+    connect: jest.fn(),
+    close: jest.fn(),
+  },
+}));
+
+jest.mock('../services/nodeManager', () => ({
+  NodeManager: jest.fn().mockImplementation(() => ({
+    shutdown: jest.fn(),
+  })),
+}));
+
+jest.mock('../services/hostAggregator', () => ({
+  HostAggregator: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../services/commandRouter', () => ({
+  CommandRouter: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../services/hostStateStreamBroker', () => ({
+  HostStateStreamBroker: jest.fn().mockImplementation(() => ({
+    subscribeToCommandRouter: jest.fn(),
+    shutdown: jest.fn(),
+  })),
+}));
+
+jest.mock('../routes', () => ({
+  createRoutes: jest.fn(() => {
+    const express = jest.requireActual('express') as typeof import('express');
+    return express.Router();
+  }),
+}));
+
+jest.mock('../websocket/server', () => ({
+  createWebSocketServer: jest.fn(),
+}));
+
+jest.mock('../middleware/errorHandler', () => ({
+  errorHandler: (_err: unknown, _req: unknown, res: { status: (code: number) => { json: (body: unknown) => void } }) => {
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Unhandled error',
+    });
+  },
+}));
+
+jest.mock('../services/commandReconciler', () => ({
+  reconcileCommandsOnStartup: jest.fn(),
+  startCommandPruning: jest.fn(),
+  stopCommandPruning: jest.fn(),
+}));
+
+jest.mock('../services/wakeScheduleWorker', () => ({
+  startWakeScheduleWorker: jest.fn(),
+  stopWakeScheduleWorker: jest.fn(),
+}));
+
+jest.mock('../services/runtimeMetrics', () => ({
+  runtimeMetrics: {
+    reset: jest.fn(),
+    snapshot: jest.fn(() => ({ commands: { total: 0 } })),
+  },
+}));
+
+jest.mock('../services/promMetrics', () => ({
+  prometheusContentType: jest.fn(() => 'text/plain; version=0.0.4'),
+  renderPrometheusMetrics: jest.fn(async () => 'woly_cnc_commands_total 0\n'),
+}));
+
+jest.mock('../utils/cncVersion', () => ({
+  CNC_VERSION: '1.2.3-test',
+}));
+
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { runServerCli, Server, isAllowedCorsOrigin } from '../server';
+import config from '../config';
+import db from '../database/connection';
+import logger from '../utils/logger';
+import { createRoutes } from '../routes';
+import { createWebSocketServer } from '../websocket/server';
+import { runtimeMetrics } from '../services/runtimeMetrics';
+import {
+  reconcileCommandsOnStartup,
+  startCommandPruning,
+  stopCommandPruning,
+} from '../services/commandReconciler';
+import { startWakeScheduleWorker, stopWakeScheduleWorker } from '../services/wakeScheduleWorker';
+import { prometheusContentType, renderPrometheusMetrics } from '../services/promMetrics';
+
+describe('server bootstrap and wiring', () => {
+  const mockedDb = db as jest.Mocked<typeof db>;
+  const mockedLogger = logger as jest.Mocked<typeof logger>;
+  const mockedConfig = config as unknown as {
+    nodeEnv: string;
+    corsOrigins: string[];
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedConfig.nodeEnv = 'test';
+    mockedConfig.corsOrigins = ['http://allowed.local'];
+    mockedDb.connect.mockResolvedValue(undefined);
+    mockedDb.close.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+  });
+
+  it('evaluates allowed CORS origins correctly', () => {
+    expect(isAllowedCorsOrigin('https://example.com', ['*'])).toBe(true);
+    expect(isAllowedCorsOrigin('https://allowed.local', ['https://allowed.local'])).toBe(true);
+    expect(isAllowedCorsOrigin('https://blocked.local', ['https://allowed.local'])).toBe(false);
+  });
+
+  it('applies production CORS policy for allowed, blocked, and missing origins', async () => {
+    mockedConfig.nodeEnv = 'production';
+    mockedConfig.corsOrigins = ['https://allowed.local'];
+    const server = new Server();
+    const app = (server as unknown as { app: Parameters<typeof request>[0] }).app;
+
+    const noOriginResponse = await request(app).get('/health');
+    expect(noOriginResponse.status).toBe(200);
+
+    const allowedResponse = await request(app)
+      .get('/health')
+      .set('Origin', 'https://allowed.local');
+    expect(allowedResponse.status).toBe(200);
+    expect(allowedResponse.headers['access-control-allow-origin']).toBe('https://allowed.local');
+
+    const blockedResponse = await request(app)
+      .get('/health')
+      .set('Origin', 'https://blocked.local');
+    expect(blockedResponse.status).toBe(200);
+    expect(blockedResponse.headers['access-control-allow-origin']).toBeUndefined();
+    expect(mockedLogger.warn).toHaveBeenCalledWith('Blocked by CORS policy', {
+      origin: 'https://blocked.local',
+    });
+  });
+
+  it('registers health/root/metrics routes and uses injected dependencies', async () => {
+    const server = new Server();
+    const app = (server as unknown as { app: Parameters<typeof request>[0] }).app;
+
+    const healthResponse = await request(app).get('/health');
+    expect(healthResponse.status).toBe(200);
+    expect(healthResponse.body).toEqual(
+      expect.objectContaining({
+        status: 'healthy',
+        version: '1.2.3-test',
+      }),
+    );
+    expect(runtimeMetrics.snapshot).toHaveBeenCalled();
+
+    const metricsResponse = await request(app).get('/metrics');
+    expect(metricsResponse.status).toBe(200);
+    expect(metricsResponse.text).toContain('woly_cnc_commands_total');
+    expect(prometheusContentType).toHaveBeenCalled();
+    expect(renderPrometheusMetrics).toHaveBeenCalled();
+
+    const rootResponse = await request(app).get('/');
+    expect(rootResponse.status).toBe(200);
+    expect(rootResponse.body).toEqual(
+      expect.objectContaining({
+        name: 'WoLy C&C Backend',
+        version: '1.2.3-test',
+        status: 'running',
+      }),
+    );
+
+    const missingResponse = await request(app).get('/missing-route');
+    expect(missingResponse.status).toBe(404);
+    expect(missingResponse.body).toEqual({
+      error: 'Not Found',
+      message: 'Route GET /missing-route not found',
+    });
+
+    expect(createRoutes).toHaveBeenCalledTimes(1);
+    expect(createWebSocketServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts successfully and schedules reconciliation/pruning workers', async () => {
+    const server = new Server();
+    const httpServer = (server as unknown as { httpServer: { listen: (...args: unknown[]) => unknown } }).httpServer;
+    const listenSpy = jest
+      .spyOn(httpServer, 'listen')
+      .mockImplementation(((port: number, callback?: () => void) => {
+        if (callback) {
+          callback();
+        }
+        return httpServer;
+      }) as typeof httpServer.listen);
+    const setupGracefulShutdownSpy = jest
+      .spyOn(server as unknown as { setupGracefulShutdown: () => void }, 'setupGracefulShutdown')
+      .mockImplementation(() => undefined);
+
+    await server.start();
+
+    expect(mockedDb.connect).toHaveBeenCalledTimes(1);
+    expect(reconcileCommandsOnStartup).toHaveBeenCalledWith({ commandTimeoutMs: 30000 });
+    expect(startCommandPruning).toHaveBeenCalledWith(30);
+    expect(startWakeScheduleWorker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        pollIntervalMs: 1000,
+        batchSize: 10,
+      }),
+    );
+    expect(listenSpy).toHaveBeenCalledWith(8080, expect.any(Function));
+    expect(setupGracefulShutdownSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and exits when startup fails', async () => {
+    mockedDb.connect.mockRejectedValueOnce(new Error('connect failed'));
+    const server = new Server();
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    await server.start();
+
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      'Failed to start server',
+      expect.objectContaining({
+        error: expect.any(Error),
+      }),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('handles graceful shutdown when SIGTERM is received', async () => {
+    const server = new Server();
+    const httpServer = (server as unknown as { httpServer: { close: (...args: unknown[]) => unknown } }).httpServer;
+    const closeSpy = jest
+      .spyOn(httpServer, 'close')
+      .mockImplementation(((callback?: () => void) => {
+        if (callback) {
+          callback();
+        }
+        return httpServer;
+      }) as typeof httpServer.close);
+    const nodeManager = (server as unknown as { nodeManager: { shutdown: jest.Mock } }).nodeManager;
+    const hostStateStreamBroker = (
+      server as unknown as { hostStateStreamBroker: { shutdown: jest.Mock } }
+    ).hostStateStreamBroker;
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    (server as unknown as { setupGracefulShutdown: () => void }).setupGracefulShutdown();
+    process.emit('SIGTERM');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(stopCommandPruning).toHaveBeenCalledTimes(1);
+    expect(stopWakeScheduleWorker).toHaveBeenCalledTimes(1);
+    expect(nodeManager.shutdown).toHaveBeenCalledTimes(1);
+    expect(hostStateStreamBroker.shutdown).toHaveBeenCalledTimes(1);
+    expect(mockedDb.close).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+
+  it('runServerCli skips startup when module is not the process entrypoint', () => {
+    const createServer = jest.fn();
+    const result = runServerCli(
+      { id: 'current-module' } as NodeModule,
+      { id: 'main-module' } as NodeModule,
+      createServer,
+    );
+
+    expect(result).toBeNull();
+    expect(createServer).not.toHaveBeenCalled();
+  });
+
+  it('runServerCli default createServer path returns null when module is not the entrypoint', () => {
+    const result = runServerCli(
+      { id: 'current-module' } as NodeModule,
+      { id: 'main-module' } as NodeModule,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('runServerCli creates and starts server when module is the process entrypoint', () => {
+    const start = jest.fn();
+    const fakeServer = { start } as unknown as Server;
+    const createServer = jest.fn(() => fakeServer);
+    const entryModule = { id: 'entry' } as NodeModule;
+
+    const result = runServerCli(entryModule, entryModule, createServer);
+
+    expect(createServer).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(result).toBe(fakeServer);
+  });
+});

--- a/apps/cnc/src/database/__tests__/init-db.test.ts
+++ b/apps/cnc/src/database/__tests__/init-db.test.ts
@@ -1,0 +1,153 @@
+import { getTableName, initDatabase, runInitDbCli } from '../../init-db';
+
+function createDbClientMock() {
+  return {
+    connect: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
+    query: jest
+      .fn<Promise<{ rows: unknown[]; rowCount: number }>, [string]>()
+      .mockResolvedValue({ rows: [], rowCount: 0 }),
+    close: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
+  };
+}
+
+describe('init-db script helpers', () => {
+  it('getTableName returns null for non-record input', () => {
+    expect(getTableName(null)).toBeNull();
+    expect(getTableName('hosts')).toBeNull();
+    expect(getTableName({})).toBeNull();
+    expect(getTableName({ table_name: 123 })).toBeNull();
+  });
+
+  it('getTableName extracts table_name strings', () => {
+    expect(getTableName({ table_name: 'aggregated_hosts' })).toBe('aggregated_hosts');
+  });
+
+  it('initializes sqlite schema and logs discovered tables', async () => {
+    const dbClient = createDbClientMock();
+    dbClient.query
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({
+        rows: [
+          { table_name: 'aggregated_hosts' },
+          { table_name: 'nodes' },
+          { table_name: 100 },
+        ],
+        rowCount: 3,
+      });
+
+    const readFile = jest.fn().mockReturnValue('-- sqlite schema');
+    const log = {
+      info: jest.fn(),
+      error: jest.fn(),
+    };
+    const exit = jest.fn();
+
+    await initDatabase({
+      dbClient,
+      readFile,
+      log,
+      exit,
+      dbType: 'sqlite',
+      schemaRootDir: '/tmp/cnc',
+    });
+
+    expect(readFile).toHaveBeenCalledWith('/tmp/cnc/database/schema.sqlite.sql', 'utf-8');
+    expect(dbClient.connect).toHaveBeenCalledTimes(1);
+    expect(dbClient.query).toHaveBeenCalledTimes(2);
+    expect(log.info).toHaveBeenCalledWith('Created tables:', {
+      tables: ['aggregated_hosts', 'nodes'],
+    });
+    expect(dbClient.close).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('initializes postgres schema and logs discovered tables', async () => {
+    const dbClient = createDbClientMock();
+    dbClient.query
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({
+        rows: [
+          { table_name: 'aggregated_hosts' },
+          { table_name: 'host_wake_schedules' },
+        ],
+        rowCount: 2,
+      });
+
+    const readFile = jest.fn().mockReturnValue('-- postgres schema');
+    const log = {
+      info: jest.fn(),
+      error: jest.fn(),
+    };
+    const exit = jest.fn();
+
+    await initDatabase({
+      dbClient,
+      readFile,
+      log,
+      exit,
+      dbType: 'postgres',
+      schemaRootDir: '/tmp/cnc',
+    });
+
+    expect(readFile).toHaveBeenCalledWith('/tmp/cnc/database/schema.sql', 'utf-8');
+    expect(dbClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('information_schema.tables'),
+    );
+    expect(log.info).toHaveBeenCalledWith('Created tables:', {
+      tables: ['aggregated_hosts', 'host_wake_schedules'],
+    });
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('logs failures and exits with status 1', async () => {
+    const dbClient = createDbClientMock();
+    dbClient.connect.mockRejectedValueOnce(new Error('connection failed'));
+
+    const log = {
+      info: jest.fn(),
+      error: jest.fn(),
+    };
+    const exit = jest.fn();
+
+    await initDatabase({
+      dbClient,
+      readFile: jest.fn(),
+      log,
+      exit,
+      dbType: 'postgres',
+      schemaRootDir: '/tmp/cnc',
+    });
+
+    expect(log.error).toHaveBeenCalledWith(
+      'Database initialization failed',
+      expect.objectContaining({
+        error: expect.any(Error),
+      }),
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('runInitDbCli returns null when module is not the process entrypoint', () => {
+    const runner = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+    const result = runInitDbCli({ id: 'a' } as NodeModule, { id: 'b' } as NodeModule, runner);
+
+    expect(result).toBeNull();
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('runInitDbCli default runner path returns null when module is not the process entrypoint', () => {
+    const result = runInitDbCli({ id: 'a' } as NodeModule, { id: 'b' } as NodeModule);
+
+    expect(result).toBeNull();
+  });
+
+  it('runInitDbCli invokes provided runner when module is the process entrypoint', async () => {
+    const entryModule = { id: 'entry' } as NodeModule;
+    const runner = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+
+    const result = runInitDbCli(entryModule, entryModule, runner);
+
+    await expect(result).resolves.toBeUndefined();
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/cnc/src/server.ts
+++ b/apps/cnc/src/server.ts
@@ -24,12 +24,12 @@ import { runtimeMetrics } from './services/runtimeMetrics';
 import { CNC_VERSION } from './utils/cncVersion';
 import { prometheusContentType, renderPrometheusMetrics } from './services/promMetrics';
 
-function isAllowedCorsOrigin(origin: string, allowedOrigins: string[]): boolean {
+export function isAllowedCorsOrigin(origin: string, allowedOrigins: string[]): boolean {
   if (allowedOrigins.includes('*')) return true;
   return allowedOrigins.includes(origin);
 }
 
-class Server {
+export class Server {
   private app: express.Application;
   private httpServer: ReturnType<typeof createServer>;
   private hostAggregator: HostAggregator;
@@ -256,8 +256,18 @@ class Server {
   }
 }
 
-// Start server
-const server = new Server();
-server.start();
+export function runServerCli(
+  currentModule: NodeModule,
+  mainModule: NodeModule | undefined = require.main,
+  createServer: () => Server = () => new Server(),
+): Server | null {
+  if (mainModule !== currentModule) {
+    return null;
+  }
 
-export default server;
+  const server = createServer();
+  void server.start();
+  return server;
+}
+
+void runServerCli(module);


### PR DESCRIPTION
## CNC Sync Classification

- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: kaonis/woly-server#318
- Backend issue: kaonis/woly-server#318
- Frontend issue: kaonis/woly#308

## 3-Part Chain Checklist (required for CNC feature changes)

- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
npm run test -w apps/cnc -- src/database/__tests__/init-db.test.ts src/__tests__/server.bootstrap.test.ts
npm run test:ci --workspace=@woly-server/cnc -- --coverageReporters=json-summary --coverageReporters=text
npm run build -w packages/protocol
npm run test -w packages/protocol -- contract.cross-repo
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run validate:standard
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- No known validation gaps.
- Policy checklist revalidated after metadata update.

## Summary

- add direct bootstrap tests for `apps/cnc/src/server.ts` (routing, startup/shutdown, CLI wrapper, production CORS branches)
- add direct tests for `apps/cnc/src/init-db.ts` (sqlite/postgres schema init, failure path, CLI wrapper)
- refactor server/init-db startup blocks into exported, testable helpers without changing runtime behavior
- raise CNC branch coverage to **78.03%** (>= 78% target)

Closes #318
