### PR TITLE
feat: add cloudflare tunnel command routing (#347)

### DIFF
--- a/apps/cnc/src/models/__tests__/Node.test.ts
+++ b/apps/cnc/src/models/__tests__/Node.test.ts
@@ -28,6 +28,7 @@ describe('NodeModel', () => {
         name: 'Test Node',
         location: 'Test Location',
         authToken: 'test-token',
+        publicUrl: 'https://test-node.example.trycloudflare.com',
         metadata: {
           version: '1.0.0',
           platform: 'linux',
@@ -44,6 +45,7 @@ describe('NodeModel', () => {
       expect(node.id).toBe('test-node-1');
       expect(node.name).toBe('Test Node');
       expect(node.location).toBe('Test Location');
+      expect(node.publicUrl).toBe('https://test-node.example.trycloudflare.com');
       expect(node.status).toBe('online');
       expect(node.metadata).toEqual(registration.metadata);
     });
@@ -54,6 +56,7 @@ describe('NodeModel', () => {
         name: 'Updated Node',
         location: 'Updated Location',
         authToken: 'test-token',
+        publicUrl: 'https://updated-node.example.trycloudflare.com',
         metadata: {
           version: '1.0.1',
           platform: 'linux',
@@ -69,6 +72,7 @@ describe('NodeModel', () => {
 
       expect(node.name).toBe('Updated Node');
       expect(node.location).toBe('Updated Location');
+      expect(node.publicUrl).toBe('https://updated-node.example.trycloudflare.com');
       expect(node.metadata.version).toBe('1.0.1');
     });
   });

--- a/apps/cnc/src/services/__tests__/nodeManager.test.ts
+++ b/apps/cnc/src/services/__tests__/nodeManager.test.ts
@@ -487,14 +487,14 @@ describe('NodeManager', () => {
         },
       };
 
-      nodeManager.sendCommand('test-ws-node-4', command);
+      await nodeManager.sendCommand('test-ws-node-4', command);
 
       expect(mockWs.send).toHaveBeenCalledWith(
         expect.stringContaining('test-cmd-1')
       );
     });
 
-    it('should throw error when node not connected', () => {
+    it('should throw error when node not connected', async () => {
       const command = {
         type: 'wake' as const,
         commandId: 'test-cmd-2',
@@ -504,9 +504,7 @@ describe('NodeManager', () => {
         },
       };
 
-      expect(() => {
-        nodeManager.sendCommand('non-existent-node', command);
-      }).toThrow('not connected');
+      await expect(nodeManager.sendCommand('non-existent-node', command)).rejects.toThrow('not connected');
     });
   });
 

--- a/apps/cnc/src/services/commandRouter/commandLifecycle.ts
+++ b/apps/cnc/src/services/commandRouter/commandLifecycle.ts
@@ -184,7 +184,7 @@ export async function dispatchPersistedCommand(
       await new Promise((resolve) => setTimeout(resolve, backoffDelay));
     }
 
-    context.nodeManager.sendCommand(nodeId, payload);
+    await context.nodeManager.sendCommand(nodeId, payload);
     runtimeMetrics.recordCommandDispatched(commandId, commandType, correlationId);
     await CommandModel.markSent(commandId);
 

--- a/apps/node-agent/.env.example
+++ b/apps/node-agent/.env.example
@@ -35,7 +35,10 @@ NODE_SESSION_TOKEN_URL=                  # Optional: endpoint to mint short-live
 NODE_SESSION_TOKEN_TIMEOUT_MS=5000       # Session token request timeout
 NODE_SESSION_TOKEN_REFRESH_BUFFER_SECONDS=60  # Refresh before expiry
 WS_ALLOW_QUERY_TOKEN_FALLBACK=true       # Set false to disable legacy ?token= fallback
-NODE_PUBLIC_URL=                         # Optional: Public URL for this node
+TUNNEL_MODE=direct                       # 'direct' (default) or 'cloudflare'
+CLOUDFLARE_TUNNEL_URL=                   # Required when TUNNEL_MODE=cloudflare (must be https://...)
+CLOUDFLARE_TUNNEL_TOKEN=                 # Required when TUNNEL_MODE=cloudflare
+NODE_PUBLIC_URL=                         # Optional override public URL for non-cloudflare tunnel setups
 HEARTBEAT_INTERVAL=30000                 # 30 seconds
 RECONNECT_INTERVAL=5000                  # 5 seconds
 MAX_RECONNECT_ATTEMPTS=0                 # 0 = infinite retries

--- a/apps/node-agent/README.md
+++ b/apps/node-agent/README.md
@@ -289,7 +289,38 @@ CORS_ORIGINS=http://localhost:19000,http://192.168.1.228:8082
 
 # Logging
 LOG_LEVEL=info          # error, warn, info, http, debug
+
+# Agent mode + tunnel dispatch
+NODE_MODE=agent
+CNC_URL=wss://cnc.example.com
+NODE_ID=home-office-node
+NODE_LOCATION=Home Office
+NODE_AUTH_TOKEN=replace-with-cnc-node-token
+TUNNEL_MODE=direct      # "direct" or "cloudflare"
+CLOUDFLARE_TUNNEL_URL=  # required when TUNNEL_MODE=cloudflare
+CLOUDFLARE_TUNNEL_TOKEN=# required when TUNNEL_MODE=cloudflare
+NODE_PUBLIC_URL=        # optional override for non-cloudflare public URLs
 ```
+
+### Cloudflare Tunnel Setup (Zero Port-Forwarding)
+
+Use this when you want C&C command routing through a Cloudflare public endpoint for the node-agent.
+
+1. Create/authenticate a Cloudflare Tunnel for the node-agent service (`http://localhost:8082`).
+2. Configure node-agent:
+
+```env
+NODE_MODE=agent
+TUNNEL_MODE=cloudflare
+CLOUDFLARE_TUNNEL_URL=https://<your-tunnel-hostname>
+CLOUDFLARE_TUNNEL_TOKEN=<your-cloudflare-tunnel-token>
+```
+
+3. Keep `NODE_AUTH_TOKEN` aligned with C&C `NODE_AUTH_TOKENS`.
+4. Start `cloudflared` with your tunnel token.
+5. Start node-agent and verify registration in C&C (`GET /api/nodes` should show `publicUrl`).
+
+When tunnel dispatch fails or is unavailable, C&C falls back to the direct WebSocket path automatically.
 
 ## Security Features
 
@@ -320,6 +351,7 @@ curl http://localhost:8082/health
 ```
 
 **Security Features**:
+
 - Constant-time key comparison (prevents timing attacks)
 - Flexible whitespace handling per HTTP spec
 - Case-sensitive validation

--- a/apps/node-agent/src/app.ts
+++ b/apps/node-agent/src/app.ts
@@ -12,6 +12,7 @@ import HostDatabase from './services/hostDatabase';
 import ScanOrchestrator from './services/scanOrchestrator';
 import * as hostsController from './controllers/hosts';
 import hosts from './routes/hosts';
+import agentCommands from './routes/agentCommands';
 import { agentService } from './services/agentService';
 import { evaluateCorsOrigin } from './utils/corsOrigin';
 import { healthLimiter } from './middleware/rateLimiter';
@@ -77,6 +78,8 @@ function logStartupDiagnostics(): void {
     mode: agentConfig.mode,
     authMode: getAgentAuthMode(),
     wsQueryTokenFallbackEnabled: agentConfig.wsAllowQueryTokenFallback,
+    tunnelMode: agentConfig.tunnelMode,
+    publicUrl: agentConfig.publicUrl || undefined,
     nodeId: agentConfig.nodeId || undefined,
     location: agentConfig.location || undefined,
     environment: config.server.env,
@@ -104,6 +107,8 @@ async function startServer() {
         nodeId: agentConfig.nodeId,
         location: agentConfig.location,
         cncUrl: agentConfig.cncUrl,
+        tunnelMode: agentConfig.tunnelMode,
+        publicUrl: agentConfig.publicUrl || undefined,
       });
 
       // Pass database instance to agent service
@@ -136,6 +141,9 @@ async function startServer() {
 
     // Routes
     app.use('/hosts', hosts);
+    if (agentConfig.mode === 'agent') {
+      app.use('/agent', agentCommands);
+    }
 
     /**
      * @swagger

--- a/apps/node-agent/src/config/__tests__/agent.unit.test.ts
+++ b/apps/node-agent/src/config/__tests__/agent.unit.test.ts
@@ -4,6 +4,9 @@ describe('agent config', () => {
   beforeEach(() => {
     jest.resetModules();
     process.env = { ...ORIGINAL_ENV };
+    delete process.env.TUNNEL_MODE;
+    delete process.env.CLOUDFLARE_TUNNEL_URL;
+    delete process.env.CLOUDFLARE_TUNNEL_TOKEN;
   });
 
   afterAll(() => {
@@ -49,5 +52,54 @@ describe('agent config', () => {
     expect(agentConfig.mode).toBe('agent');
     expect(agentConfig.cncUrl).toBe('ws://localhost:8080');
     expect(() => validateAgentConfig()).not.toThrow();
+  });
+
+  it('uses Cloudflare tunnel URL as publicUrl when tunnel mode is cloudflare', async () => {
+    process.env.NODE_MODE = 'agent';
+    process.env.CNC_URL = 'ws://localhost:8080';
+    process.env.NODE_ID = 'node-1';
+    process.env.NODE_LOCATION = 'lab';
+    process.env.NODE_AUTH_TOKEN = 'secret-token';
+    process.env.TUNNEL_MODE = 'cloudflare';
+    process.env.CLOUDFLARE_TUNNEL_URL = 'https://node-1.example.trycloudflare.com/';
+    process.env.CLOUDFLARE_TUNNEL_TOKEN = 'cloudflare-token';
+
+    const { agentConfig, validateAgentConfig } = await import('../agent');
+
+    expect(agentConfig.tunnelMode).toBe('cloudflare');
+    expect(agentConfig.publicUrl).toBe('https://node-1.example.trycloudflare.com');
+    expect(() => validateAgentConfig()).not.toThrow();
+  });
+
+  it('throws when cloudflare tunnel mode is enabled without required tunnel config', async () => {
+    process.env.NODE_MODE = 'agent';
+    process.env.CNC_URL = 'ws://localhost:8080';
+    process.env.NODE_ID = 'node-1';
+    process.env.NODE_LOCATION = 'lab';
+    process.env.NODE_AUTH_TOKEN = 'secret-token';
+    process.env.TUNNEL_MODE = 'cloudflare';
+    process.env.CLOUDFLARE_TUNNEL_URL = '';
+    process.env.CLOUDFLARE_TUNNEL_TOKEN = '';
+
+    const { validateAgentConfig } = await import('../agent');
+
+    expect(() => validateAgentConfig()).toThrow(
+      'Agent mode enabled but missing required configuration'
+    );
+  });
+
+  it('throws when TUNNEL_MODE is invalid', async () => {
+    process.env.NODE_MODE = 'agent';
+    process.env.CNC_URL = 'ws://localhost:8080';
+    process.env.NODE_ID = 'node-1';
+    process.env.NODE_LOCATION = 'lab';
+    process.env.NODE_AUTH_TOKEN = 'secret-token';
+    process.env.TUNNEL_MODE = 'invalid-mode';
+
+    const { validateAgentConfig } = await import('../agent');
+
+    expect(() => validateAgentConfig()).toThrow(
+      'TUNNEL_MODE must be either "direct" or "cloudflare"'
+    );
   });
 });

--- a/apps/node-agent/src/middleware/agentCommandAuth.ts
+++ b/apps/node-agent/src/middleware/agentCommandAuth.ts
@@ -1,0 +1,66 @@
+import crypto from 'crypto';
+import type { NextFunction, Request, Response } from 'express';
+import { agentConfig } from '../config/agent';
+import { AppError } from './errorHandler';
+import { logger } from '../utils/logger';
+
+/**
+ * Auth middleware for tunnel command dispatch from C&C.
+ * Uses NODE_AUTH_TOKEN and constant-time comparison.
+ */
+export function agentCommandAuth(req: Request, _res: Response, next: NextFunction): void {
+  if (!agentConfig.authToken) {
+    throw new AppError(
+      'Agent command tunnel authentication is not configured',
+      503,
+      'SERVICE_UNAVAILABLE',
+    );
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader) {
+    logger.warn('Agent tunnel auth failed: missing Authorization header', {
+      method: req.method,
+      path: req.path,
+      ip: req.ip,
+    });
+    throw new AppError('Missing Authorization header', 401, 'UNAUTHORIZED');
+  }
+
+  const parts = authHeader.trim().split(/\s+/);
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    logger.warn('Agent tunnel auth failed: invalid Authorization header format', {
+      method: req.method,
+      path: req.path,
+      ip: req.ip,
+    });
+    throw new AppError(
+      'Invalid Authorization header format. Expected: Bearer <token>',
+      401,
+      'UNAUTHORIZED',
+    );
+  }
+
+  const providedToken = parts[1];
+
+  try {
+    const expectedBuffer = Buffer.from(agentConfig.authToken, 'utf8');
+    const providedBuffer = Buffer.from(providedToken, 'utf8');
+    if (expectedBuffer.length !== providedBuffer.length) {
+      throw new Error('Token length mismatch');
+    }
+
+    if (!crypto.timingSafeEqual(expectedBuffer, providedBuffer)) {
+      throw new Error('Token mismatch');
+    }
+  } catch {
+    logger.warn('Agent tunnel auth failed: invalid token', {
+      method: req.method,
+      path: req.path,
+      ip: req.ip,
+    });
+    throw new AppError('Invalid authentication token', 401, 'UNAUTHORIZED');
+  }
+
+  next();
+}

--- a/apps/node-agent/src/routes/__tests__/agentCommands.integration.test.ts
+++ b/apps/node-agent/src/routes/__tests__/agentCommands.integration.test.ts
@@ -1,0 +1,111 @@
+import express from 'express';
+import request from 'supertest';
+import agentCommandsRouter from '../agentCommands';
+import { errorHandler, notFoundHandler } from '../../middleware/errorHandler';
+import { agentConfig } from '../../config/agent';
+
+const dispatchTunnelCommand = jest.fn();
+
+jest.mock('../../config/agent', () => ({
+  agentConfig: {
+    mode: 'agent',
+    authToken: 'dev-token-home',
+    nodeId: 'node-1',
+  },
+}));
+
+jest.mock('../../services/agentService', () => ({
+  agentService: {
+    dispatchTunnelCommand: (...args: unknown[]) => dispatchTunnelCommand(...args),
+  },
+}));
+
+function createApp(): express.Application {
+  const app = express();
+  app.use(express.json());
+  app.use('/agent', agentCommandsRouter);
+  app.use(notFoundHandler);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('agent tunnel command routes', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = createApp();
+    dispatchTunnelCommand.mockReset();
+    (agentConfig as { mode: string }).mode = 'agent';
+  });
+
+  it('rejects requests without Authorization header', async () => {
+    const response = await request(app)
+      .post('/agent/commands')
+      .send({
+        type: 'wake',
+        commandId: 'cmd-1',
+        data: { hostName: 'desktop', mac: 'AA:BB:CC:DD:EE:FF' },
+      })
+      .expect(401);
+
+    expect(response.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('rejects malformed command payloads', async () => {
+    const response = await request(app)
+      .post('/agent/commands')
+      .set('Authorization', `Bearer ${(agentConfig as { authToken: string }).authToken}`)
+      .send({
+        type: 'wake',
+        data: { hostName: 'desktop', mac: 'AA:BB:CC:DD:EE:FF' },
+      })
+      .expect(400);
+
+    expect(response.body.error.code).toBe('BAD_REQUEST');
+  });
+
+  it('dispatches command and returns canonical command-result payload', async () => {
+    dispatchTunnelCommand.mockResolvedValue({
+      success: true,
+      message: 'Wake-on-LAN packet sent',
+    });
+
+    const response = await request(app)
+      .post('/agent/commands')
+      .set('Authorization', `Bearer ${(agentConfig as { authToken: string }).authToken}`)
+      .send({
+        type: 'wake',
+        commandId: 'cmd-1',
+        data: { hostName: 'desktop', mac: 'AA:BB:CC:DD:EE:FF' },
+      })
+      .expect(200);
+
+    expect(dispatchTunnelCommand).toHaveBeenCalledWith({
+      type: 'wake',
+      commandId: 'cmd-1',
+      data: { hostName: 'desktop', mac: 'AA:BB:CC:DD:EE:FF' },
+    });
+    expect(response.body.type).toBe('command-result');
+    expect(response.body.data).toMatchObject({
+      nodeId: 'node-1',
+      commandId: 'cmd-1',
+      success: true,
+      message: 'Wake-on-LAN packet sent',
+    });
+    expect(typeof response.body.data.timestamp).toBe('string');
+  });
+
+  it('rejects tunnel dispatch when node-agent is not in agent mode', async () => {
+    (agentConfig as { mode: string }).mode = 'standalone';
+
+    await request(app)
+      .post('/agent/commands')
+      .set('Authorization', `Bearer ${(agentConfig as { authToken: string }).authToken}`)
+      .send({
+        type: 'wake',
+        commandId: 'cmd-1',
+        data: { hostName: 'desktop', mac: 'AA:BB:CC:DD:EE:FF' },
+      })
+      .expect(409);
+  });
+});

--- a/apps/node-agent/src/routes/agentCommands.ts
+++ b/apps/node-agent/src/routes/agentCommands.ts
@@ -1,0 +1,49 @@
+import express from 'express';
+import { inboundCncCommandSchema } from '@kaonis/woly-protocol';
+import type { CncCommand } from '../types';
+import { agentConfig } from '../config/agent';
+import { AppError } from '../middleware/errorHandler';
+import { agentCommandAuth } from '../middleware/agentCommandAuth';
+import { agentService } from '../services/agentService';
+
+type DispatchableCommand = Extract<CncCommand, { commandId: string }>;
+
+function asDispatchableCommand(command: CncCommand): DispatchableCommand {
+  if (!('commandId' in command) || typeof command.commandId !== 'string') {
+    throw new AppError('Unsupported command payload for tunnel dispatch', 400, 'BAD_REQUEST');
+  }
+
+  return command as DispatchableCommand;
+}
+
+const router = express.Router();
+
+router.post('/commands', agentCommandAuth, async (req, res) => {
+  if (agentConfig.mode !== 'agent') {
+    throw new AppError(
+      'Tunnel command dispatch is only available in agent mode',
+      409,
+      'CONFLICT',
+    );
+  }
+
+  const parsed = inboundCncCommandSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new AppError('Invalid command payload', 400, 'BAD_REQUEST');
+  }
+
+  const command = asDispatchableCommand(parsed.data);
+  const result = await agentService.dispatchTunnelCommand(command);
+
+  res.status(200).json({
+    type: 'command-result',
+    data: {
+      nodeId: agentConfig.nodeId,
+      commandId: command.commandId,
+      ...result,
+      timestamp: new Date().toISOString(),
+    },
+  });
+});
+
+export default router;

--- a/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+++ b/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
@@ -59,6 +59,10 @@ Minimum required secrets/config:
   - `NODE_ID`
   - `NODE_LOCATION`
   - `NODE_AUTH_TOKEN`
+  - optional tunnel mode:
+    - `TUNNEL_MODE=cloudflare`
+    - `CLOUDFLARE_TUNNEL_URL=https://...`
+    - `CLOUDFLARE_TUNNEL_TOKEN=...`
   - optional hardening: `NODE_API_KEY`
 
 Rotation guidance:
@@ -68,7 +72,24 @@ Rotation guidance:
 3. Validate reconnect/auth behavior after each rotation.
 
 Related runbook:
+
 - `apps/cnc/docs/runbooks/ws-session-token-rotation.md`
+
+### 3.1 Cloudflare Tunnel Mode (Zero Port-Forwarding)
+
+Use this for remote node-agent access without router port-forwarding:
+
+1. Deploy `cloudflared` near the node-agent.
+2. Route the tunnel hostname to node-agent (`http://localhost:8082`).
+3. Set:
+   - `TUNNEL_MODE=cloudflare`
+   - `CLOUDFLARE_TUNNEL_URL=https://<tunnel-hostname>`
+   - `CLOUDFLARE_TUNNEL_TOKEN=<token>`
+4. Keep `NODE_AUTH_TOKEN` synchronized with C&C `NODE_AUTH_TOKENS`.
+5. Validate in C&C:
+   - node registration includes `publicUrl`
+   - command routing succeeds via tunnel endpoint
+   - if tunnel is unavailable, command routing falls back to direct WebSocket transport.
 
 ## 4. Production Security Defaults
 


### PR DESCRIPTION
## CNC Sync Classification

- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: kaonis/woly-server#257
- Backend issue: kaonis/woly-server#347
- Frontend issue: kaonis/woly#441

## 3-Part Chain Checklist (required for CNC feature changes)

- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
npm ci
npm run build -w packages/protocol
npm run build -w apps/node-agent
npm run build -w apps/cnc
npm run test -w packages/protocol -- contract.cross-repo
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run validate:standard
git diff --stat origin/master...HEAD
git diff origin/master...HEAD
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:
- No protocol schema additions were required; tunnel dispatch reuses existing command and `command-result` protocol types.
- Frontend follow-up tracking issue: kaonis/woly#441.

## Summary

Adds Cloudflare tunnel mode support for node-agent command routing with secure token-authenticated tunnel dispatch and automatic WebSocket fallback.

Closes kaonis/woly-server#347
