### PR TITLE
Skip node-agent scan pings unless validation enabled

### DIFF
--- a/apps/node-agent/README.md
+++ b/apps/node-agent/README.md
@@ -278,7 +278,8 @@ PING_TIMEOUT=2000       # 2 seconds
 USE_PING_VALIDATION=false  # Use ping to validate awake status (default: false, ARP is sufficient)
 # Note: ARP discovery means a host is responding on the network (awake)
 # Ping validation is optional but may fail even for awake hosts due to firewalls
-# All hosts are always ping-tested to track pingResponsive status (separate from awake/asleep)
+# With validation disabled, scans do not ping discovered hosts and pingResponsive stays null
+# With validation enabled, ping results drive awake/asleep status and pingResponsive
 
 # Caching
 MAC_VENDOR_TTL=86400000        # 24 hours

--- a/apps/node-agent/src/services/__tests__/hostDatabase.unit.test.ts
+++ b/apps/node-agent/src/services/__tests__/hostDatabase.unit.test.ts
@@ -42,6 +42,7 @@ describe('HostDatabase', () => {
   beforeEach(async () => {
     // Clear all mocks before each test
     jest.clearAllMocks();
+    config.network.usePingValidation = false;
 
     // Default MAC normalization used throughout HostDatabase.
     (networkDiscovery.formatMAC as jest.Mock).mockImplementation((mac: string) =>
@@ -515,7 +516,7 @@ describe('HostDatabase', () => {
       expect(hostAfter?.lastSeen).not.toBe(lastSeenBefore);
     });
 
-    it('should handle ping failures during sync', async () => {
+    it('should skip ping checks during default ARP-only sync', async () => {
       const mockDiscoveredHosts: DiscoveredHost[] = [
         { ip: '192.168.1.200', mac: 'AA:BB:CC:DD:EE:FF', hostname: 'OfflineHost' },
       ];
@@ -531,8 +532,30 @@ describe('HostDatabase', () => {
       const host = await db.getHost('OfflineHost');
       // Host found via ARP is marked as awake even if ping fails (default mode)
       expect(host?.status).toBe('awake');
-      // But pingResponsive should be 0 (doesn't respond to ping)
-      expect(host?.pingResponsive).toBe(0);
+      // Ping was not attempted because validation is disabled by default.
+      expect(host?.pingResponsive).toBe(null);
+      expect(networkDiscovery.isHostAlive).not.toHaveBeenCalled();
+    });
+
+    it('should clear stale ping responsiveness during default ARP-only sync', async () => {
+      await db.addHost('PreviouslyPingedHost', 'AA:BB:CC:DD:EE:20', '192.168.1.220');
+      await db.updateHostSeen('AA:BB:CC:DD:EE:20', 'asleep', 0);
+
+      const mockDiscoveredHosts: DiscoveredHost[] = [
+        { ip: '192.168.1.220', mac: 'AA:BB:CC:DD:EE:20', hostname: 'PreviouslyPingedHost' },
+      ];
+
+      (networkDiscovery.scanNetworkARP as jest.Mock).mockResolvedValue(mockDiscoveredHosts);
+      (networkDiscovery.isHostAlive as jest.Mock).mockRejectedValue(
+        new Error('ping should not be called')
+      );
+
+      await scanOrchestrator.syncWithNetwork();
+
+      const host = await db.getHost('PreviouslyPingedHost');
+      expect(host?.status).toBe('awake');
+      expect(host?.pingResponsive).toBe(null);
+      expect(networkDiscovery.isHostAlive).not.toHaveBeenCalled();
     });
 
     it('should use ARP-only status when usePingValidation=false (default)', async () => {
@@ -548,21 +571,21 @@ describe('HostDatabase', () => {
       (networkDiscovery.formatMAC as jest.Mock).mockImplementation((mac: string) =>
         mac.toUpperCase().replace(/-/g, ':')
       );
-      // First host blocks ping, second responds
-      (networkDiscovery.isHostAlive as jest.Mock)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true);
+      (networkDiscovery.isHostAlive as jest.Mock).mockRejectedValue(
+        new Error('ping should not be called')
+      );
 
       await scanOrchestrator.syncWithNetwork();
 
       // Both hosts should be marked awake because ARP found them
       const host1 = await db.getHost('PingBlockedHost');
       expect(host1?.status).toBe('awake');
-      expect(host1?.pingResponsive).toBe(0);
+      expect(host1?.pingResponsive).toBe(null);
 
       const host2 = await db.getHost('PingResponsiveHost');
       expect(host2?.status).toBe('awake');
-      expect(host2?.pingResponsive).toBe(1);
+      expect(host2?.pingResponsive).toBe(null);
+      expect(networkDiscovery.isHostAlive).not.toHaveBeenCalled();
     });
 
     it('should use ping result for status when usePingValidation=true', async () => {
@@ -670,6 +693,7 @@ describe('HostDatabase', () => {
     });
 
     it('should ping hosts concurrently in batches', async () => {
+      config.network.usePingValidation = true;
       // Create 25 mock hosts to test batching (with default concurrency of 10)
       const mockDiscoveredHosts: DiscoveredHost[] = Array.from({ length: 25 }, (_, i) => ({
         ip: `192.168.1.${100 + i}`,
@@ -703,9 +727,11 @@ describe('HostDatabase', () => {
         expect(host?.status).toBe('awake');
         expect(host?.pingResponsive).toBe(1);
       }
+      config.network.usePingValidation = false;
     });
 
-    it('should handle mixed ping results in concurrent batches', async () => {
+    it('should handle mixed ping results in concurrent batches when validation is enabled', async () => {
+      config.network.usePingValidation = true;
       const mockDiscoveredHosts: DiscoveredHost[] = [
         { ip: '192.168.1.100', mac: 'AA:BB:CC:DD:EE:01', hostname: 'Host1' },
         { ip: '192.168.1.101', mac: 'AA:BB:CC:DD:EE:02', hostname: 'Host2' },
@@ -725,18 +751,18 @@ describe('HostDatabase', () => {
 
       await scanOrchestrator.syncWithNetwork();
 
-      // All hosts should be marked as awake (ARP discovery overrides ping)
       const host1 = await db.getHost('Host1');
       expect(host1?.status).toBe('awake');
       expect(host1?.pingResponsive).toBe(1);
 
       const host2 = await db.getHost('Host2');
-      expect(host2?.status).toBe('awake');
+      expect(host2?.status).toBe('asleep');
       expect(host2?.pingResponsive).toBe(0);
 
       const host3 = await db.getHost('Host3');
       expect(host3?.status).toBe('awake');
       expect(host3?.pingResponsive).toBe(1);
+      config.network.usePingValidation = false;
     });
   });
 

--- a/apps/node-agent/src/services/scanOrchestrator.ts
+++ b/apps/node-agent/src/services/scanOrchestrator.ts
@@ -104,11 +104,11 @@ class ScanOrchestrator {
         const batchResults = await Promise.all(
           batch.map(async (host) => {
             let isAlive: boolean;
-
-            const pingResult = await this.discovery.isHostAlive(host.ip);
-            const pingResponsive = pingResult ? 1 : 0;
+            let pingResponsive: number | null = null;
 
             if (config.network.usePingValidation) {
+              const pingResult = await this.discovery.isHostAlive(host.ip);
+              pingResponsive = pingResult ? 1 : 0;
               isAlive = pingResult;
               if (!isAlive) {
                 logger.debug(

--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -235,3 +235,13 @@ Period reviewed: maintenance dependency/policy round
 - Budget and throughput assessment: Scoped audit (`ci:audit:manual -- --since 2026-07-02T22:38:05Z --fail-on-unexpected`) observed no unexpected workflow events; local dependency and workflow policy checks were used, the CNC mobile contract gate timeout was reduced to the policy cap, and no extra GitHub Actions runs were required.
 - Decision: Continue manual-only
 - Follow-up actions: Keep using `ci:audit:latest`; checkpoint parsing now recognizes logged `ci:audit:manual -- --since ...` commands.
+
+Date: 2026-07-03
+Reviewer: Codex autonomous loop
+Period reviewed: maintenance review loop after 2026-07-03T15:34:54Z
+
+- Unexpected automatic workflow runs observed: No
+- Local gate policy followed: Yes
+- Budget and throughput assessment: Dependency and health inventory ran locally under Node 24 after the Node 26 engine guard correctly blocked install; no GitHub Actions runs were needed.
+- Decision: Continue manual-only
+- Follow-up actions: Keep treating `npm outdated` as inventory, keep Node 26 deferred until the SQLite runtime supports it, and continue local-first validation before merge.

--- a/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
+++ b/docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md
@@ -219,3 +219,10 @@ Issue #144 is complete when:
   - Observed `npm ci` failure on Node `v26.3.0` because pinned `better-sqlite3@12.6.2` supports Node `20.x || 22.x || 23.x || 24.x || 25.x` and native rebuild fails against Node 26.
   - Constrained repo and app engine ranges to `>=24.0.0 <26.0.0`, enabled npm `engine-strict`, and aligned CNC/node-agent test preflights to fail fast on unsupported Node versions.
   - Node 26 adoption remains deferred until the SQLite runtime is upgraded and local gates pass under Node 26.
+- 2026-07-03 (maintenance review checkpoint):
+  - Confirmed the default shell still runs Node `v26.3.0`; `npm ci` correctly fails fast under the repo engine guard.
+  - Re-ran install and dependency inventory under Node `v24.13.0` / npm `11.6.2`:
+    - `npm ci` PASS.
+    - `npm run deps:check` PASS for high-severity production audit and ESLint 10 watchdog.
+    - `npm outdated` remains informational; no dependency upgrade was applied in this review round.
+  - Node 26 adoption remains deferred pending `better-sqlite3` compatibility and successful local gates.


### PR DESCRIPTION
## CNC Sync Classification

- [ ] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: N/A - not a CNC feature change
- Backend issue: N/A - not a CNC feature change
- Frontend issue: N/A - not a CNC feature change

## 3-Part Chain Checklist (required for CNC feature changes)

- [ ] Protocol contract updated or verified.
- [ ] Backend endpoint/command implemented or explicitly unchanged.
- [ ] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is unchanged; this is node-agent scan maintenance only.
- [x] Standalone probing de-scope work is unchanged.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Summary

- Skip `networkDiscovery.isHostAlive()` during node-agent ARP scans unless `USE_PING_VALIDATION=true`.
- Keep ARP-discovered hosts awake and store `pingResponsive: null` in the default ARP-only mode.
- Update node-agent tests, README scan semantics, and maintenance CI/dependency review logs.

## Local Validation

Commands run:

```bash
# Initial inventory
npm ci # expected failure under Node v26.3.0 engine guard
export PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$PATH"
npm ci
npm run deps:check

# Focused validation
npm run test:preflight --workspace=@woly-server/node-agent && node ../../node_modules/jest/bin/jest.js --watchman=false --runInBand src/services/__tests__/scanOrchestrator.unit.test.ts src/services/__tests__/hostDatabase.unit.test.ts

# Required full local gates
npm run lint
npm run typecheck
npm run test:ci
npm run build
npm run deps:check
npm run ci:policy:check
npm run build -w packages/protocol
npm run test -w packages/protocol -- contract.cross-repo
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run validate:standard

# Review pass and push hook
npm run typecheck
npm run test --workspace=@woly-server/node-agent -- --bail --passWithNoTests --findRelatedTests src/services/__tests__/hostDatabase.unit.test.ts src/services/scanOrchestrator.ts
```

Result summary:

- [x] Local validation passed under Node v24.13.0 / npm 11.6.2.
- [x] Dependency audit found 0 high-severity production vulnerabilities.
- [x] `npm outdated` was reviewed as inventory only; no dependency updates were applied.
- [x] Known gap: default shell Node v26.3.0 remains intentionally blocked by the repo engine guard until `better-sqlite3` supports Node 26.
