### PR TITLE
fix: harden host port contract

### DIFF
--- a/.github/workflows/cnc-sync-policy.yml
+++ b/.github/workflows/cnc-sync-policy.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
+      - master
       - main
     types:
       - opened

--- a/docs/CNC_SYNC_POLICY.md
+++ b/docs/CNC_SYNC_POLICY.md
@@ -33,6 +33,7 @@ Each CNC feature PR must link all of the following:
 ## 4. CI Budget Rule
 
 GitHub Actions runs only bare-minimum policy checks on pull requests.
+The approved scheduled exception is the weekly dependency health watchdog.
 Heavy validation runs locally before merge.
 
 ## 5. Required Local Pre-Merge Gates

--- a/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
+++ b/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
@@ -66,17 +66,17 @@ Primary impact:
 
 ## 4. Decision Table (2026-02-15)
 
-| Dependency                    | Decision                                | Rationale                                                                                                                  | Tracking |
-| ----------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------- |
-| ESLint v9                     | Merged                                  | Adopted with typescript-eslint v8 via PR #151                                                                              | #146     |
-| ESLint v10                    | Deferred pending upstream compatibility | Still blocked: latest `@typescript-eslint/*@8.55.0` peers `eslint ^8.57.0 \|\| ^9.0.0`; Renovate PR #11 currently unstable | #150     |
-| typescript-eslint v8          | Merged                                  | Upgraded with ESLint v9 toolchain migration via PR #151                                                                    | #146     |
-| eslint-config-prettier v10    | Merged                                  | Upgraded with ESLint v9 toolchain migration via PR #151                                                                    | #146     |
-| Zod v4                        | Merged                                  | Runtime schema compatibility validated across protocol/C&C/node-agent and merged via PR #152                               | #147     |
-| npm v11                       | Merged                                  | Workspace tooling and CI remained stable; adopted via PR #17                                                               | #148     |
-| ESLint flat config mode       | Merged                                  | Migrated to root `eslint.config.js` and removed legacy `.eslintrc` mode via PR #155                                        | #154     |
-| Turbo v2.8.9                  | Merged                                  | Adopted and validated with local + CI gates via PR #157 (issue #156)                                                       | #156     |
-| ESLint 10 watchdog automation | Merged                                  | Added scheduled/manual watchdog workflow with sticky issue updates via PR #160                                             | #159     |
+| Dependency                    | Decision                            | Rationale                                                                                                               | Tracking |
+| ----------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------- |
+| ESLint v9                     | Merged                              | Adopted with typescript-eslint v8 via PR #151                                                                           | #146     |
+| ESLint v10                    | Unblocked by upstream compatibility | Latest `@typescript-eslint/*@8.62.1` peers include `eslint ^10.0.0`; continue through Renovate PR #398 with local gates | #150     |
+| typescript-eslint v8          | Merged                              | Upgraded with ESLint v9 toolchain migration via PR #151                                                                 | #146     |
+| eslint-config-prettier v10    | Merged                              | Upgraded with ESLint v9 toolchain migration via PR #151                                                                 | #146     |
+| Zod v4                        | Merged                              | Runtime schema compatibility validated across protocol/C&C/node-agent and merged via PR #152                            | #147     |
+| npm v11                       | Merged                              | Workspace tooling and CI remained stable; adopted via PR #17                                                            | #148     |
+| ESLint flat config mode       | Merged                              | Migrated to root `eslint.config.js` and removed legacy `.eslintrc` mode via PR #155                                     | #154     |
+| Turbo v2.8.9                  | Merged                              | Adopted and validated with local + CI gates via PR #157 (issue #156)                                                    | #156     |
+| ESLint 10 watchdog automation | Merged                              | Added scheduled/manual watchdog workflow with sticky issue updates via PR #160                                          | #159     |
 
 ## 5. Exit Criteria for #144
 

--- a/packages/protocol/src/__tests__/schemas.test.ts
+++ b/packages/protocol/src/__tests__/schemas.test.ts
@@ -632,6 +632,16 @@ describe('hostPortScanResponseSchema', () => {
       }).success
     ).toBe(false);
   });
+
+  it.each([0, 65536])('rejects TCP port %i outside the valid range', (port) => {
+    expect(
+      hostPortScanResponseSchema.safeParse({
+        target: 'Office-Mac@Home',
+        scannedAt: '2026-02-15T00:00:00.000Z',
+        openPorts: [{ port, protocol: 'tcp', service: 'HTTP' }],
+      }).success
+    ).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -529,7 +529,7 @@ export const hostStatusSchema = z.enum(['awake', 'asleep']);
 export const hostNotesSchema = z.string().max(2_000).nullable();
 export const hostTagsSchema = z.array(z.string().min(1).max(64)).max(32);
 export const hostPortSchema: z.ZodType<HostPort> = z.object({
-  port: z.number().int().positive(),
+  port: z.number().int().min(1).max(65535),
   protocol: z.literal('tcp'),
   service: z.string().min(1),
 });

--- a/scripts/manual-ci-followup-issue.cjs
+++ b/scripts/manual-ci-followup-issue.cjs
@@ -81,7 +81,7 @@ function buildBody(afterIssue) {
     '- Update active roadmap progress and dependency checkpoint notes.',
     '',
     '## Definition of Done',
-    '- PR merged to `main`',
+    '- PR merged to `master`',
     '- Manual review log updated for the reviewed period',
     '',
   ].join('\n');


### PR DESCRIPTION
## CNC Sync Classification

- [x] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: kaonis/woly-server#256
- Backend issue: kaonis/woly-server#256
- Frontend issue: kaonis/woly#308

## 3-Part Chain Checklist (required for CNC feature changes)

- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
nvm use 24
npm ci
npm run deps:check
npm audit --omit=dev --audit-level=high
npm outdated
npm run ci:policy:check
npm run test -w packages/protocol -- --runInBand
npm run test:ci:helpers
npm run lint
npm run typecheck
npm run test:ci
npm run build
npm run build -w packages/protocol
npm run test -w packages/protocol -- contract.cross-repo --runInBand
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts --runInBand
npm run validate:standard
# pre-push hook also ran:
# npm run typecheck
# npm run test -w packages/protocol -- --findRelatedTests src/__tests__/schemas.test.ts src/index.ts
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:

- This is a maintenance hardening PR, not a new user-facing CNC capability. It is classified as CNC because the low-cost policy gate requires that for protocol source changes.
- `npm outdated` is inventory only. It still reports patch/minor updates plus tracked major updates such as TypeScript 6 and lint-staged 17.
- `npm run deps:check` reports the ESLint 10 watchdog as unblocked with `@typescript-eslint/*@8.62.1` peer support for ESLint 10.
- Initial `npm ci` under shell default Node `v26.3.0` failed as expected because the repo requires `>=24 <26`; all validation above ran under Node `v24.13.0`.
- Read-only review lanes also found separate follow-up candidates: stale roadmap baseline, duplicate capabilities controller, node-agent config/logger hardening, and woly-client generator cleanup. Those are intentionally deferred to keep this PR small.
- Separate reviewer subagents could not be spawned after the read-only lanes because the agent thread limit was reached; coordinator self-review was completed on the final diff.
