### PR TITLE
feat(cnc): offline command queue with reconnect delivery (#345)

### DIFF
--- a/apps/cnc/src/config/__tests__/index.test.ts
+++ b/apps/cnc/src/config/__tests__/index.test.ts
@@ -50,6 +50,7 @@ describe('config parsing and validation', () => {
       SCHEDULE_WORKER_ENABLED: 'false',
       SCHEDULE_POLL_INTERVAL_MS: '45000',
       SCHEDULE_BATCH_SIZE: '10',
+      OFFLINE_COMMAND_TTL_MS: '120000',
     });
 
     expect(config.operatorAuthTokens).toEqual(['node-token-1', 'node-token-2']);
@@ -61,6 +62,7 @@ describe('config parsing and validation', () => {
     expect(config.scheduleWorkerEnabled).toBe(false);
     expect(config.schedulePollIntervalMs).toBe(45000);
     expect(config.scheduleBatchSize).toBe(10);
+    expect(config.offlineCommandTtlMs).toBe(120000);
   });
 
   it('parses TRUST_PROXY numeric hop count', async () => {
@@ -127,5 +129,13 @@ describe('config parsing and validation', () => {
         SCHEDULE_POLL_INTERVAL_MS: '0',
       }),
     ).rejects.toThrow('SCHEDULE_POLL_INTERVAL_MS must be a finite number > 0');
+  });
+
+  it('throws when offline command ttl is not greater than zero', async () => {
+    await expect(
+      loadConfig({
+        OFFLINE_COMMAND_TTL_MS: '0',
+      }),
+    ).rejects.toThrow('OFFLINE_COMMAND_TTL_MS must be a finite number > 0');
   });
 });

--- a/apps/cnc/src/config/index.ts
+++ b/apps/cnc/src/config/index.ts
@@ -121,6 +121,7 @@ export const config: ServerConfig = {
   nodeHeartbeatInterval: getEnvNumber('NODE_HEARTBEAT_INTERVAL', 30000),
   nodeTimeout: getEnvNumber('NODE_TIMEOUT', 90000),
   commandTimeout: getEnvNumber('COMMAND_TIMEOUT', 30000),
+  offlineCommandTtlMs: getEnvNumber('OFFLINE_COMMAND_TTL_MS', 60 * 60 * 1000),
   commandRetentionDays: getEnvNumber('COMMAND_RETENTION_DAYS', 30),
   commandMaxRetries: getEnvNumber('COMMAND_MAX_RETRIES', 3),
   commandRetryBaseDelayMs: getEnvNumber('COMMAND_RETRY_BASE_DELAY_MS', 1000),
@@ -161,6 +162,10 @@ if (!Number.isFinite(config.wsMaxConnectionsPerIp) || config.wsMaxConnectionsPer
 
 if (!Number.isFinite(config.jwtTtlSeconds) || config.jwtTtlSeconds <= 0) {
   throw new Error('JWT_TTL_SECONDS must be a finite number > 0');
+}
+
+if (!Number.isFinite(config.offlineCommandTtlMs) || config.offlineCommandTtlMs <= 0) {
+  throw new Error('OFFLINE_COMMAND_TTL_MS must be a finite number > 0');
 }
 
 if (!Number.isFinite(config.schedulePollIntervalMs) || config.schedulePollIntervalMs <= 0) {

--- a/apps/cnc/src/controllers/__tests__/hosts.additional.test.ts
+++ b/apps/cnc/src/controllers/__tests__/hosts.additional.test.ts
@@ -431,6 +431,26 @@ describe('HostsController additional branches', () => {
       });
     });
 
+    it('returns queued delete response when router reports queued state', async () => {
+      commandRouter.routeDeleteHostCommand.mockResolvedValue({
+        success: true,
+        commandId: 'cmd-delete-queued',
+        state: 'queued',
+      });
+
+      const req = createMockRequest({ params: { fqn: 'desktop@lab' } });
+      const res = createMockResponse();
+
+      await controller.deleteHost(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        message: 'Delete command queued (node offline)',
+        commandId: 'cmd-delete-queued',
+        state: 'queued',
+      });
+    });
+
     it('maps not-found errors to 404', async () => {
       commandRouter.routeDeleteHostCommand.mockRejectedValue(new Error('Host not found: desktop@lab'));
 
@@ -764,6 +784,29 @@ describe('HostsController additional branches', () => {
         success: true,
         message: 'Host updated successfully',
         correlationId: 'cid-router',
+      });
+    });
+
+    it('returns queued update response when router reports queued state', async () => {
+      commandRouter.routeUpdateHostCommand.mockResolvedValue({
+        success: true,
+        commandId: 'cmd-update-queued',
+        state: 'queued',
+      });
+
+      const req = createMockRequest({
+        params: { fqn: 'desktop@lab' },
+        body: { name: 'new-name' },
+      });
+      const res = createMockResponse();
+
+      await controller.updateHost(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        message: 'Update command queued (node offline)',
+        commandId: 'cmd-update-queued',
+        state: 'queued',
       });
     });
 

--- a/apps/cnc/src/controllers/hosts.ts
+++ b/apps/cnc/src/controllers/hosts.ts
@@ -830,10 +830,25 @@ export class HostsController {
         return;
       }
 
-      const responseBody: { success: boolean; message: string; correlationId?: string } = {
+      const responseBody: {
+        success: boolean;
+        message: string;
+        commandId?: string;
+        state?: string;
+        correlationId?: string;
+      } = {
         success: true,
-        message: 'Host updated successfully',
+        message:
+          result.state === 'queued'
+            ? 'Update command queued (node offline)'
+            : 'Host updated successfully',
       };
+      if (result.commandId) {
+        responseBody.commandId = result.commandId;
+      }
+      if (result.state) {
+        responseBody.state = result.state;
+      }
       const responseCorrelationId = result.correlationId ?? correlationId ?? undefined;
       if (responseCorrelationId) {
         responseBody.correlationId = responseCorrelationId;
@@ -970,10 +985,25 @@ export class HostsController {
         return;
       }
 
-      const responseBody: { success: boolean; message: string; correlationId?: string } = {
+      const responseBody: {
+        success: boolean;
+        message: string;
+        commandId?: string;
+        state?: string;
+        correlationId?: string;
+      } = {
         success: true,
-        message: 'Host deleted successfully',
+        message:
+          result.state === 'queued'
+            ? 'Delete command queued (node offline)'
+            : 'Host deleted successfully',
       };
+      if (result.commandId) {
+        responseBody.commandId = result.commandId;
+      }
+      if (result.state) {
+        responseBody.state = result.state;
+      }
       const responseCorrelationId = result.correlationId ?? correlationId ?? undefined;
       if (responseCorrelationId) {
         responseBody.correlationId = responseCorrelationId;

--- a/apps/cnc/src/services/__tests__/commandRouter.test.ts
+++ b/apps/cnc/src/services/__tests__/commandRouter.test.ts
@@ -45,7 +45,7 @@ describe('CommandRouter', () => {
       ).rejects.toThrow('Host not found');
     });
 
-    it('should throw error if node is offline', async () => {
+    it('queues wake command when node is offline', async () => {
       // Register offline node
       await NodeModel.register({
         nodeId: 'test-cmd-node-1',
@@ -81,9 +81,12 @@ describe('CommandRouter', () => {
         },
       });
 
-      await expect(
-        commandRouter.routeWakeCommand('test-host@Test%20Location-test-cmd-node-1')
-      ).rejects.toThrow('offline');
+      const response = await commandRouter.routeWakeCommand(
+        'test-host@Test%20Location-test-cmd-node-1'
+      );
+      expect(response.success).toBe(true);
+      expect(response.state).toBe('queued');
+      expect(response.message).toContain('queued');
     });
   });
 
@@ -127,7 +130,7 @@ describe('CommandRouter', () => {
       ).rejects.toThrow('Host not found');
     });
 
-    it('should throw error if node is offline', async () => {
+    it('queues delete command if node is offline', async () => {
       await NodeModel.register({
         nodeId: 'test-cmd-node-3',
         name: 'Delete Test',
@@ -160,9 +163,11 @@ describe('CommandRouter', () => {
         },
       });
 
-      await expect(
-        commandRouter.routeDeleteHostCommand('delete-host@Test%20Location-test-cmd-node-3')
-      ).rejects.toThrow('offline');
+      const result = await commandRouter.routeDeleteHostCommand(
+        'delete-host@Test%20Location-test-cmd-node-3'
+      );
+      expect(result.success).toBe(true);
+      expect(result.state).toBe('queued');
     });
   });
 

--- a/apps/cnc/src/services/nodeManager.ts
+++ b/apps/cnc/src/services/nodeManager.ts
@@ -126,6 +126,7 @@ export class NodeManager extends EventEmitter {
         logger.info('Node disconnected', { nodeId: connection.nodeId });
         this.connections.delete(connection.nodeId);
         runtimeMetrics.setConnectedNodeCount(this.connections.size);
+        this.emit('node-disconnected', { nodeId: connection.nodeId });
         
         // Mark node's hosts as unreachable
         try {
@@ -285,6 +286,7 @@ export class NodeManager extends EventEmitter {
         location: node.location,
       });
       runtimeMetrics.setConnectedNodeCount(this.connections.size);
+      this.emit('node-connected', { nodeId: node.id });
 
       const minted = mintWsSessionToken(node.id, {
         issuer: config.wsSessionTokenIssuer,

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -58,6 +58,7 @@ export type {
 export interface CommandResult {
   commandId: string;
   success: boolean;
+  state?: CommandState;
   message?: string;
   error?: string;
   hostPing?: ProtocolHostPingResult;
@@ -105,6 +106,8 @@ export interface WakeupResponse {
   message: string;
   nodeId: string;
   location: string;
+  commandId?: string;
+  state?: CommandState;
   correlationId?: string;
   wakeVerification?: {
     status: 'pending';
@@ -153,6 +156,7 @@ export interface ServerConfig {
   nodeHeartbeatInterval: number;
   nodeTimeout: number;
   commandTimeout: number;
+  offlineCommandTtlMs: number;
   commandRetentionDays: number;
   commandMaxRetries: number;
   commandRetryBaseDelayMs: number;


### PR DESCRIPTION
## CNC Sync Classification

- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: kaonis/woly-server#345
- Backend issue: kaonis/woly-server#345
- Frontend issue: kaonis/woly#308

## 3-Part Chain Checklist (required for CNC feature changes)

- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
npm run test -w apps/cnc -- src/services/__tests__/commandRouter.unit.test.ts src/services/__tests__/commandRouter.test.ts src/models/__tests__/Command.test.ts src/models/__tests__/Command.postgres.test.ts src/config/__tests__/index.test.ts src/controllers/__tests__/hosts.additional.test.ts
npm run test:ci --workspace=@woly-server/cnc -- --coverageReporters=json-summary --coverageReporters=text
npm run build -w packages/protocol
npm run test -w packages/protocol -- contract.cross-repo
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run validate:standard
git diff --stat origin/master...HEAD
git diff origin/master...HEAD
gh pr view --comments
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- No known validation gaps.
- `gh pr view --comments` had no PR to show before creation.

## Summary

- queue wake/update/delete commands when target node is offline instead of failing immediately
- flush queued commands in FIFO order when `node-connected` is emitted by `NodeManager`
- add configurable offline queue TTL (`OFFLINE_COMMAND_TTL_MS`, default 1 hour) and expire stale queued commands during reconnect flush
- keep command idempotency semantics by reusing existing `idempotency_key` behavior in `CommandModel`
- surface queued command feedback in HTTP responses for update/delete endpoints (plus coverage for queued wake routing)
- update reconciliation semantics to time out stale `sent` commands only (queued commands are managed by offline TTL)
- extend model/router/controller/config tests to cover queueing, reconnect flush, TTL expiration, and queued response payloads

Closes #345
