### PR TITLE
feat: sleep/shutdown host power control

### DIFF
--- a/apps/cnc/migrations/003_add_host_power_config.sql
+++ b/apps/cnc/migrations/003_add_host_power_config.sql
@@ -1,0 +1,4 @@
+-- Migration 003: Add host power control configuration column to aggregated_hosts
+
+ALTER TABLE aggregated_hosts
+  ADD COLUMN IF NOT EXISTS power_config TEXT;

--- a/apps/cnc/migrations/003_add_host_power_config.sqlite.sql
+++ b/apps/cnc/migrations/003_add_host_power_config.sqlite.sql
@@ -1,0 +1,3 @@
+-- Migration 003: Add host power control configuration column to aggregated_hosts
+
+ALTER TABLE aggregated_hosts ADD COLUMN power_config TEXT;

--- a/apps/cnc/migrations/README.md
+++ b/apps/cnc/migrations/README.md
@@ -8,10 +8,11 @@ The schema files in `src/database/` are used for **fresh installations only**. I
 
 ## Migration History
 
-| Version | File | Description | Date |
-|---------|------|-------------|------|
-| 001 | `001_add_commands_table.sql` (PostgreSQL)<br/>`001_add_commands_table.sqlite.sql` (SQLite) | Adds the `commands` table for Phase 4 (Durable Command Lifecycle) with lifecycle states and idempotency support | 2026-02-07 |
-| 002 | `002_add_host_metadata.sql` (PostgreSQL)<br/>`002_add_host_metadata.sqlite.sql` (SQLite) | Adds `notes` and `tags` host metadata columns to `aggregated_hosts` and backfills null tags | 2026-02-15 |
+| Version | File                                                                                             | Description                                                                                                     | Date       |
+| ------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ---------- |
+| 001     | `001_add_commands_table.sql` (PostgreSQL)<br/>`001_add_commands_table.sqlite.sql` (SQLite)       | Adds the `commands` table for Phase 4 (Durable Command Lifecycle) with lifecycle states and idempotency support | 2026-02-07 |
+| 002     | `002_add_host_metadata.sql` (PostgreSQL)<br/>`002_add_host_metadata.sqlite.sql` (SQLite)         | Adds `notes` and `tags` host metadata columns to `aggregated_hosts` and backfills null tags                     | 2026-02-15 |
+| 003     | `003_add_host_power_config.sql` (PostgreSQL)<br/>`003_add_host_power_config.sqlite.sql` (SQLite) | Adds `power_config` metadata column to `aggregated_hosts` for per-host sleep/shutdown opt-in                    | 2026-02-18 |
 
 ## How to Apply Migrations
 
@@ -23,11 +24,13 @@ For production PostgreSQL databases, run the migration script using `psql`:
 # Connect to your database and run the migration
 psql -U woly -d woly < migrations/001_add_commands_table.sql
 psql -U woly -d woly < migrations/002_add_host_metadata.sql
+psql -U woly -d woly < migrations/003_add_host_power_config.sql
 
 # Or connect first, then run the migration
 psql -U woly -d woly
 \i migrations/001_add_commands_table.sql
 \i migrations/002_add_host_metadata.sql
+\i migrations/003_add_host_power_config.sql
 ```
 
 ### SQLite
@@ -38,11 +41,13 @@ For SQLite databases (development/tunnel environments), use the `sqlite3` comman
 # Run the migration
 sqlite3 db/woly-cnc.db < migrations/001_add_commands_table.sqlite.sql
 sqlite3 db/woly-cnc.db < migrations/002_add_host_metadata.sqlite.sql
+sqlite3 db/woly-cnc.db < migrations/003_add_host_power_config.sqlite.sql
 
 # Or interactively
 sqlite3 db/woly-cnc.db
 .read migrations/001_add_commands_table.sqlite.sql
 .read migrations/002_add_host_metadata.sqlite.sql
+.read migrations/003_add_host_power_config.sqlite.sql
 ```
 
 ### Docker Environments
@@ -119,6 +124,7 @@ DROP TABLE IF EXISTS commands;
 ## Future Enhancements
 
 Consider implementing a migration management tool in the future:
+
 - **Flyway** - Java-based database migration tool
 - **Liquibase** - Database schema change management
 - **TypeORM migrations** - If adopting an ORM layer

--- a/apps/cnc/src/database/schema.sql
+++ b/apps/cnc/src/database/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS aggregated_hosts (
     ping_responsive INTEGER,
     notes TEXT,
     tags TEXT NOT NULL DEFAULT '[]',
+    power_config TEXT,
     open_ports TEXT NOT NULL DEFAULT '[]',
     ports_scanned_at TIMESTAMP,
     ports_expire_at TIMESTAMP,

--- a/apps/cnc/src/database/schema.sqlite.sql
+++ b/apps/cnc/src/database/schema.sqlite.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS aggregated_hosts (
     ping_responsive INTEGER,
     notes TEXT,
     tags TEXT NOT NULL DEFAULT '[]',
+    power_config TEXT,
     open_ports TEXT NOT NULL DEFAULT '[]',
     ports_scanned_at DATETIME,
     ports_expire_at DATETIME,

--- a/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/hostRoutes.test.ts
@@ -50,6 +50,8 @@ describe('Host Routes Authentication and Authorization', () => {
 
     const commandRouter = {
       routeWakeCommand: jest.fn().mockRejectedValue(new Error('Node not connected')),
+      routeSleepHostCommand: jest.fn().mockRejectedValue(new Error('Node not connected')),
+      routeShutdownHostCommand: jest.fn().mockRejectedValue(new Error('Node not connected')),
       routeScanHostsCommand: jest.fn().mockResolvedValue({
         state: 'acknowledged',
         queuedAt: '2026-02-18T00:00:00.000Z',

--- a/apps/cnc/src/routes/__tests__/webhookRoutes.test.ts
+++ b/apps/cnc/src/routes/__tests__/webhookRoutes.test.ts
@@ -78,6 +78,8 @@ describe('Webhook Routes Authentication and Authorization', () => {
 
     const commandRouter = {
       routeWakeCommand: jest.fn().mockRejectedValue(new Error('Node not connected')),
+      routeSleepHostCommand: jest.fn().mockRejectedValue(new Error('Node not connected')),
+      routeShutdownHostCommand: jest.fn().mockRejectedValue(new Error('Node not connected')),
       routeScanHostsCommand: jest.fn().mockResolvedValue({
         state: 'acknowledged',
         queuedAt: '2026-02-18T00:00:00.000Z',

--- a/apps/cnc/src/routes/index.ts
+++ b/apps/cnc/src/routes/index.ts
@@ -114,6 +114,8 @@ export function createRoutes(
   router.get('/hosts/:fqn/uptime', (req, res) => hostsController.getHostUptime(req, res));
   router.get('/hosts/:fqn', (req, res) => hostsController.getHostByFQN(req, res));
   router.post('/hosts/wakeup/:fqn', (req, res) => hostsController.wakeupHost(req, res));
+  router.post('/hosts/:fqn/sleep', (req, res) => hostsController.sleepHost(req, res));
+  router.post('/hosts/:fqn/shutdown', (req, res) => hostsController.shutdownHost(req, res));
   router.put('/hosts/:fqn', (req, res) => hostsController.updateHost(req, res));
   router.delete('/hosts/:fqn', (req, res) => hostsController.deleteHost(req, res));
 

--- a/apps/cnc/src/services/__tests__/commandRouter.test.ts
+++ b/apps/cnc/src/services/__tests__/commandRouter.test.ts
@@ -223,7 +223,9 @@ describe('CommandRouter', () => {
               | 'scan-host-ports'
               | 'update-host'
               | 'delete-host'
-              | 'ping-host';
+              | 'ping-host'
+              | 'sleep-host'
+              | 'shutdown-host';
           }
         >;
         handleCommandResult: (result: {

--- a/apps/cnc/src/services/__tests__/protocol.contract.test.ts
+++ b/apps/cnc/src/services/__tests__/protocol.contract.test.ts
@@ -41,6 +41,21 @@ describe('Shared protocol contract', () => {
     expect(inboundCncCommandSchema.safeParse(command).success).toBe(true);
   });
 
+  it('accepts valid sleep-host command payloads', () => {
+    const command = {
+      type: 'sleep-host' as const,
+      commandId: 'cmd-sleep-1',
+      data: {
+        hostName: 'office-pc',
+        mac: 'AA:BB:CC:DD:EE:FF',
+        ip: '192.168.1.20',
+        confirmation: 'sleep' as const,
+      },
+    };
+
+    expect(inboundCncCommandSchema.safeParse(command).success).toBe(true);
+  });
+
   it('rejects malformed wake command payload', () => {
     const invalidCommand = {
       type: 'wake' as const,

--- a/apps/cnc/src/services/runtimeMetrics.ts
+++ b/apps/cnc/src/services/runtimeMetrics.ts
@@ -7,6 +7,8 @@ const TRACKED_COMMAND_TYPES = [
   'update-host',
   'delete-host',
   'ping-host',
+  'sleep-host',
+  'shutdown-host',
 ] as const;
 
 type CommandOutcomeSnapshot = {

--- a/apps/cnc/src/swagger.ts
+++ b/apps/cnc/src/swagger.ts
@@ -766,7 +766,17 @@ const options: swaggerJsdoc.Options = {
             },
             type: {
               type: 'string',
-              enum: ['wake', 'update-host', 'delete-host', 'scan', 'scan-host-ports', 'ping-host', 'ping'],
+              enum: [
+                'wake',
+                'update-host',
+                'delete-host',
+                'scan',
+                'scan-host-ports',
+                'ping-host',
+                'sleep-host',
+                'shutdown-host',
+                'ping',
+              ],
               description: 'Command type',
               example: 'wake',
             },

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -8,6 +8,7 @@ import type {
   CommandState,
   HostWakeSchedule as ProtocolHostWakeSchedule,
   Host,
+  HostPowerAction as ProtocolHostPowerAction,
   HostPingResult as ProtocolHostPingResult,
   HostPortScanResult as ProtocolHostPortScanResult,
   HostPortScanResponse as ProtocolHostPortScanResponse,
@@ -93,6 +94,7 @@ export type CapabilityDescriptor = ProtocolCncCapabilityDescriptor;
 export type CncCapabilitiesResponse = ProtocolCncCapabilitiesResponse;
 export type HostPingResult = ProtocolHostPingResult;
 export type HostPortScanResponse = ProtocolHostPortScanResponse;
+export type HostPowerAction = ProtocolHostPowerAction;
 export type ScheduleFrequency = ProtocolScheduleFrequency;
 export type HostWakeSchedule = ProtocolHostWakeSchedule;
 export type WakeVerificationResult = ProtocolWakeVerificationResult;
@@ -152,6 +154,17 @@ export interface WakeupResponse {
     status: 'pending';
     startedAt: string;
   };
+}
+
+export interface HostPowerResponse {
+  success: boolean;
+  action: HostPowerAction;
+  message: string;
+  nodeId: string;
+  location: string;
+  commandId?: string;
+  state?: CommandState;
+  correlationId?: string;
 }
 
 export interface CommandRecord {

--- a/apps/node-agent/src/__tests__/protocol.contract.unit.test.ts
+++ b/apps/node-agent/src/__tests__/protocol.contract.unit.test.ts
@@ -44,6 +44,21 @@ describe('Protocol contract', () => {
     expect(inboundCncCommandSchema.safeParse(inbound).success).toBe(true);
   });
 
+  it('decodes valid inbound shutdown-host command payload', () => {
+    const inbound = {
+      type: 'shutdown-host' as const,
+      commandId: 'cmd-shutdown-1',
+      data: {
+        hostName: 'office-pc',
+        mac: 'AA:BB:CC:DD:EE:FF',
+        ip: '192.168.1.20',
+        confirmation: 'shutdown' as const,
+      },
+    };
+
+    expect(inboundCncCommandSchema.safeParse(inbound).success).toBe(true);
+  });
+
   it('rejects invalid inbound command payloads', () => {
     const invalidInbound = {
       type: 'wake' as const,

--- a/apps/node-agent/src/routes/hosts.ts
+++ b/apps/node-agent/src/routes/hosts.ts
@@ -10,6 +10,8 @@ import {
   hostNameAndMacParamSchema,
   macAddressSchema,
   mergeHostMacSchema,
+  shutdownHostSchema,
+  sleepHostSchema,
   updateHostSchema,
   wakeHostSchema,
 } from '../validators/hostValidator';
@@ -66,6 +68,24 @@ router.post(
   validateRequest(hostNameParamSchema, 'params'),
   validateRequest(wakeHostSchema, 'body'),
   hostsController.wakeUpHost
+);
+
+// Put a host to sleep (dangerous; explicit confirmation required)
+router.post(
+  '/:name/sleep',
+  wakeLimiter,
+  validateRequest(hostNameParamSchema, 'params'),
+  validateRequest(sleepHostSchema, 'body'),
+  hostsController.sleepHost
+);
+
+// Shut down a host (dangerous; explicit confirmation required)
+router.post(
+  '/:name/shutdown',
+  wakeLimiter,
+  validateRequest(hostNameParamSchema, 'params'),
+  validateRequest(shutdownHostSchema, 'body'),
+  hostsController.shutdownHost
 );
 
 // Update a specific host

--- a/apps/node-agent/src/services/__tests__/cncClient.unit.test.ts
+++ b/apps/node-agent/src/services/__tests__/cncClient.unit.test.ts
@@ -368,6 +368,66 @@ describe('CncClient Phase 1 auth lifecycle', () => {
     );
   });
 
+  it('dispatches sleep-host commands to the node-agent command handler', async () => {
+    await client.connect();
+
+    const onSleepHost = jest.fn();
+    client.on('command:sleep-host', onSleepHost);
+
+    mockSockets[0].emit(
+      'message',
+      Buffer.from(
+        JSON.stringify({
+          type: 'sleep-host',
+          commandId: 'cmd-sleep-1',
+          data: {
+            hostName: 'PC-01',
+            mac: 'AA:BB:CC:DD:EE:FF',
+            ip: '192.168.1.50',
+            confirmation: 'sleep',
+          },
+        })
+      )
+    );
+
+    expect(onSleepHost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'sleep-host',
+        commandId: 'cmd-sleep-1',
+      })
+    );
+  });
+
+  it('dispatches shutdown-host commands to the node-agent command handler', async () => {
+    await client.connect();
+
+    const onShutdownHost = jest.fn();
+    client.on('command:shutdown-host', onShutdownHost);
+
+    mockSockets[0].emit(
+      'message',
+      Buffer.from(
+        JSON.stringify({
+          type: 'shutdown-host',
+          commandId: 'cmd-shutdown-1',
+          data: {
+            hostName: 'PC-01',
+            mac: 'AA:BB:CC:DD:EE:FF',
+            ip: '192.168.1.50',
+            confirmation: 'shutdown',
+          },
+        })
+      )
+    );
+
+    expect(onShutdownHost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'shutdown-host',
+        commandId: 'cmd-shutdown-1',
+      })
+    );
+  });
+
   it('rejects malformed outbound node messages and logs validation errors', async () => {
     await client.connect();
 

--- a/apps/node-agent/src/services/cncClient.ts
+++ b/apps/node-agent/src/services/cncClient.ts
@@ -271,6 +271,12 @@ export class CncClient extends EventEmitter {
         case 'ping-host':
           this.emit('command:ping-host', message);
           break;
+        case 'sleep-host':
+          this.emit('command:sleep-host', message);
+          break;
+        case 'shutdown-host':
+          this.emit('command:shutdown-host', message);
+          break;
         case 'ping':
           this.handlePing(message.data);
           break;

--- a/apps/node-agent/src/services/hostPowerControl.ts
+++ b/apps/node-agent/src/services/hostPowerControl.ts
@@ -1,0 +1,146 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { Host, HostPowerAction, HostPowerControlConfig } from '@kaonis/woly-protocol';
+import { logger } from '../utils/logger';
+
+const execFile = promisify(execFileCallback);
+
+const DEFAULT_SSH_PORT = 22;
+const SSH_CONNECT_TIMEOUT_SECONDS = 10;
+const SSH_EXEC_TIMEOUT_MS = 30_000;
+const SSH_MAX_BUFFER_BYTES = 256 * 1024;
+
+const DEFAULT_HOST_POWER_COMMANDS: Record<HostPowerControlConfig['platform'], Record<HostPowerAction, string>> = {
+  linux: {
+    sleep: 'systemctl suspend',
+    shutdown: 'shutdown -h now',
+  },
+  macos: {
+    sleep: 'pmset sleepnow',
+    shutdown: 'shutdown -h now',
+  },
+  windows: {
+    sleep: 'rundll32.exe powrprof.dll,SetSuspendState 0,1,0',
+    shutdown: 'shutdown /s /t 0 /f',
+  },
+};
+
+const HOST_KEY_CHECKING_ARGS: Record<NonNullable<HostPowerControlConfig['ssh']['strictHostKeyChecking']>, string[]> = {
+  enforce: ['-o', 'StrictHostKeyChecking=yes'],
+  'accept-new': ['-o', 'StrictHostKeyChecking=accept-new'],
+  off: ['-o', 'StrictHostKeyChecking=no'],
+};
+
+type HostPowerExecutionPlan = {
+  target: string;
+  sshArgs: string[];
+  remoteCommand: string;
+};
+
+function resolvePowerConfig(host: Host): HostPowerControlConfig {
+  const powerControl = host.powerControl;
+  if (!powerControl) {
+    throw new Error(`Host '${host.name}' does not have power control configured`);
+  }
+
+  if (!powerControl.enabled) {
+    throw new Error(`Power control is disabled for host '${host.name}'`);
+  }
+
+  if (powerControl.transport !== 'ssh') {
+    throw new Error(
+      `Unsupported power control transport '${String(powerControl.transport)}' for host '${host.name}'`
+    );
+  }
+
+  return powerControl;
+}
+
+export function resolveHostPowerExecutionPlan(host: Host, action: HostPowerAction): HostPowerExecutionPlan {
+  if (!host.ip || host.ip.trim().length === 0) {
+    throw new Error(`Host '${host.name}' does not have a valid IP address`);
+  }
+
+  const powerControl = resolvePowerConfig(host);
+  const ssh = powerControl.ssh;
+
+  if (!ssh.username || ssh.username.trim().length === 0) {
+    throw new Error(`Host '${host.name}' is missing ssh.username in power control configuration`);
+  }
+
+  const port = ssh.port ?? DEFAULT_SSH_PORT;
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`Host '${host.name}' has invalid ssh.port value (${String(port)})`);
+  }
+
+  const defaultCommand = DEFAULT_HOST_POWER_COMMANDS[powerControl.platform][action];
+  const overrideCommand = powerControl.commands?.[action];
+  const remoteCommand = overrideCommand && overrideCommand.trim().length > 0
+    ? overrideCommand.trim()
+    : defaultCommand;
+
+  if (!remoteCommand || remoteCommand.trim().length === 0) {
+    throw new Error(`No SSH command resolved for '${action}' on host '${host.name}'`);
+  }
+
+  const sshArgs: string[] = [
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    `ConnectTimeout=${SSH_CONNECT_TIMEOUT_SECONDS}`,
+    ...HOST_KEY_CHECKING_ARGS[ssh.strictHostKeyChecking ?? 'enforce'],
+    '-p',
+    String(port),
+  ];
+
+  if (ssh.privateKeyPath && ssh.privateKeyPath.trim().length > 0) {
+    sshArgs.push('-i', ssh.privateKeyPath.trim());
+  }
+
+  const target = `${ssh.username.trim()}@${host.ip.trim()}`;
+  sshArgs.push(target, remoteCommand);
+
+  return {
+    target,
+    sshArgs,
+    remoteCommand,
+  };
+}
+
+export async function executeHostPowerAction(host: Host, action: HostPowerAction): Promise<{ message: string }> {
+  const plan = resolveHostPowerExecutionPlan(host, action);
+
+  logger.info('Executing host power action over SSH', {
+    hostName: host.name,
+    action,
+    target: plan.target,
+    platform: host.powerControl?.platform,
+  });
+
+  try {
+    await execFile('ssh', plan.sshArgs, {
+      timeout: SSH_EXEC_TIMEOUT_MS,
+      maxBuffer: SSH_MAX_BUFFER_BYTES,
+      windowsHide: true,
+      encoding: 'utf8',
+    });
+  } catch (error) {
+    const typedError = error as {
+      message?: string;
+      stderr?: string;
+      stdout?: string;
+      signal?: string;
+    };
+    const stderr = typeof typedError.stderr === 'string' ? typedError.stderr.trim() : '';
+    const stdout = typeof typedError.stdout === 'string' ? typedError.stdout.trim() : '';
+    const reason = stderr || stdout || typedError.message || 'unknown error';
+
+    throw new Error(`SSH ${action} command failed for host '${host.name}': ${reason}`, {
+      cause: error,
+    });
+  }
+
+  return {
+    message: `Remote ${action} command executed for ${host.name}`,
+  };
+}

--- a/apps/node-agent/src/swagger.ts
+++ b/apps/node-agent/src/swagger.ts
@@ -139,6 +139,45 @@ const options: swaggerJsdoc.Options = {
               },
               example: ['infra', 'linux'],
             },
+            powerControl: {
+              type: 'object',
+              nullable: true,
+              description: 'Optional per-host remote power-control configuration',
+              properties: {
+                enabled: {
+                  type: 'boolean',
+                  example: true,
+                },
+                transport: {
+                  type: 'string',
+                  enum: ['ssh'],
+                },
+                platform: {
+                  type: 'string',
+                  enum: ['linux', 'macos', 'windows'],
+                },
+                ssh: {
+                  type: 'object',
+                  properties: {
+                    username: { type: 'string', example: 'ops' },
+                    port: { type: 'integer', minimum: 1, maximum: 65535, example: 22 },
+                    privateKeyPath: { type: 'string', example: '/home/ops/.ssh/id_ed25519' },
+                    strictHostKeyChecking: {
+                      type: 'string',
+                      enum: ['enforce', 'accept-new', 'off'],
+                    },
+                  },
+                  required: ['username'],
+                },
+                commands: {
+                  type: 'object',
+                  properties: {
+                    sleep: { type: 'string', example: 'systemctl suspend' },
+                    shutdown: { type: 'string', example: 'shutdown -h now' },
+                  },
+                },
+              },
+            },
           },
           required: ['name', 'mac', 'ip', 'status'],
         },

--- a/apps/node-agent/src/validators/__tests__/hostValidator.unit.test.ts
+++ b/apps/node-agent/src/validators/__tests__/hostValidator.unit.test.ts
@@ -3,6 +3,8 @@ import {
   deleteHostSchema,
   hostNameParamSchema,
   macAddressSchema,
+  shutdownHostSchema,
+  sleepHostSchema,
   updateHostSchema,
   wakeHostSchema,
 } from '../hostValidator';
@@ -46,6 +48,18 @@ describe('hostValidator schemas', () => {
       expect(updateHostSchema.safeParse({ notes: null }).success).toBe(true);
       expect(updateHostSchema.safeParse({ tags: ['tag-1'] }).success).toBe(true);
       expect(updateHostSchema.safeParse({ wolPort: 7 }).success).toBe(true);
+      expect(
+        updateHostSchema.safeParse({
+          powerControl: {
+            enabled: true,
+            transport: 'ssh',
+            platform: 'linux',
+            ssh: {
+              username: 'root',
+            },
+          },
+        }).success
+      ).toBe(true);
     });
 
     it('accepts combined updates', () => {
@@ -79,6 +93,18 @@ describe('hostValidator schemas', () => {
       expect(updateHostSchema.safeParse({ tags: [''] }).success).toBe(false);
       expect(updateHostSchema.safeParse({ wolPort: 0 }).success).toBe(false);
       expect(updateHostSchema.safeParse({ wolPort: 70000 }).success).toBe(false);
+      expect(
+        updateHostSchema.safeParse({
+          powerControl: {
+            enabled: true,
+            transport: 'ssh',
+            platform: 'linux',
+            ssh: {
+              username: '',
+            },
+          },
+        }).success
+      ).toBe(false);
     });
   });
 
@@ -104,6 +130,18 @@ describe('hostValidator schemas', () => {
       if (result.success) {
         expect(result.data.name).toBe('PHANTOM-MBP');
       }
+    });
+  });
+
+  describe('dangerous power action schemas', () => {
+    it('requires explicit confirmation for sleep', () => {
+      expect(sleepHostSchema.safeParse({ confirm: 'sleep' }).success).toBe(true);
+      expect(sleepHostSchema.safeParse({ confirm: 'shutdown' }).success).toBe(false);
+    });
+
+    it('requires explicit confirmation for shutdown', () => {
+      expect(shutdownHostSchema.safeParse({ confirm: 'shutdown' }).success).toBe(true);
+      expect(shutdownHostSchema.safeParse({ confirm: 'sleep' }).success).toBe(false);
     });
   });
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaonis/woly-protocol",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Shared WoLy node <-> C&C protocol types and runtime schemas",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/packages/protocol/src/__tests__/contract.cross-repo.test.ts
+++ b/packages/protocol/src/__tests__/contract.cross-repo.test.ts
@@ -611,6 +611,52 @@ describe('Cross-repo protocol contract', () => {
       });
     });
 
+    describe('sleep-host command', () => {
+      it('successfully encodes sleep-host commands with confirmation token', () => {
+        const command = {
+          type: 'sleep-host' as const,
+          commandId: 'cmd-sleep-001',
+          data: {
+            hostName: 'desktop-gaming',
+            mac: 'AA:BB:CC:DD:EE:FF',
+            ip: '192.168.1.100',
+            confirmation: 'sleep' as const,
+          },
+        };
+
+        const result = inboundCncCommandSchema.safeParse(command);
+        expect(result.success).toBe(true);
+
+        const roundTrip = inboundCncCommandSchema.safeParse(
+          JSON.parse(JSON.stringify(command)),
+        );
+        expect(roundTrip.success).toBe(true);
+      });
+    });
+
+    describe('shutdown-host command', () => {
+      it('successfully encodes shutdown-host commands with confirmation token', () => {
+        const command = {
+          type: 'shutdown-host' as const,
+          commandId: 'cmd-shutdown-001',
+          data: {
+            hostName: 'desktop-gaming',
+            mac: 'AA:BB:CC:DD:EE:FF',
+            ip: '192.168.1.100',
+            confirmation: 'shutdown' as const,
+          },
+        };
+
+        const result = inboundCncCommandSchema.safeParse(command);
+        expect(result.success).toBe(true);
+
+        const roundTrip = inboundCncCommandSchema.safeParse(
+          JSON.parse(JSON.stringify(command)),
+        );
+        expect(roundTrip.success).toBe(true);
+      });
+    });
+
     describe('ping command', () => {
       it('successfully encodes ping with timestamp coercion', () => {
         const command = {

--- a/packages/protocol/src/__tests__/schemas.test.ts
+++ b/packages/protocol/src/__tests__/schemas.test.ts
@@ -1514,6 +1514,66 @@ describe('inboundCncCommandSchema', () => {
     });
   });
 
+  describe('sleep-host', () => {
+    it('accepts valid sleep-host command', () => {
+      const cmd = {
+        type: 'sleep-host' as const,
+        commandId: 'cmd-sleep-1',
+        data: {
+          hostName: 'office-pc',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          ip: '192.168.1.20',
+          confirmation: 'sleep' as const,
+        },
+      };
+      expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(true);
+    });
+
+    it('rejects sleep-host with mismatched confirmation token', () => {
+      const cmd = {
+        type: 'sleep-host' as const,
+        commandId: 'cmd-sleep-2',
+        data: {
+          hostName: 'office-pc',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          ip: '192.168.1.20',
+          confirmation: 'shutdown',
+        },
+      };
+      expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(false);
+    });
+  });
+
+  describe('shutdown-host', () => {
+    it('accepts valid shutdown-host command', () => {
+      const cmd = {
+        type: 'shutdown-host' as const,
+        commandId: 'cmd-shutdown-1',
+        data: {
+          hostName: 'office-pc',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          ip: '192.168.1.20',
+          confirmation: 'shutdown' as const,
+        },
+      };
+      expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(true);
+    });
+
+    it('rejects shutdown-host with mismatched confirmation token', () => {
+      const cmd = {
+        type: 'shutdown-host' as const,
+        commandId: 'cmd-shutdown-2',
+        data: {
+          hostName: 'office-pc',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          ip: '192.168.1.20',
+          confirmation: 'sleep',
+        },
+      };
+      expect(inboundCncCommandSchema.safeParse(cmd).success).toBe(false);
+    });
+  });
+
   describe('ping', () => {
     it('accepts valid ping', () => {
       const cmd = {


### PR DESCRIPTION
## Summary
Implements Sleep-on-LAN / remote shutdown support end-to-end using SSH-based host power control.

## Linked Issues
- Protocol issue: kaonis/woly-server#376
- Backend issue: kaonis/woly-server#348
- Frontend issue: kaonis/woly#427

## What Changed
- Protocol (`packages/protocol`)
  - Added `powerControl` host contract with SSH configuration and platform/command options
  - Added `sleep-host` and `shutdown-host` inbound command schemas with explicit confirmation token requirements
  - Bumped protocol version to `1.4.0` and retained compatibility list
- Backend (`apps/cnc`)
  - Added `/api/hosts/:fqn/sleep` and `/api/hosts/:fqn/shutdown` routes with explicit confirmation checks
  - Routed new commands through command router/runtime metrics/swagger
  - Persisted host `powerControl` config via `power_config` DB column + migrations
- Node agent (`apps/node-agent`)
  - Added SSH host power execution service with platform defaults and optional per-host command overrides
  - Added handler support for `sleep-host` and `shutdown-host` commands
  - Added local host sleep/shutdown endpoints and validation
  - Persisted host `powerControl` config in node-agent host DB
- Tests
  - Added/updated protocol contract tests, CNC command/controller/route tests, and node-agent validator/client/service tests

## Validation
- `npm run build -w packages/protocol`
- `npm run test -w packages/protocol -- --runTestsByPath src/__tests__/schemas.test.ts src/__tests__/contract.cross-repo.test.ts`
- `npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts`
- `npm run validate:standard`
- Pre-push hooks (`typecheck` + related tests) passed on push

Closes #348
Closes #376
