### PR TITLE
feat: multi-MAC host merge support across protocol, node-agent, and CNC

### DIFF
--- a/apps/cnc/src/database/schema.sql
+++ b/apps/cnc/src/database/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS aggregated_hosts (
     node_id VARCHAR(255) NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
     name VARCHAR(255) NOT NULL,
     mac VARCHAR(17) NOT NULL,
+    secondary_macs TEXT NOT NULL DEFAULT '[]',
     ip VARCHAR(45) NOT NULL,
     status VARCHAR(20) NOT NULL,
     last_seen TIMESTAMP,

--- a/apps/cnc/src/database/schema.sqlite.sql
+++ b/apps/cnc/src/database/schema.sqlite.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS aggregated_hosts (
     node_id TEXT NOT NULL,
     name TEXT NOT NULL,
     mac TEXT NOT NULL,
+    secondary_macs TEXT NOT NULL DEFAULT '[]',
     ip TEXT NOT NULL,
     status TEXT NOT NULL CHECK(status IN ('awake', 'asleep')),
     last_seen DATETIME,

--- a/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
@@ -435,6 +435,160 @@ describe('Host Routes Authentication and Authorization', () => {
     });
   });
 
+  describe('GET /api/hosts/merge-candidates', () => {
+    it('returns 401 when no authorization header is provided', async () => {
+      const response = await request(app).get('/api/hosts/merge-candidates');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for unsupported role', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .get('/api/hosts/merge-candidates')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+
+    it('allows access with valid operator token', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'operator',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .get('/api/hosts/merge-candidates')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('candidates');
+    });
+  });
+
+  describe('PUT /api/hosts/:fqn/merge-mac', () => {
+    it('returns 401 when no authorization header is provided', async () => {
+      const response = await request(app).put('/api/hosts/node1.example.com/merge-mac').send({
+        mac: 'AA:BB:CC:DD:EE:11',
+      });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for unsupported role', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .put('/api/hosts/node1.example.com/merge-mac')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ mac: 'AA:BB:CC:DD:EE:11' });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+
+    it('allows access with valid operator token', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'operator',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .put('/api/hosts/node1.example.com/merge-mac')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ mac: 'AA:BB:CC:DD:EE:11' });
+
+      // Will be 404 since host doesn't exist in mock, but auth passed
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/hosts/:fqn/merge-mac/:mac', () => {
+    it('returns 401 when no authorization header is provided', async () => {
+      const response = await request(app).delete('/api/hosts/node1.example.com/merge-mac/AA:BB:CC:DD:EE:11');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: 'Unauthorized',
+        code: 'AUTH_UNAUTHORIZED',
+      });
+    });
+
+    it('returns 403 for unsupported role', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'viewer',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .delete('/api/hosts/node1.example.com/merge-mac/AA:BB:CC:DD:EE:11')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toMatchObject({
+        code: 'AUTH_FORBIDDEN',
+      });
+    });
+
+    it('allows access with valid operator token', async () => {
+      const token = createToken({
+        sub: 'user-1',
+        role: 'operator',
+        iss: 'test-issuer',
+        aud: 'test-audience',
+        exp: now + 3600,
+        nbf: now - 10,
+      });
+
+      const response = await request(app)
+        .delete('/api/hosts/node1.example.com/merge-mac/AA:BB:CC:DD:EE:11')
+        .set('Authorization', `Bearer ${token}`);
+
+      // Will be 404 since host doesn't exist in mock, but auth passed
+      expect(response.status).toBe(404);
+    });
+  });
+
   describe('POST /api/hosts/scan', () => {
     it('returns 401 when no authorization header is provided', async () => {
       const response = await request(app).post('/api/hosts/scan');

--- a/apps/cnc/src/routes/index.ts
+++ b/apps/cnc/src/routes/index.ts
@@ -92,6 +92,9 @@ export function createRoutes(
   router.get('/hosts/ports/:fqn', (req, res) => hostsController.getHostPorts(req, res));
   router.get('/hosts/scan-ports/:fqn', (req, res) => hostsController.scanHostPorts(req, res));
   router.post('/hosts/scan', (req, res) => hostsController.scanHosts(req, res));
+  router.get('/hosts/merge-candidates', (req, res) => hostsController.getMergeCandidates(req, res));
+  router.put('/hosts/:fqn/merge-mac', (req, res) => hostsController.mergeHostMac(req, res));
+  router.delete('/hosts/:fqn/merge-mac/:mac', (req, res) => hostsController.unmergeHostMac(req, res));
   // IMPORTANT: schedule routes must be registered before the :fqn catch-all
   router.get('/hosts/:fqn/schedules', scheduleSyncLimiter, (req, res) =>
     schedulesController.listHostSchedules(req, res),

--- a/apps/cnc/src/services/__tests__/commandRouter.unit.test.ts
+++ b/apps/cnc/src/services/__tests__/commandRouter.unit.test.ts
@@ -39,6 +39,7 @@ type HostRecord = {
   nodeId: string;
   name: string;
   mac: string;
+  secondaryMacs?: string[];
   ip: string;
   wolPort?: number;
   status: 'awake' | 'asleep';
@@ -188,6 +189,7 @@ describe('CommandRouter unit behavior', () => {
       nodeId: 'node-2',
       name: 'old-name',
       mac: '00:11:22:33:44:55',
+      secondaryMacs: ['00:11:22:33:44:66'],
       ip: '10.0.0.10',
       status: 'asleep',
     });
@@ -210,6 +212,7 @@ describe('CommandRouter unit behavior', () => {
           currentName: 'old-name',
           name: 'new-name',
           mac: '00:11:22:33:44:55',
+          secondaryMacs: ['00:11:22:33:44:66'],
           ip: '10.0.0.10',
           wolPort: undefined,
           status: 'asleep',
@@ -269,6 +272,7 @@ describe('CommandRouter unit behavior', () => {
       nodeId: 'node-2',
       name: 'old-name',
       mac: '00:11:22:33:44:55',
+      secondaryMacs: ['00:11:22:33:44:66'],
       ip: '10.0.0.10',
       status: 'asleep',
       notes: 'legacy note',
@@ -288,6 +292,7 @@ describe('CommandRouter unit behavior', () => {
     await router.routeUpdateHostCommand('old-name@SiteA', {
       notes: null,
       tags: ['prod', 'critical'],
+      secondaryMacs: ['00:11:22:33:44:77'],
     });
 
     expect(executeSpy).toHaveBeenCalledWith(
@@ -295,6 +300,7 @@ describe('CommandRouter unit behavior', () => {
       expect.objectContaining({
         type: 'update-host',
         data: expect.objectContaining({
+          secondaryMacs: ['00:11:22:33:44:77'],
           notes: null,
           tags: ['prod', 'critical'],
         }),

--- a/apps/cnc/src/services/commandRouter.ts
+++ b/apps/cnc/src/services/commandRouter.ts
@@ -16,6 +16,7 @@ type DispatchCommand = Extract<CncCommand, { commandId: string }>;
 interface HostUpdateData {
   name?: string;
   mac?: string;
+  secondaryMacs?: string[];
   ip?: string;
   wolPort?: number;
   status?: HostStatus;
@@ -479,6 +480,7 @@ export class CommandRouter extends EventEmitter {
         currentName: host.name,
         name: hostData.name ?? host.name,
         mac: hostData.mac ?? host.mac,
+        secondaryMacs: hostData.secondaryMacs ?? host.secondaryMacs,
         ip: hostData.ip ?? host.ip,
         wolPort: hostData.wolPort ?? host.wolPort,
         status: hostData.status ?? host.status,

--- a/apps/cnc/src/swagger.ts
+++ b/apps/cnc/src/swagger.ts
@@ -128,6 +128,15 @@ const options: swaggerJsdoc.Options = {
               description: 'MAC address',
               example: '80:6D:97:60:39:08',
             },
+            secondaryMacs: {
+              type: 'array',
+              description: 'Additional known MAC addresses for the same logical host',
+              items: {
+                type: 'string',
+                pattern: '^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$',
+              },
+              example: ['11:22:33:44:55:66'],
+            },
             ip: {
               type: 'string',
               format: 'ipv4',

--- a/apps/node-agent/src/routes/hosts.ts
+++ b/apps/node-agent/src/routes/hosts.ts
@@ -7,7 +7,9 @@ import {
   addHostSchema,
   deleteHostSchema,
   hostNameParamSchema,
+  hostNameAndMacParamSchema,
   macAddressSchema,
+  mergeHostMacSchema,
   updateHostSchema,
   wakeHostSchema,
 } from '../validators/hostValidator';
@@ -34,6 +36,24 @@ router.get(
   '/mac-vendor/:mac',
   validateRequest(macAddressSchema, 'params'),
   hostsController.getMacVendor
+);
+
+// Suggest duplicate hosts that are good merge candidates
+router.get('/merge-candidates', hostsController.getMergeCandidates);
+
+// Merge another MAC into a host
+router.put(
+  '/:name/merge-mac',
+  validateRequest(hostNameParamSchema, 'params'),
+  validateRequest(mergeHostMacSchema, 'body'),
+  hostsController.mergeHostMac
+);
+
+// Undo a MAC merge for a host
+router.delete(
+  '/:name/merge-mac/:mac',
+  validateRequest(hostNameAndMacParamSchema, 'params'),
+  hostsController.unmergeHostMac
 );
 
 // Get a specific host by name

--- a/apps/node-agent/src/swagger.ts
+++ b/apps/node-agent/src/swagger.ts
@@ -78,6 +78,15 @@ const options: swaggerJsdoc.Options = {
               description: 'MAC address',
               example: '80:6D:97:60:39:08',
             },
+            secondaryMacs: {
+              type: 'array',
+              description: 'Additional known MAC addresses for the same logical host',
+              items: {
+                type: 'string',
+                pattern: '^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$',
+              },
+              example: ['11:22:33:44:55:66'],
+            },
             ip: {
               type: 'string',
               format: 'ipv4',

--- a/apps/node-agent/src/types.ts
+++ b/apps/node-agent/src/types.ts
@@ -23,6 +23,22 @@ export interface HostsResponse {
   lastScanTime: string | null;
 }
 
+export interface HostMergeCandidate {
+  targetName: string;
+  targetMac: string;
+  targetIp: string;
+  candidateName: string;
+  candidateMac: string;
+  candidateIp: string;
+  subnetHint: string;
+  reason: 'same_hostname_subnet';
+}
+
+export interface HostMergeCandidatesResponse {
+  candidates: HostMergeCandidate[];
+  generatedAt: string;
+}
+
 export interface ScanResponse {
   message: string;
   hostsCount: number;

--- a/apps/node-agent/src/validators/hostValidator.ts
+++ b/apps/node-agent/src/validators/hostValidator.ts
@@ -57,6 +57,15 @@ export const updateHostSchema = z
         'MAC address must be in format XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX'
       )
       .optional(),
+    secondaryMacs: z
+      .array(
+        z.string().regex(
+          macAddressPattern,
+          'Secondary MAC addresses must be in format XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX'
+        )
+      )
+      .max(32, 'secondaryMacs must not exceed 32 entries')
+      .optional(),
     notes: hostNotesSchema.optional(),
     tags: hostTagsSchema.optional(),
     wolPort: wolPortSchema.optional(),
@@ -65,11 +74,30 @@ export const updateHostSchema = z
       value.name !== undefined ||
       value.ip !== undefined ||
       value.mac !== undefined ||
+      value.secondaryMacs !== undefined ||
       value.notes !== undefined ||
       value.tags !== undefined ||
       value.wolPort !== undefined, {
-    message: 'At least one field is required: name, ip, mac, notes, tags, or wolPort',
+    message: 'At least one field is required: name, ip, mac, secondaryMacs, notes, tags, or wolPort',
   });
+
+/**
+ * Schema for validating host MAC merge body.
+ */
+export const mergeHostMacSchema = z.object({
+  mac: z.string().regex(
+    macAddressPattern,
+    'MAC address must be in format XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX'
+  ),
+  makePrimary: z.boolean().optional(),
+  sourceHostName: z
+    .string()
+    .min(1, 'sourceHostName must be at least 1 character')
+    .max(255, 'sourceHostName must not exceed 255 characters')
+    .trim()
+    .optional(),
+  deleteSourceHost: z.boolean().optional(),
+});
 
 /**
  * Schema for validating wake-up request body
@@ -87,6 +115,17 @@ export const wakeHostSchema = z
  */
 export const hostNameParamSchema = z.object({
   name: z.string().min(1, 'Hostname must be at least 1 character').max(255, 'Hostname must not exceed 255 characters').trim(),
+});
+
+/**
+ * Schema for validating host name + MAC path parameters.
+ */
+export const hostNameAndMacParamSchema = z.object({
+  name: z.string().min(1, 'Hostname must be at least 1 character').max(255, 'Hostname must not exceed 255 characters').trim(),
+  mac: z.string().regex(
+    macAddressPattern,
+    'MAC address must be in format XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX'
+  ),
 });
 
 /**

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -7,7 +7,7 @@
 ### Types
 
 - `HostStatus` — `'awake' | 'asleep'`
-- `Host` — Canonical host representation shared across all WoLy apps (replaces `HostPayload`), including optional cached port-scan snapshot fields
+- `Host` — Canonical host representation shared across all WoLy apps (replaces `HostPayload`), including optional multi-MAC (`secondaryMacs`) and cached port-scan snapshot fields
 - `HostPayload` — **@deprecated** Alias for `Host`, kept for backwards compatibility
 - `CommandState` — Command lifecycle state: `'queued' | 'sent' | 'acknowledged' | 'failed' | 'timed_out'`
 - `ErrorResponse` — Standardized error response shape with `error`, `message`, optional `code` and `details`

--- a/packages/protocol/src/__tests__/contract.cross-repo.test.ts
+++ b/packages/protocol/src/__tests__/contract.cross-repo.test.ts
@@ -559,6 +559,7 @@ describe('Cross-repo protocol contract', () => {
             currentName: 'old-hostname',
             name: 'new-hostname',
             mac: '11:22:33:44:55:66',
+            secondaryMacs: ['AA:BB:CC:DD:EE:FF'],
             ip: '192.168.1.200',
             wolPort: 7,
             status: 'awake' as const,

--- a/packages/protocol/src/__tests__/schemas.test.ts
+++ b/packages/protocol/src/__tests__/schemas.test.ts
@@ -129,6 +129,15 @@ describe('hostSchema', () => {
     ).toBe(true);
   });
 
+  it('accepts host with secondaryMacs', () => {
+    expect(
+      hostSchema.safeParse({
+        ...validHost,
+        secondaryMacs: ['11:22:33:44:55:66', 'AA-BB-CC-DD-EE-11'],
+      }).success
+    ).toBe(true);
+  });
+
   it('rejects host with invalid cached port protocol', () => {
     expect(
       hostSchema.safeParse({
@@ -1419,8 +1428,21 @@ describe('inboundCncCommandSchema', () => {
           ip: '192.168.1.50',
           wolPort: 7,
           status: 'awake' as const,
+          secondaryMacs: ['11:22:33:44:55:66'],
           notes: 'Renamed workstation',
           tags: ['desk', 'critical'],
+        },
+      };
+      expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(true);
+    });
+
+    it('accepts update with secondaryMacs only', () => {
+      const cmd = {
+        type: 'update-host' as const,
+        commandId: 'cmd-1',
+        data: {
+          name: 'pc',
+          secondaryMacs: ['11:22:33:44:55:66'],
         },
       };
       expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(true);

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -16,6 +16,7 @@ export type HostStatus = 'awake' | 'asleep';
 export interface Host {
   name: string;
   mac: string;
+  secondaryMacs?: string[];
   ip: string;
   wolPort?: number;
   status: HostStatus;
@@ -391,6 +392,7 @@ export type CncCommand =
         currentName?: string;
         name: string;
         mac?: string;
+        secondaryMacs?: string[];
         ip?: string;
         wolPort?: number;
         status?: HostStatus;
@@ -426,6 +428,7 @@ export const wolPortSchema = z.number().int().min(1).max(65535);
 export const hostSchema = z.object({
   name: z.string().min(1),
   mac: z.string().min(1),
+  secondaryMacs: z.array(z.string().min(1)).max(32).optional(),
   ip: z.string().min(1),
   wolPort: wolPortSchema.optional(),
   status: hostStatusSchema,
@@ -825,6 +828,7 @@ export const inboundCncCommandSchema: z.ZodType<CncCommand> = z.discriminatedUni
       currentName: z.string().min(1).optional(),
       name: z.string().min(1),
       mac: z.string().min(1).optional(),
+      secondaryMacs: z.array(z.string().min(1)).max(32).optional(),
       ip: z.string().min(1).optional(),
       wolPort: wolPortSchema.optional(),
       status: hostStatusSchema.optional(),

--- a/packages/woly-client/openapi/cnc.json
+++ b/packages/woly-client/openapi/cnc.json
@@ -125,6 +125,15 @@
             "description": "MAC address",
             "example": "80:6D:97:60:39:08"
           },
+          "secondaryMacs": {
+            "type": "array",
+            "description": "Additional known MAC addresses for the same logical host",
+            "items": {
+              "type": "string",
+              "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+            },
+            "example": ["11:22:33:44:55:66"]
+          },
           "ip": {
             "type": "string",
             "format": "ipv4",
@@ -1295,6 +1304,12 @@
                   "mac": {
                     "type": "string"
                   },
+                  "secondaryMacs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "ip": {
                     "type": "string"
                   },
@@ -1792,6 +1807,29 @@
             "$ref": "#/components/responses/GatewayTimeout"
           }
         }
+      }
+    },
+    "/api/hosts/merge-candidates": {
+      "get": {
+        "summary": "List potential duplicate-host merge candidates",
+        "tags": ["Hosts"],
+        "responses": {
+          "200": {
+            "description": "Candidate pairs detected from aggregated host inventory"
+          }
+        }
+      }
+    },
+    "/api/hosts/{fqn}/merge-mac": {
+      "put": {
+        "summary": "Associate an additional MAC address with a host",
+        "tags": ["Hosts"]
+      }
+    },
+    "/api/hosts/{fqn}/merge-mac/{mac}": {
+      "delete": {
+        "summary": "Remove a merged MAC association from a host (undo)",
+        "tags": ["Hosts"]
       }
     },
     "/api/hosts/mac-vendor/{mac}": {

--- a/packages/woly-client/openapi/node-agent.json
+++ b/packages/woly-client/openapi/node-agent.json
@@ -75,6 +75,15 @@
             "description": "MAC address",
             "example": "80:6D:97:60:39:08"
           },
+          "secondaryMacs": {
+            "type": "array",
+            "description": "Additional known MAC addresses for the same logical host",
+            "items": {
+              "type": "string",
+              "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+            },
+            "example": ["11:22:33:44:55:66"]
+          },
           "ip": {
             "type": "string",
             "format": "ipv4",
@@ -562,6 +571,13 @@
                     "type": "string",
                     "example": "AA:BB:CC:DD:EE:FF"
                   },
+                  "secondaryMacs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": ["11:22:33:44:55:66"]
+                  },
                   "ip": {
                     "type": "string",
                     "example": "192.168.1.200"
@@ -878,6 +894,29 @@
             "$ref": "#/components/responses/InternalError"
           }
         }
+      }
+    },
+    "/hosts/merge-candidates": {
+      "get": {
+        "summary": "List potential duplicate-host merge candidates",
+        "tags": ["Hosts"],
+        "responses": {
+          "200": {
+            "description": "Candidate pairs detected from local host inventory"
+          }
+        }
+      }
+    },
+    "/hosts/{name}/merge-mac": {
+      "put": {
+        "summary": "Associate an additional MAC address with a host",
+        "tags": ["Hosts"]
+      }
+    },
+    "/hosts/{name}/merge-mac/{mac}": {
+      "delete": {
+        "summary": "Remove a merged MAC association from a host (undo)",
+        "tags": ["Hosts"]
       }
     },
     "/hosts/mac-vendor/{mac}": {

--- a/packages/woly-client/src/generated/cnc/models/Host.ts
+++ b/packages/woly-client/src/generated/cnc/models/Host.ts
@@ -12,6 +12,10 @@ export type Host = {
      */
     mac?: string;
     /**
+     * Additional known MAC addresses for the same logical host
+     */
+    secondaryMacs?: Array<string>;
+    /**
      * IP address
      */
     ip?: string;

--- a/packages/woly-client/src/generated/cnc/services/HostsService.ts
+++ b/packages/woly-client/src/generated/cnc/services/HostsService.ts
@@ -75,6 +75,7 @@ export class HostsService {
         requestBody: {
             name?: string;
             mac?: string;
+            secondaryMacs?: Array<string>;
             ip?: string;
             wolPort?: number;
             status?: 'awake' | 'asleep';
@@ -338,6 +339,37 @@ export class HostsService {
                 503: `Service unavailable (e.g., node offline)`,
                 504: `Command timeout`,
             },
+        });
+    }
+    /**
+     * List potential duplicate-host merge candidates
+     * @returns any Candidate pairs detected from aggregated host inventory
+     * @throws ApiError
+     */
+    public static getApiHostsMergeCandidates(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/hosts/merge-candidates',
+        });
+    }
+    /**
+     * Associate an additional MAC address with a host
+     * @throws ApiError
+     */
+    public static putApiHostsMergeMac(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/hosts/{fqn}/merge-mac',
+        });
+    }
+    /**
+     * Remove a merged MAC association from a host (undo)
+     * @throws ApiError
+     */
+    public static deleteApiHostsMergeMac(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/hosts/{fqn}/merge-mac/{mac}',
         });
     }
     /**

--- a/packages/woly-client/src/generated/node-agent/models/Host.ts
+++ b/packages/woly-client/src/generated/node-agent/models/Host.ts
@@ -12,6 +12,10 @@ export type Host = {
      */
     mac: string;
     /**
+     * Additional known MAC addresses for the same logical host
+     */
+    secondaryMacs?: Array<string>;
+    /**
      * IP address
      */
     ip: string;

--- a/packages/woly-client/src/generated/node-agent/services/HostsService.ts
+++ b/packages/woly-client/src/generated/node-agent/services/HostsService.ts
@@ -113,6 +113,7 @@ export class HostsService {
         requestBody: {
             name?: string;
             mac?: string;
+            secondaryMacs?: Array<string>;
             ip?: string;
             wolPort?: number;
             notes?: string | null;
@@ -152,6 +153,37 @@ export class HostsService {
             errors: {
                 404: `Host not found`,
             },
+        });
+    }
+    /**
+     * List potential duplicate-host merge candidates
+     * @returns any Candidate pairs detected from local host inventory
+     * @throws ApiError
+     */
+    public static getHostsMergeCandidates(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/hosts/merge-candidates',
+        });
+    }
+    /**
+     * Associate an additional MAC address with a host
+     * @throws ApiError
+     */
+    public static putHostsMergeMac(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/hosts/{name}/merge-mac',
+        });
+    }
+    /**
+     * Remove a merged MAC association from a host (undo)
+     * @throws ApiError
+     */
+    public static deleteHostsMergeMac(): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/hosts/{name}/merge-mac/{mac}',
         });
     }
     /**


### PR DESCRIPTION
## Summary
- add secondaryMacs to protocol host and update-host contracts
- add node-agent storage + migration support for secondary MACs, duplicate detection hints, and merge/unmerge APIs
- add CNC aggregated-host support for secondary MACs and new merge-candidate / merge / unmerge endpoints
- regenerate OpenAPI specs and @kaonis/woly-client generated clients
- add/expand controller, route, and service tests for merge flows and secondary-MAC reconciliation

## Validation
- npm run validate:standard
- npm run test -w @woly-server/cnc -- --watchman=false apps/cnc/src/controllers/__tests__/hosts.additional.test.ts apps/cnc/src/routes/__tests__/hostRoutes.test.ts apps/cnc/src/services/__tests__/hostAggregator.test.ts apps/cnc/src/services/__tests__/commandRouter.unit.test.ts
- npm run test -w @woly-server/node-agent -- --watchman=false src/__tests__/api.integration.test.ts src/services/__tests__/hostDatabase.unit.test.ts src/services/__tests__/agentService.unit.test.ts

Closes #343
