### PR TITLE
feat(cnc): add plugin runtime and webhook reference plugin

### DIFF
--- a/apps/cnc/src/config/__tests__/index.test.ts
+++ b/apps/cnc/src/config/__tests__/index.test.ts
@@ -50,6 +50,7 @@ describe('config parsing and validation', () => {
       SCHEDULE_WORKER_ENABLED: 'false',
       SCHEDULE_POLL_INTERVAL_MS: '45000',
       SCHEDULE_BATCH_SIZE: '10',
+      CNC_PLUGINS: 'webhook, custom-plugin,',
       WEBHOOK_RETRY_BASE_DELAY_MS: '2000',
       WEBHOOK_DELIVERY_TIMEOUT_MS: '8000',
       OFFLINE_COMMAND_TTL_MS: '120000',
@@ -64,6 +65,7 @@ describe('config parsing and validation', () => {
     expect(config.scheduleWorkerEnabled).toBe(false);
     expect(config.schedulePollIntervalMs).toBe(45000);
     expect(config.scheduleBatchSize).toBe(10);
+    expect(config.enabledPlugins).toEqual(['webhook', 'custom-plugin']);
     expect(config.webhookRetryBaseDelayMs).toBe(2000);
     expect(config.webhookDeliveryTimeoutMs).toBe(8000);
     expect(config.offlineCommandTtlMs).toBe(120000);

--- a/apps/cnc/src/config/index.ts
+++ b/apps/cnc/src/config/index.ts
@@ -129,6 +129,10 @@ export const config: ServerConfig = {
   scheduleWorkerEnabled: getEnvBoolean('SCHEDULE_WORKER_ENABLED', true),
   schedulePollIntervalMs: getEnvNumber('SCHEDULE_POLL_INTERVAL_MS', 60000),
   scheduleBatchSize: getEnvNumber('SCHEDULE_BATCH_SIZE', 25),
+  enabledPlugins: getEnvVarOptional('CNC_PLUGINS', 'webhook')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean),
   webhookRetryBaseDelayMs: getEnvNumber('WEBHOOK_RETRY_BASE_DELAY_MS', 1000),
   webhookDeliveryTimeoutMs: getEnvNumber('WEBHOOK_DELIVERY_TIMEOUT_MS', 5000),
   logLevel: getEnvVar('LOG_LEVEL', 'info'),

--- a/apps/cnc/src/services/__tests__/pluginEventBridge.test.ts
+++ b/apps/cnc/src/services/__tests__/pluginEventBridge.test.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from 'events';
+import { PluginEventBridge } from '../pluginEventBridge';
+import type { PluginEventBus } from '../pluginEventBus';
+
+describe('PluginEventBridge', () => {
+  it('bridges host and node events into plugin bus events', () => {
+    const hostAggregator = new EventEmitter();
+    const nodeManager = new EventEmitter();
+    const publish = jest.fn();
+    const eventBus = {
+      publish,
+    } as unknown as PluginEventBus;
+
+    const bridge = new PluginEventBridge(hostAggregator as never, nodeManager as never, eventBus);
+    bridge.start();
+
+    hostAggregator.emit('host-added', {
+      nodeId: 'node-1',
+      fullyQualifiedName: 'desktop@node-1',
+      host: {
+        name: 'desktop',
+        mac: 'aa:bb:cc:dd:ee:ff',
+        status: 'awake',
+      },
+    });
+
+    hostAggregator.emit('host-status-transition', {
+      hostFqn: 'desktop@node-1',
+      oldStatus: 'asleep',
+      newStatus: 'awake',
+      changedAt: '2026-02-18T20:00:00.000Z',
+    });
+
+    nodeManager.emit('node-connected', {
+      nodeId: 'node-1',
+    });
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'host.discovered',
+        data: expect.objectContaining({
+          hostFqn: 'desktop@node-1',
+        }),
+      })
+    );
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'host.status-transition',
+        data: expect.objectContaining({
+          hostFqn: 'desktop@node-1',
+          newStatus: 'awake',
+        }),
+      })
+    );
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'node.connected',
+        data: {
+          nodeId: 'node-1',
+        },
+      })
+    );
+  });
+
+  it('detaches listeners on shutdown', () => {
+    const hostAggregator = new EventEmitter();
+    const nodeManager = new EventEmitter();
+    const publish = jest.fn();
+    const eventBus = {
+      publish,
+    } as unknown as PluginEventBus;
+
+    const bridge = new PluginEventBridge(hostAggregator as never, nodeManager as never, eventBus);
+    bridge.start();
+    bridge.shutdown();
+
+    hostAggregator.emit('host-removed', {
+      nodeId: 'node-1',
+      name: 'desktop',
+    });
+
+    nodeManager.emit('scan-complete', {
+      nodeId: 'node-1',
+      hostCount: 3,
+    });
+
+    expect(publish).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cnc/src/services/__tests__/pluginEventBus.test.ts
+++ b/apps/cnc/src/services/__tests__/pluginEventBus.test.ts
@@ -1,0 +1,92 @@
+import { PluginEventBus } from '../pluginEventBus';
+import logger from '../../utils/logger';
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('PluginEventBus', () => {
+  const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('publishes events to subscribed handlers', () => {
+    const bus = new PluginEventBus();
+    const handler = jest.fn();
+
+    bus.subscribe('node.connected', handler);
+
+    bus.publish({
+      type: 'node.connected',
+      timestamp: '2026-02-18T20:00:00.000Z',
+      data: {
+        nodeId: 'node-1',
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'node.connected',
+        data: {
+          nodeId: 'node-1',
+        },
+      })
+    );
+  });
+
+  it('unsubscribe detaches handlers', () => {
+    const bus = new PluginEventBus();
+    const handler = jest.fn();
+
+    const unsubscribe = bus.subscribe('scan.complete', handler);
+    unsubscribe();
+
+    bus.publish({
+      type: 'scan.complete',
+      timestamp: '2026-02-18T20:00:00.000Z',
+      data: {
+        nodeId: 'node-1',
+        hostCount: 5,
+      },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('logs and continues when a handler throws', () => {
+    const bus = new PluginEventBus();
+    const failingHandler = jest.fn(() => {
+      throw new Error('handler boom');
+    });
+    const healthyHandler = jest.fn();
+
+    bus.subscribe('host.removed', failingHandler);
+    bus.subscribe('host.removed', healthyHandler);
+
+    bus.publish({
+      type: 'host.removed',
+      timestamp: '2026-02-18T20:00:00.000Z',
+      data: {
+        nodeId: 'node-1',
+        name: 'desktop',
+      },
+    });
+
+    expect(failingHandler).toHaveBeenCalledTimes(1);
+    expect(healthyHandler).toHaveBeenCalledTimes(1);
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      'Plugin event handler failed',
+      expect.objectContaining({
+        eventType: 'host.removed',
+      })
+    );
+  });
+});

--- a/apps/cnc/src/services/pluginEventBridge.ts
+++ b/apps/cnc/src/services/pluginEventBridge.ts
@@ -1,0 +1,144 @@
+import type { Host, HostStatus } from '@kaonis/woly-protocol';
+import type { HostAggregator } from './hostAggregator';
+import type { NodeManager } from './nodeManager';
+import type { PluginEventBus } from './pluginEventBus';
+
+type HostAddedPayload = {
+  nodeId: string;
+  fullyQualifiedName?: string;
+  hostFqn?: string;
+  host: Host;
+};
+
+type HostRemovedPayload = {
+  nodeId: string;
+  name: string;
+};
+
+type HostStatusTransitionPayload = {
+  hostFqn: string;
+  oldStatus: HostStatus;
+  newStatus: HostStatus;
+  changedAt: string;
+};
+
+type NodeConnectionPayload = {
+  nodeId: string;
+};
+
+type ScanCompletePayload = {
+  nodeId: string;
+  hostCount: number;
+};
+
+export class PluginEventBridge {
+  private started = false;
+
+  constructor(
+    private readonly hostAggregator: HostAggregator,
+    private readonly nodeManager: NodeManager,
+    private readonly eventBus: PluginEventBus,
+  ) {}
+
+  private readonly onHostAdded = (payload: HostAddedPayload): void => {
+    const hostFqn = payload.hostFqn ?? payload.fullyQualifiedName;
+    if (!hostFqn) {
+      return;
+    }
+
+    this.eventBus.publish({
+      type: 'host.discovered',
+      timestamp: new Date().toISOString(),
+      data: {
+        nodeId: payload.nodeId,
+        hostFqn,
+        host: payload.host,
+      },
+    });
+  };
+
+  private readonly onHostRemoved = (payload: HostRemovedPayload): void => {
+    this.eventBus.publish({
+      type: 'host.removed',
+      timestamp: new Date().toISOString(),
+      data: {
+        nodeId: payload.nodeId,
+        name: payload.name,
+      },
+    });
+  };
+
+  private readonly onHostStatusTransition = (payload: HostStatusTransitionPayload): void => {
+    this.eventBus.publish({
+      type: 'host.status-transition',
+      timestamp: new Date().toISOString(),
+      data: {
+        hostFqn: payload.hostFqn,
+        oldStatus: payload.oldStatus,
+        newStatus: payload.newStatus,
+        changedAt: payload.changedAt,
+      },
+    });
+  };
+
+  private readonly onNodeConnected = (payload: NodeConnectionPayload): void => {
+    this.eventBus.publish({
+      type: 'node.connected',
+      timestamp: new Date().toISOString(),
+      data: {
+        nodeId: payload.nodeId,
+      },
+    });
+  };
+
+  private readonly onNodeDisconnected = (payload: NodeConnectionPayload): void => {
+    this.eventBus.publish({
+      type: 'node.disconnected',
+      timestamp: new Date().toISOString(),
+      data: {
+        nodeId: payload.nodeId,
+      },
+    });
+  };
+
+  private readonly onScanComplete = (payload: ScanCompletePayload): void => {
+    this.eventBus.publish({
+      type: 'scan.complete',
+      timestamp: new Date().toISOString(),
+      data: {
+        nodeId: payload.nodeId,
+        hostCount: payload.hostCount,
+      },
+    });
+  };
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+
+    this.started = true;
+    this.hostAggregator.on('host-added', this.onHostAdded);
+    this.hostAggregator.on('host-removed', this.onHostRemoved);
+    this.hostAggregator.on('host-status-transition', this.onHostStatusTransition);
+    this.nodeManager.on('node-connected', this.onNodeConnected);
+    this.nodeManager.on('node-disconnected', this.onNodeDisconnected);
+    this.nodeManager.on('scan-complete', this.onScanComplete);
+  }
+
+  shutdown(): void {
+    if (!this.started) {
+      return;
+    }
+
+    this.started = false;
+    this.hostAggregator.off('host-added', this.onHostAdded);
+    this.hostAggregator.off('host-removed', this.onHostRemoved);
+    this.hostAggregator.off('host-status-transition', this.onHostStatusTransition);
+    this.nodeManager.off('node-connected', this.onNodeConnected);
+    this.nodeManager.off('node-disconnected', this.onNodeDisconnected);
+    this.nodeManager.off('scan-complete', this.onScanComplete);
+  }
+}
+
+export default PluginEventBridge;

--- a/apps/cnc/src/services/pluginEventBus.ts
+++ b/apps/cnc/src/services/pluginEventBus.ts
@@ -1,0 +1,54 @@
+import logger from '../utils/logger';
+import type { CncPluginEventMap, CncPluginEventType } from './plugins/types';
+
+type PluginEventHandler<T extends CncPluginEventType> = (event: CncPluginEventMap[T]) => void;
+
+export class PluginEventBus {
+  private readonly handlers = new Map<CncPluginEventType, Set<PluginEventHandler<CncPluginEventType>>>();
+
+  subscribe<T extends CncPluginEventType>(eventType: T, handler: PluginEventHandler<T>): () => void {
+    const typedHandlers = this.handlers.get(eventType) ?? new Set<PluginEventHandler<CncPluginEventType>>();
+    typedHandlers.add(handler as PluginEventHandler<CncPluginEventType>);
+    this.handlers.set(eventType, typedHandlers);
+
+    return () => {
+      this.unsubscribe(eventType, handler);
+    };
+  }
+
+  unsubscribe<T extends CncPluginEventType>(eventType: T, handler: PluginEventHandler<T>): void {
+    const typedHandlers = this.handlers.get(eventType);
+    if (!typedHandlers) {
+      return;
+    }
+
+    typedHandlers.delete(handler as PluginEventHandler<CncPluginEventType>);
+    if (typedHandlers.size === 0) {
+      this.handlers.delete(eventType);
+    }
+  }
+
+  publish<T extends CncPluginEventType>(event: CncPluginEventMap[T]): void {
+    const typedHandlers = this.handlers.get(event.type);
+    if (!typedHandlers || typedHandlers.size === 0) {
+      return;
+    }
+
+    for (const handler of typedHandlers) {
+      try {
+        handler(event as CncPluginEventMap[CncPluginEventType]);
+      } catch (error) {
+        logger.error('Plugin event handler failed', {
+          eventType: event.type,
+          error,
+        });
+      }
+    }
+  }
+
+  clear(): void {
+    this.handlers.clear();
+  }
+}
+
+export type { CncPluginEventMap, CncPluginEventType } from './plugins/types';

--- a/apps/cnc/src/services/plugins/__tests__/pluginManager.test.ts
+++ b/apps/cnc/src/services/plugins/__tests__/pluginManager.test.ts
@@ -1,0 +1,70 @@
+import { PluginManager } from '../pluginManager';
+import { PluginEventBus } from '../../pluginEventBus';
+import logger from '../../../utils/logger';
+
+jest.mock('../../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('PluginManager', () => {
+  const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts known plugins and skips unknown plugin ids', async () => {
+    const init = jest.fn();
+    const destroy = jest.fn();
+
+    const manager = new PluginManager({
+      eventBus: new PluginEventBus(),
+      enabledPlugins: ['mock-plugin', 'unknown-plugin', 'mock-plugin'],
+      pluginFactories: {
+        'mock-plugin': () => ({
+          name: 'mock-plugin',
+          version: '1.0.0',
+          init,
+          destroy,
+        }),
+      },
+    });
+
+    await manager.start();
+
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(manager.getActivePluginNames()).toEqual(['mock-plugin']);
+    expect(mockedLogger.warn).toHaveBeenCalledWith('Skipping unknown CNC plugin', {
+      pluginId: 'unknown-plugin',
+    });
+  });
+
+  it('shuts down started plugins', async () => {
+    const destroy = jest.fn();
+
+    const manager = new PluginManager({
+      eventBus: new PluginEventBus(),
+      enabledPlugins: ['mock-plugin'],
+      pluginFactories: {
+        'mock-plugin': () => ({
+          name: 'mock-plugin',
+          version: '1.0.0',
+          init: jest.fn(),
+          destroy,
+        }),
+      },
+    });
+
+    await manager.start();
+    await manager.shutdown();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(manager.getActivePluginNames()).toEqual([]);
+  });
+});

--- a/apps/cnc/src/services/plugins/__tests__/webhookPlugin.test.ts
+++ b/apps/cnc/src/services/plugins/__tests__/webhookPlugin.test.ts
@@ -1,0 +1,103 @@
+import { PluginEventBus } from '../../pluginEventBus';
+import { WebhookPlugin } from '../webhookPlugin';
+
+describe('WebhookPlugin', () => {
+  it('maps host status transition events to host.awake and host.asleep webhooks', () => {
+    const dispatchEvent = jest.fn().mockResolvedValue(undefined);
+    const shutdown = jest.fn();
+
+    const plugin = new WebhookPlugin({
+      dispatcher: {
+        dispatchEvent,
+        shutdown,
+      } as never,
+    });
+
+    const eventBus = new PluginEventBus();
+    plugin.init({ eventBus });
+
+    eventBus.publish({
+      type: 'host.status-transition',
+      timestamp: '2026-02-18T20:00:00.000Z',
+      data: {
+        hostFqn: 'desktop@node-1',
+        oldStatus: 'asleep',
+        newStatus: 'awake',
+        changedAt: '2026-02-18T20:00:00.000Z',
+      },
+    });
+
+    eventBus.publish({
+      type: 'host.status-transition',
+      timestamp: '2026-02-18T20:05:00.000Z',
+      data: {
+        hostFqn: 'desktop@node-1',
+        oldStatus: 'awake',
+        newStatus: 'asleep',
+        changedAt: '2026-02-18T20:05:00.000Z',
+      },
+    });
+
+    expect(dispatchEvent).toHaveBeenNthCalledWith(
+      1,
+      'host.awake',
+      expect.objectContaining({
+        hostFqn: 'desktop@node-1',
+      }),
+    );
+
+    expect(dispatchEvent).toHaveBeenNthCalledWith(
+      2,
+      'host.asleep',
+      expect.objectContaining({
+        hostFqn: 'desktop@node-1',
+      }),
+    );
+  });
+
+  it('forwards direct event mappings and cleans up on destroy', () => {
+    const dispatchEvent = jest.fn().mockResolvedValue(undefined);
+    const shutdown = jest.fn();
+
+    const plugin = new WebhookPlugin({
+      dispatcher: {
+        dispatchEvent,
+        shutdown,
+      } as never,
+    });
+
+    const eventBus = new PluginEventBus();
+    plugin.init({ eventBus });
+
+    eventBus.publish({
+      type: 'scan.complete',
+      timestamp: '2026-02-18T20:00:00.000Z',
+      data: {
+        nodeId: 'node-1',
+        hostCount: 5,
+      },
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      'scan.complete',
+      expect.objectContaining({
+        nodeId: 'node-1',
+        hostCount: 5,
+      }),
+    );
+
+    plugin.destroy();
+
+    eventBus.publish({
+      type: 'scan.complete',
+      timestamp: '2026-02-18T20:01:00.000Z',
+      data: {
+        nodeId: 'node-1',
+        hostCount: 6,
+      },
+    });
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/cnc/src/services/plugins/pluginManager.ts
+++ b/apps/cnc/src/services/plugins/pluginManager.ts
@@ -1,0 +1,102 @@
+import logger from '../../utils/logger';
+import type { PluginEventBus } from '../pluginEventBus';
+import type { PluginContext, PluginFactory, WolyPlugin } from './types';
+import { WebhookPlugin } from './webhookPlugin';
+
+const DEFAULT_PLUGIN_FACTORIES: Record<string, PluginFactory> = {
+  webhook: () => new WebhookPlugin(),
+};
+
+type PluginManagerOptions = {
+  eventBus: PluginEventBus;
+  enabledPlugins: string[];
+  pluginFactories?: Record<string, PluginFactory>;
+};
+
+export class PluginManager {
+  private readonly eventBus: PluginEventBus;
+  private readonly enabledPlugins: string[];
+  private readonly pluginFactories: Record<string, PluginFactory>;
+  private readonly activePlugins: WolyPlugin[] = [];
+  private started = false;
+
+  constructor(options: PluginManagerOptions) {
+    this.eventBus = options.eventBus;
+    this.enabledPlugins = options.enabledPlugins;
+    this.pluginFactories = options.pluginFactories ?? DEFAULT_PLUGIN_FACTORIES;
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      return;
+    }
+
+    this.started = true;
+    const context: PluginContext = {
+      eventBus: this.eventBus,
+    };
+
+    for (const pluginId of this.getDedupedEnabledPluginIds()) {
+      const factory = this.pluginFactories[pluginId];
+      if (!factory) {
+        logger.warn('Skipping unknown CNC plugin', { pluginId });
+        continue;
+      }
+
+      try {
+        const plugin = factory();
+        await plugin.init(context);
+        this.activePlugins.push(plugin);
+        logger.info('Started CNC plugin', {
+          pluginId,
+          version: plugin.version,
+        });
+      } catch (error) {
+        logger.error('Failed to start CNC plugin', {
+          pluginId,
+          error,
+        });
+      }
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+
+    this.started = false;
+
+    for (let index = this.activePlugins.length - 1; index >= 0; index -= 1) {
+      const plugin = this.activePlugins[index];
+      try {
+        await plugin.destroy();
+      } catch (error) {
+        logger.warn('Failed to shutdown CNC plugin cleanly', {
+          pluginName: plugin.name,
+          error,
+        });
+      }
+    }
+
+    this.activePlugins.length = 0;
+  }
+
+  getActivePluginNames(): string[] {
+    return this.activePlugins.map((plugin) => plugin.name);
+  }
+
+  private getDedupedEnabledPluginIds(): string[] {
+    const deduped = new Set<string>();
+    for (const pluginId of this.enabledPlugins) {
+      const normalized = pluginId.trim();
+      if (!normalized) {
+        continue;
+      }
+      deduped.add(normalized);
+    }
+    return [...deduped];
+  }
+}
+
+export default PluginManager;

--- a/apps/cnc/src/services/plugins/types.ts
+++ b/apps/cnc/src/services/plugins/types.ts
@@ -1,0 +1,75 @@
+import type { Host, HostStatus } from '@kaonis/woly-protocol';
+import type { PluginEventBus } from '../pluginEventBus';
+
+export type CncPluginEventType =
+  | 'host.discovered'
+  | 'host.removed'
+  | 'host.status-transition'
+  | 'node.connected'
+  | 'node.disconnected'
+  | 'scan.complete';
+
+export type CncPluginEventMap = {
+  'host.discovered': {
+    type: 'host.discovered';
+    timestamp: string;
+    data: {
+      nodeId: string;
+      hostFqn: string;
+      host: Host;
+    };
+  };
+  'host.removed': {
+    type: 'host.removed';
+    timestamp: string;
+    data: {
+      nodeId: string;
+      name: string;
+    };
+  };
+  'host.status-transition': {
+    type: 'host.status-transition';
+    timestamp: string;
+    data: {
+      hostFqn: string;
+      oldStatus: HostStatus;
+      newStatus: HostStatus;
+      changedAt: string;
+    };
+  };
+  'node.connected': {
+    type: 'node.connected';
+    timestamp: string;
+    data: {
+      nodeId: string;
+    };
+  };
+  'node.disconnected': {
+    type: 'node.disconnected';
+    timestamp: string;
+    data: {
+      nodeId: string;
+    };
+  };
+  'scan.complete': {
+    type: 'scan.complete';
+    timestamp: string;
+    data: {
+      nodeId: string;
+      hostCount: number;
+    };
+  };
+};
+
+export interface PluginContext {
+  eventBus: PluginEventBus;
+}
+
+export interface WolyPlugin {
+  readonly name: string;
+  readonly version: string;
+  init(context: PluginContext): Promise<void> | void;
+  destroy(): Promise<void> | void;
+}
+
+export type PluginFactory = () => WolyPlugin;

--- a/apps/cnc/src/services/plugins/webhookPlugin.ts
+++ b/apps/cnc/src/services/plugins/webhookPlugin.ts
@@ -1,0 +1,69 @@
+import type { WebhookEventType } from '@kaonis/woly-protocol';
+import { WebhookDispatcher } from '../webhookDispatcher';
+import type { PluginContext, WolyPlugin } from './types';
+
+export class WebhookPlugin implements WolyPlugin {
+  readonly name = 'webhook';
+  readonly version = '1.0.0';
+
+  private readonly dispatcher: WebhookDispatcher;
+  private readonly unsubscribers: Array<() => void> = [];
+
+  constructor(options?: { dispatcher?: WebhookDispatcher }) {
+    this.dispatcher = options?.dispatcher ?? new WebhookDispatcher();
+  }
+
+  init(context: PluginContext): void {
+    this.unsubscribers.push(
+      context.eventBus.subscribe('host.discovered', (event) => {
+        void this.dispatcher.dispatchEvent('host.discovered', event.data);
+      })
+    );
+
+    this.unsubscribers.push(
+      context.eventBus.subscribe('host.removed', (event) => {
+        void this.dispatcher.dispatchEvent('host.removed', event.data);
+      })
+    );
+
+    this.unsubscribers.push(
+      context.eventBus.subscribe('host.status-transition', (event) => {
+        const webhookEventType: WebhookEventType = event.data.newStatus === 'awake' ? 'host.awake' : 'host.asleep';
+        void this.dispatcher.dispatchEvent(webhookEventType, {
+          hostFqn: event.data.hostFqn,
+          oldStatus: event.data.oldStatus,
+          newStatus: event.data.newStatus,
+          changedAt: event.data.changedAt,
+        });
+      })
+    );
+
+    this.unsubscribers.push(
+      context.eventBus.subscribe('node.connected', (event) => {
+        void this.dispatcher.dispatchEvent('node.connected', event.data);
+      })
+    );
+
+    this.unsubscribers.push(
+      context.eventBus.subscribe('node.disconnected', (event) => {
+        void this.dispatcher.dispatchEvent('node.disconnected', event.data);
+      })
+    );
+
+    this.unsubscribers.push(
+      context.eventBus.subscribe('scan.complete', (event) => {
+        void this.dispatcher.dispatchEvent('scan.complete', event.data);
+      })
+    );
+  }
+
+  destroy(): void {
+    for (const unsubscribe of this.unsubscribers) {
+      unsubscribe();
+    }
+    this.unsubscribers.length = 0;
+    this.dispatcher.shutdown();
+  }
+}
+
+export default WebhookPlugin;

--- a/apps/cnc/src/types.ts
+++ b/apps/cnc/src/types.ts
@@ -216,6 +216,7 @@ export interface ServerConfig {
   scheduleWorkerEnabled: boolean;
   schedulePollIntervalMs: number;
   scheduleBatchSize: number;
+  enabledPlugins: string[];
   webhookRetryBaseDelayMs: number;
   webhookDeliveryTimeoutMs: number;
   logLevel: string;

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -1,0 +1,50 @@
+# CNC Plugin System
+
+The CNC backend supports a lightweight plugin runtime for third-party integrations.
+
+## Configuration
+
+Use `CNC_PLUGINS` to enable plugins by ID.
+
+```bash
+CNC_PLUGINS=webhook
+```
+
+- Value is a comma-separated list.
+- Unknown plugin IDs are skipped with a warning.
+- Default: `webhook`.
+
+## Runtime Design
+
+- `PluginEventBridge` normalizes internal host/node events and publishes them to `PluginEventBus`.
+- `PluginManager` loads enabled plugin IDs and manages lifecycle (`init`/`destroy`).
+- Plugins subscribe to `PluginEventBus` and react to events.
+
+## Plugin Contract
+
+```ts
+interface WolyPlugin {
+  readonly name: string;
+  readonly version: string;
+  init(context: PluginContext): Promise<void> | void;
+  destroy(): Promise<void> | void;
+}
+
+interface PluginContext {
+  eventBus: PluginEventBus;
+}
+```
+
+## Built-in Reference Plugin
+
+`webhook` is the reference plugin. It subscribes to plugin events and dispatches webhook deliveries for:
+
+- `host.discovered`
+- `host.removed`
+- `host.awake`
+- `host.asleep`
+- `node.connected`
+- `node.disconnected`
+- `scan.complete`
+
+This provides a baseline implementation that external plugins can follow.


### PR DESCRIPTION
## Summary
Implements a first-class CNC plugin runtime with a typed event bus, lifecycle manager, and built-in webhook reference plugin.

## Linked Issues
- Protocol issue: kaonis/woly-server#378
- Backend issue: kaonis/woly-server#349
- Frontend issue: kaonis/woly#428

## What Changed
- Added plugin runtime foundations:
  - `PluginEventBus` with subscribe/unsubscribe/publish
  - `PluginEventBridge` to normalize host/node runtime events into plugin events
  - `PluginManager` for plugin lifecycle loading (`init`/`destroy`) from config
  - Plugin contracts in `services/plugins/types.ts`
- Added built-in `WebhookPlugin` as the reference plugin implementation.
- Refactored `WebhookDispatcher` into a pure delivery engine (`dispatchEvent`) so it can be reused by plugins.
- Rewired `Server` startup/shutdown to plugin runtime instead of direct webhook subscriptions.
- Added config support for plugin loading via `CNC_PLUGINS` (default: `webhook`).
- Added developer documentation: `docs/PLUGIN_SYSTEM.md`.
- Added/updated tests for bus, bridge, plugin manager, webhook plugin, dispatcher, config, and server wiring.

## Validation
- `npm run validate:standard`
- `npm run build -w packages/protocol`
- `npm run test -w packages/protocol -- contract.cross-repo`
- `npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts`
- Pre-push checks passed (`typecheck` + related Jest suites)

Closes #349
Closes #378
