### PR TITLE
feat(node-agent/cnc): add custom WoL port per host (#346)

### DIFF
--- a/apps/cnc/src/controllers/__tests__/hosts.test.ts
+++ b/apps/cnc/src/controllers/__tests__/hosts.test.ts
@@ -256,6 +256,25 @@ describe('HostsController.updateHost', () => {
       });
     });
 
+    it('should accept wolPort metadata updates', async () => {
+      mockCommandRouter.routeUpdateHostCommand.mockResolvedValueOnce({ success: true });
+
+      const req = createMockRequest({ wolPort: 7 });
+      const res = createMockResponse();
+
+      await controller.updateHost(req, res);
+
+      expect(mockCommandRouter.routeUpdateHostCommand).toHaveBeenCalledWith(
+        'testhost@location',
+        { wolPort: 7 },
+        { idempotencyKey: null }
+      );
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        message: 'Host updated successfully',
+      });
+    });
+
     it('should accept empty body (all fields optional)', async () => {
       mockCommandRouter.routeUpdateHostCommand.mockResolvedValueOnce({ success: true });
 
@@ -405,6 +424,16 @@ describe('HostsController.updateHost', () => {
 
     it('should reject invalid tags payload', async () => {
       const req = createMockRequest({ tags: [''] });
+      const res = createMockResponse();
+
+      await controller.updateHost(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockCommandRouter.routeUpdateHostCommand).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid wolPort payload', async () => {
+      const req = createMockRequest({ wolPort: 70000 });
       const res = createMockResponse();
 
       await controller.updateHost(req, res);

--- a/apps/cnc/src/services/__tests__/crossService.e2e.smoke.test.ts
+++ b/apps/cnc/src/services/__tests__/crossService.e2e.smoke.test.ts
@@ -184,6 +184,7 @@ function seedNodeAgentDatabase(dbPath: string): void {
     mac text NOT NULL UNIQUE,
     ip text NOT NULL UNIQUE,
     status text NOT NULL,
+    wol_port integer NOT NULL DEFAULT 9,
     lastSeen datetime,
     discovered integer DEFAULT 0,
     pingResponsive integer,
@@ -192,13 +193,14 @@ function seedNodeAgentDatabase(dbPath: string): void {
   )`);
 
   db.prepare(
-    `INSERT INTO hosts (name, mac, ip, status, lastSeen, discovered, pingResponsive, notes, tags)
-     VALUES (?, ?, ?, ?, datetime('now'), ?, ?, ?, ?)`
+    `INSERT INTO hosts (name, mac, ip, status, wol_port, lastSeen, discovered, pingResponsive, notes, tags)
+     VALUES (?, ?, ?, ?, ?, datetime('now'), ?, ?, ?, ?)`
   ).run(
     SMOKE_HOST_NAME,
     'AA:BB:CC:DD:EE:11',
     '192.168.10.42',
     'awake',
+    9,
     1,
     1,
     'seeded by cross-service smoke',

--- a/apps/cnc/src/services/commandRouter.ts
+++ b/apps/cnc/src/services/commandRouter.ts
@@ -17,6 +17,7 @@ interface HostUpdateData {
   name?: string;
   mac?: string;
   ip?: string;
+  wolPort?: number;
   status?: HostStatus;
   notes?: string | null;
   tags?: string[];
@@ -124,6 +125,7 @@ export class CommandRouter extends EventEmitter {
     options?: {
       idempotencyKey?: string | null;
       correlationId?: string | null;
+      wolPort?: number | null;
       verify?: WakeVerifyOptions | null;
     }
   ): Promise<WakeupResponse> {
@@ -143,12 +145,14 @@ export class CommandRouter extends EventEmitter {
     // Create command — include verify options if requested
     const commandId = this.generateCommandId();
     const verify = options?.verify ?? null;
+    const wolPort = options?.wolPort ?? host.wolPort;
     const command: DispatchCommand = {
       type: 'wake',
       commandId,
       data: {
         hostName: hostname,
         mac: host.mac,
+        ...(typeof wolPort === 'number' ? { wolPort } : {}),
         ...(verify ? { verify } : {}),
       }
     };
@@ -476,6 +480,7 @@ export class CommandRouter extends EventEmitter {
         name: hostData.name ?? host.name,
         mac: hostData.mac ?? host.mac,
         ip: hostData.ip ?? host.ip,
+        wolPort: hostData.wolPort ?? host.wolPort,
         status: hostData.status ?? host.status,
         notes: hostData.notes !== undefined ? hostData.notes : host.notes,
         tags: hostData.tags !== undefined ? hostData.tags : host.tags,

--- a/apps/cnc/src/swagger.ts
+++ b/apps/cnc/src/swagger.ts
@@ -130,6 +130,13 @@ const options: swaggerJsdoc.Options = {
               description: 'IP address',
               example: '192.168.1.147',
             },
+            wolPort: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 65535,
+              description: 'Configured Wake-on-LAN UDP destination port',
+              example: 9,
+            },
             status: {
               type: 'string',
               enum: ['awake', 'asleep'],

--- a/apps/node-agent/src/routes/hosts.ts
+++ b/apps/node-agent/src/routes/hosts.ts
@@ -9,6 +9,7 @@ import {
   hostNameParamSchema,
   macAddressSchema,
   updateHostSchema,
+  wakeHostSchema,
 } from '../validators/hostValidator';
 
 const router = express.Router();
@@ -43,6 +44,7 @@ router.post(
   '/wakeup/:name',
   wakeLimiter,
   validateRequest(hostNameParamSchema, 'params'),
+  validateRequest(wakeHostSchema, 'body'),
   hostsController.wakeUpHost
 );
 

--- a/apps/node-agent/src/services/__tests__/hostDatabase.unit.test.ts
+++ b/apps/node-agent/src/services/__tests__/hostDatabase.unit.test.ts
@@ -182,6 +182,7 @@ describe('HostDatabase', () => {
       expect(newHost.status).toBe('asleep');
       expect(newHost.discovered).toBe(0);
       expect(newHost.pingResponsive).toBe(null);
+      expect(newHost.wolPort).toBe(9);
       expect(newHost.notes).toBe(null);
       expect(newHost.tags).toEqual([]);
 
@@ -189,6 +190,7 @@ describe('HostDatabase', () => {
       const retrieved = await db.getHost('TestHost');
       expect(retrieved).toBeDefined();
       expect(retrieved?.name).toBe('TestHost');
+      expect(retrieved?.wolPort).toBe(9);
       expect(retrieved?.notes).toBe(null);
       expect(retrieved?.tags).toEqual([]);
     });
@@ -269,6 +271,17 @@ describe('HostDatabase', () => {
       expect(updated).toBeDefined();
       expect(updated?.ip).toBe('192.168.1.211');
       expect(updated?.status).toBe('awake');
+    });
+
+    it('should update host wol port', async () => {
+      await db.addHost('PortUpdate', 'AA:BB:CC:DD:EE:41', '192.168.1.241');
+
+      await db.updateHost('PortUpdate', {
+        wolPort: 7,
+      });
+
+      const updated = await db.getHost('PortUpdate');
+      expect(updated?.wolPort).toBe(7);
     });
 
     it('should emit host-updated when updating a host', async () => {

--- a/apps/node-agent/src/swagger.ts
+++ b/apps/node-agent/src/swagger.ts
@@ -84,6 +84,13 @@ const options: swaggerJsdoc.Options = {
               description: 'IP address',
               example: '192.168.1.147',
             },
+            wolPort: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 65535,
+              description: 'Configured Wake-on-LAN UDP destination port',
+              example: 9,
+            },
             status: {
               type: 'string',
               enum: ['awake', 'asleep'],

--- a/apps/node-agent/src/validators/__tests__/hostValidator.unit.test.ts
+++ b/apps/node-agent/src/validators/__tests__/hostValidator.unit.test.ts
@@ -4,6 +4,7 @@ import {
   hostNameParamSchema,
   macAddressSchema,
   updateHostSchema,
+  wakeHostSchema,
 } from '../hostValidator';
 
 describe('hostValidator schemas', () => {
@@ -44,6 +45,7 @@ describe('hostValidator schemas', () => {
       expect(updateHostSchema.safeParse({ mac: 'AA:BB:CC:DD:EE:11' }).success).toBe(true);
       expect(updateHostSchema.safeParse({ notes: null }).success).toBe(true);
       expect(updateHostSchema.safeParse({ tags: ['tag-1'] }).success).toBe(true);
+      expect(updateHostSchema.safeParse({ wolPort: 7 }).success).toBe(true);
     });
 
     it('accepts combined updates', () => {
@@ -75,6 +77,23 @@ describe('hostValidator schemas', () => {
       expect(updateHostSchema.safeParse({ name: '' }).success).toBe(false);
       expect(updateHostSchema.safeParse({ notes: 'x'.repeat(2001) }).success).toBe(false);
       expect(updateHostSchema.safeParse({ tags: [''] }).success).toBe(false);
+      expect(updateHostSchema.safeParse({ wolPort: 0 }).success).toBe(false);
+      expect(updateHostSchema.safeParse({ wolPort: 70000 }).success).toBe(false);
+    });
+  });
+
+  describe('wakeHostSchema', () => {
+    it('accepts empty wake request body', () => {
+      expect(wakeHostSchema.safeParse({}).success).toBe(true);
+    });
+
+    it('accepts wake request with custom wolPort', () => {
+      expect(wakeHostSchema.safeParse({ wolPort: 7 }).success).toBe(true);
+    });
+
+    it('rejects wake request with invalid wolPort', () => {
+      expect(wakeHostSchema.safeParse({ wolPort: 0 }).success).toBe(false);
+      expect(wakeHostSchema.safeParse({ wolPort: 65536 }).success).toBe(false);
     });
   });
 

--- a/apps/node-agent/src/validators/hostValidator.ts
+++ b/apps/node-agent/src/validators/hostValidator.ts
@@ -14,6 +14,11 @@ const hostNotesSchema = z
 const hostTagsSchema = z
   .array(z.string().min(1, 'Tags cannot be empty').max(64, 'Tags must not exceed 64 characters').trim())
   .max(32, 'Tags must not exceed 32 entries');
+const wolPortSchema = z
+  .number()
+  .int('WoL port must be an integer')
+  .min(1, 'WoL port must be between 1 and 65535')
+  .max(65_535, 'WoL port must be between 1 and 65535');
 
 /**
  * Schema for validating MAC address parameter
@@ -54,15 +59,28 @@ export const updateHostSchema = z
       .optional(),
     notes: hostNotesSchema.optional(),
     tags: hostTagsSchema.optional(),
+    wolPort: wolPortSchema.optional(),
   })
   .refine((value) =>
       value.name !== undefined ||
       value.ip !== undefined ||
       value.mac !== undefined ||
       value.notes !== undefined ||
-      value.tags !== undefined, {
-    message: 'At least one field is required: name, ip, mac, notes, or tags',
+      value.tags !== undefined ||
+      value.wolPort !== undefined, {
+    message: 'At least one field is required: name, ip, mac, notes, tags, or wolPort',
   });
+
+/**
+ * Schema for validating wake-up request body
+ */
+export const wakeHostSchema = z
+  .object({
+    wolPort: wolPortSchema.optional(),
+  })
+  .strict()
+  .optional()
+  .transform((value) => value ?? {});
 
 /**
  * Schema for validating host name path parameter

--- a/packages/protocol/src/__tests__/contract.cross-repo.test.ts
+++ b/packages/protocol/src/__tests__/contract.cross-repo.test.ts
@@ -450,6 +450,29 @@ describe('Cross-repo protocol contract', () => {
         }
       });
 
+      it('successfully encodes wake-on-lan command with custom wolPort', () => {
+        const command = {
+          type: 'wake' as const,
+          commandId: 'cmd-wake-port-001',
+          data: {
+            hostName: 'desktop-gaming',
+            mac: 'AA:BB:CC:DD:EE:FF',
+            wolPort: 7,
+          },
+        };
+
+        const result = inboundCncCommandSchema.safeParse(command);
+        expect(result.success).toBe(true);
+
+        const roundTrip = inboundCncCommandSchema.safeParse(
+          JSON.parse(JSON.stringify(command)),
+        );
+        expect(roundTrip.success).toBe(true);
+        if (roundTrip.success && roundTrip.data.type === 'wake') {
+          expect(roundTrip.data.data.wolPort).toBe(7);
+        }
+      });
+
       it('rejects wake command without required mac address', () => {
         const invalidCommand = {
           type: 'wake' as const,
@@ -531,6 +554,7 @@ describe('Cross-repo protocol contract', () => {
             name: 'new-hostname',
             mac: '11:22:33:44:55:66',
             ip: '192.168.1.200',
+            wolPort: 7,
             status: 'awake' as const,
             notes: 'Primary office workstation',
             tags: ['office', 'critical'],

--- a/packages/protocol/src/__tests__/schemas.test.ts
+++ b/packages/protocol/src/__tests__/schemas.test.ts
@@ -69,6 +69,14 @@ describe('hostSchema', () => {
     expect(hostSchema.safeParse({ ...validHost, pingResponsive: 1 }).success).toBe(true);
   });
 
+  it('accepts host with custom wolPort', () => {
+    expect(hostSchema.safeParse({ ...validHost, wolPort: 7 }).success).toBe(true);
+  });
+
+  it('rejects host with out-of-range wolPort', () => {
+    expect(hostSchema.safeParse({ ...validHost, wolPort: 70000 }).success).toBe(false);
+  });
+
   it('accepts host with null pingResponsive', () => {
     expect(hostSchema.safeParse({ ...validHost, pingResponsive: null }).success).toBe(true);
   });
@@ -1121,6 +1129,24 @@ describe('inboundCncCommandSchema', () => {
       };
       expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(true);
     });
+
+    it('accepts wake command with custom wolPort', () => {
+      const cmd = {
+        type: 'wake' as const,
+        commandId: 'cmd-custom-port',
+        data: { hostName: 'office-pc', mac: 'AA:BB:CC:DD:EE:FF', wolPort: 7 },
+      };
+      expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(true);
+    });
+
+    it('rejects wake command with invalid wolPort', () => {
+      const cmd = {
+        type: 'wake' as const,
+        commandId: 'cmd-invalid-port',
+        data: { hostName: 'office-pc', mac: 'AA:BB:CC:DD:EE:FF', wolPort: 0 },
+      };
+      expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(false);
+    });
   });
 
   describe('scan', () => {
@@ -1193,12 +1219,22 @@ describe('inboundCncCommandSchema', () => {
           name: 'new-name',
           mac: 'AA:BB:CC:DD:EE:FF',
           ip: '192.168.1.50',
+          wolPort: 7,
           status: 'awake' as const,
           notes: 'Renamed workstation',
           tags: ['desk', 'critical'],
         },
       };
       expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(true);
+    });
+
+    it('rejects update with invalid wolPort', () => {
+      const cmd = {
+        type: 'update-host' as const,
+        commandId: 'cmd-1',
+        data: { name: 'pc', wolPort: 65536 },
+      };
+      expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(false);
     });
 
     it('rejects update with invalid status', () => {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -17,6 +17,7 @@ export interface Host {
   name: string;
   mac: string;
   ip: string;
+  wolPort?: number;
   status: HostStatus;
   lastSeen: string | null;
   discovered: number;
@@ -292,7 +293,11 @@ export interface RegisteredCommandData {
 
 export type CncCommand =
   | { type: 'registered'; data: RegisteredCommandData }
-  | { type: 'wake'; commandId: string; data: { hostName: string; mac: string; verify?: WakeVerifyOptions } }
+  | {
+      type: 'wake';
+      commandId: string;
+      data: { hostName: string; mac: string; wolPort?: number; verify?: WakeVerifyOptions };
+    }
   | { type: 'scan'; commandId: string; data: { immediate: boolean } }
   | {
       type: 'scan-host-ports';
@@ -313,6 +318,7 @@ export type CncCommand =
         name: string;
         mac?: string;
         ip?: string;
+        wolPort?: number;
         status?: HostStatus;
         notes?: string | null;
         tags?: string[];
@@ -341,11 +347,13 @@ export const hostPortSchema: z.ZodType<HostPort> = z.object({
   protocol: z.literal('tcp'),
   service: z.string().min(1),
 });
+export const wolPortSchema = z.number().int().min(1).max(65535);
 
 export const hostSchema = z.object({
   name: z.string().min(1),
   mac: z.string().min(1),
   ip: z.string().min(1),
+  wolPort: wolPortSchema.optional(),
   status: hostStatusSchema,
   lastSeen: z.string().nullable(),
   discovered: z.number().int(),
@@ -632,6 +640,7 @@ export const inboundCncCommandSchema: z.ZodType<CncCommand> = z.discriminatedUni
     data: z.object({
       hostName: z.string().min(1),
       mac: z.string().min(1),
+      wolPort: wolPortSchema.optional(),
       verify: wakeVerifyOptionsSchema.optional(),
     }),
   }),
@@ -661,6 +670,7 @@ export const inboundCncCommandSchema: z.ZodType<CncCommand> = z.discriminatedUni
       name: z.string().min(1),
       mac: z.string().min(1).optional(),
       ip: z.string().min(1).optional(),
+      wolPort: wolPortSchema.optional(),
       status: hostStatusSchema.optional(),
       notes: hostNotesSchema.optional(),
       tags: hostTagsSchema.optional(),

--- a/packages/woly-client/openapi/cnc.json
+++ b/packages/woly-client/openapi/cnc.json
@@ -127,6 +127,13 @@
             "description": "IP address",
             "example": "192.168.1.147"
           },
+          "wolPort": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "Configured Wake-on-LAN UDP destination port",
+            "example": 9
+          },
           "status": {
             "type": "string",
             "enum": ["awake", "asleep"],
@@ -1013,6 +1020,11 @@
                   "ip": {
                     "type": "string"
                   },
+                  "wolPort": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
                   "status": {
                     "type": "string",
                     "enum": ["awake", "asleep"]
@@ -1170,6 +1182,29 @@
             "example": "unique-request-id-123"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "verify": {
+                    "type": "boolean",
+                    "description": "Enable asynchronous wake verification for this command"
+                  },
+                  "wolPort": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Optional WoL UDP destination port override for this wake request",
+                    "example": 7
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Wake command sent successfully",

--- a/packages/woly-client/openapi/node-agent.json
+++ b/packages/woly-client/openapi/node-agent.json
@@ -81,6 +81,13 @@
             "description": "IP address",
             "example": "192.168.1.147"
           },
+          "wolPort": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "Configured Wake-on-LAN UDP destination port",
+            "example": 9
+          },
           "status": {
             "type": "string",
             "enum": ["awake", "asleep"],
@@ -559,6 +566,12 @@
                     "type": "string",
                     "example": "192.168.1.200"
                   },
+                  "wolPort": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "example": 9
+                  },
                   "notes": {
                     "type": "string",
                     "nullable": true,
@@ -677,6 +690,25 @@
             "description": "Verification polling interval in milliseconds (bounded by server limits)"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "wolPort": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Optional WoL UDP destination port override for this request",
+                    "example": 7
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Magic packet sent successfully",
@@ -696,6 +728,10 @@
                     "mac": {
                       "type": "string",
                       "example": "80:6D:97:60:39:08"
+                    },
+                    "wolPort": {
+                      "type": "integer",
+                      "example": 9
                     },
                     "message": {
                       "type": "string",

--- a/packages/woly-client/src/generated/cnc/models/Host.ts
+++ b/packages/woly-client/src/generated/cnc/models/Host.ts
@@ -16,6 +16,10 @@ export type Host = {
      */
     ip?: string;
     /**
+     * Configured Wake-on-LAN UDP destination port
+     */
+    wolPort?: number;
+    /**
      * Current host status (based on ARP response)
      */
     status?: 'awake' | 'asleep';

--- a/packages/woly-client/src/generated/cnc/services/HostsService.ts
+++ b/packages/woly-client/src/generated/cnc/services/HostsService.ts
@@ -74,6 +74,7 @@ export class HostsService {
             name?: string;
             mac?: string;
             ip?: string;
+            wolPort?: number;
             status?: 'awake' | 'asleep';
             notes?: string | null;
             tags?: Array<string>;
@@ -141,12 +142,23 @@ export class HostsService {
      * Send a Wake-on-LAN magic packet to the specified host via its managing node
      * @param fqn Fully qualified name (hostname@location)
      * @param idempotencyKey Optional idempotency key to prevent duplicate commands
+     * @param requestBody
      * @returns CommandResult Wake command sent successfully
      * @throws ApiError
      */
     public static postApiHostsWakeup(
         fqn: string,
         idempotencyKey?: string,
+        requestBody?: {
+            /**
+             * Enable asynchronous wake verification for this command
+             */
+            verify?: boolean;
+            /**
+             * Optional WoL UDP destination port override for this wake request
+             */
+            wolPort?: number;
+        },
     ): CancelablePromise<CommandResult> {
         return __request(OpenAPI, {
             method: 'POST',
@@ -157,6 +169,8 @@ export class HostsService {
             headers: {
                 'Idempotency-Key': idempotencyKey,
             },
+            body: requestBody,
+            mediaType: 'application/json',
             errors: {
                 401: `Missing or invalid authentication`,
                 404: `Resource not found`,

--- a/packages/woly-client/src/generated/node-agent/models/Host.ts
+++ b/packages/woly-client/src/generated/node-agent/models/Host.ts
@@ -16,6 +16,10 @@ export type Host = {
      */
     ip: string;
     /**
+     * Configured Wake-on-LAN UDP destination port
+     */
+    wolPort?: number;
+    /**
      * Current host status
      */
     status: 'awake' | 'asleep';

--- a/packages/woly-client/src/generated/node-agent/services/HostsService.ts
+++ b/packages/woly-client/src/generated/node-agent/services/HostsService.ts
@@ -114,6 +114,7 @@ export class HostsService {
             name?: string;
             mac?: string;
             ip?: string;
+            wolPort?: number;
             notes?: string | null;
             tags?: Array<string>;
         },

--- a/packages/woly-client/src/generated/node-agent/services/WakeOnLanService.ts
+++ b/packages/woly-client/src/generated/node-agent/services/WakeOnLanService.ts
@@ -13,6 +13,7 @@ export class WakeOnLanService {
      * @param verify Enable/disable post-WoL wake verification for this request
      * @param verifyTimeoutMs Verification timeout in milliseconds (bounded by server limits)
      * @param verifyPollIntervalMs Verification polling interval in milliseconds (bounded by server limits)
+     * @param requestBody
      * @returns any Magic packet sent successfully
      * @throws ApiError
      */
@@ -21,10 +22,17 @@ export class WakeOnLanService {
         verify?: boolean,
         verifyTimeoutMs?: number,
         verifyPollIntervalMs?: number,
+        requestBody?: {
+            /**
+             * Optional WoL UDP destination port override for this request
+             */
+            wolPort?: number;
+        },
     ): CancelablePromise<{
         success?: boolean;
         name?: string;
         mac?: string;
+        wolPort?: number;
         message?: string;
         verification?: {
             enabled?: boolean;
@@ -49,6 +57,8 @@ export class WakeOnLanService {
                 'verifyTimeoutMs': verifyTimeoutMs,
                 'verifyPollIntervalMs': verifyPollIntervalMs,
             },
+            body: requestBody,
+            mediaType: 'application/json',
             errors: {
                 401: `Unauthorized - API key required (when NODE_API_KEY is configured)`,
                 404: `Host not found`,


### PR DESCRIPTION
## Summary
- add `wolPort` to protocol host/command contracts and schemas
- support per-host `wolPort` persistence + migration in node-agent
- allow wake request-time `wolPort` overrides in node-agent and CNC routes
- propagate `wolPort` through CNC command routing and generated API clients

## Validation
- npm run build -w packages/protocol
- npm run test -w packages/protocol -- contract.cross-repo
- npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
- npm run validate:standard

Closes #346
