### PR TITLE
fix: accept latest manual CI audit checkpoints

### DIFF
--- a/scripts/__tests__/manual-ci-helpers.test.cjs
+++ b/scripts/__tests__/manual-ci-helpers.test.cjs
@@ -52,10 +52,20 @@ test('findLatestSinceCheckpoint returns the latest valid checkpoint', () => {
   assert.equal(latest, '2026-02-15T21:31:02Z');
 });
 
+test('findLatestSinceCheckpoint accepts latest audit checkpoints', () => {
+  const markdown = [
+    '- Budget: `ci:audit:manual -- --since 2026-02-15T21:31:02Z --fail-on-unexpected`',
+    '- Budget: `ci:audit:latest -- --since 2026-07-04T07:45:00Z --fail-on-unexpected`',
+  ].join('\n');
+
+  const latest = findLatestSinceCheckpoint(markdown);
+  assert.equal(latest, '2026-07-04T07:45:00Z');
+});
+
 test('findLatestSinceCheckpoint throws when no checkpoint exists', () => {
   assert.throws(
     () => findLatestSinceCheckpoint('no checkpoint lines here'),
-    /No valid ci:audit:manual --since checkpoint/
+    /No valid ci:audit:manual\/latest --since checkpoint/
   );
 });
 

--- a/scripts/manual-ci-run-audit-latest.cjs
+++ b/scripts/manual-ci-run-audit-latest.cjs
@@ -15,7 +15,7 @@ function hasSinceArg(argv) {
 }
 
 function findLatestSinceCheckpoint(markdown) {
-  const regex = /ci:audit:manual\s+(?:--\s+)?--since\s+([^\s`]+)/g;
+  const regex = /ci:audit:(?:manual|latest)\s+(?:--\s+)?--since\s+([^\s`]+)/g;
   let match;
   let latest = null;
 
@@ -30,7 +30,7 @@ function findLatestSinceCheckpoint(markdown) {
 
   if (!latest) {
     throw new Error(
-      `No valid ci:audit:manual --since checkpoint found in ${REVIEW_LOG_PATH}`
+      `No valid ci:audit:manual/latest --since checkpoint found in ${REVIEW_LOG_PATH}`
     );
   }
 


### PR DESCRIPTION
## CNC Sync Classification

- [ ] This PR is a CNC feature change.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: N/A
- Backend issue: N/A
- Frontend issue: N/A

## 3-Part Chain Checklist (required for CNC feature changes)

- [ ] Protocol contract updated or verified.
- [ ] Backend endpoint/command implemented or explicitly unchanged.
- [ ] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [ ] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [ ] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation

Commands run:

```bash
npm ci
npm run deps:check
npm audit --omit=dev --audit-level=high
npm outdated
npm run ci:policy:check
node --test scripts/__tests__/manual-ci-helpers.test.cjs
npm run ci:audit:latest -- --since 2026-07-02T22:38:05Z --fail-on-unexpected
npm run ci:audit:latest -- --fail-on-unexpected
npm run lint
npm run typecheck
npm run test:ci
npm run build
npm run deps:check
npm run ci:policy:check
git diff --stat origin/master...HEAD
git diff origin/master...HEAD
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:

- `npm outdated` remains dependency inventory only. No dependency updates were applied.
- Manual CI audit observed only allowlisted low-cost `pull_request` runs for the CNC Sync Policy workflow.
- Node 26 remains intentionally deferred behind the existing `<26` engine guard until the SQLite runtime path is revalidated.
- Review lanes also found larger follow-ups in protocol/OpenAPI drift, generated client drift gating, and CNC command lifecycle behavior; these were not included to keep this PR narrowly scoped.

## Summary

- Let `ci:audit:latest` checkpoint discovery read both legacy `ci:audit:manual ... --since` entries and newer `ci:audit:latest ... --since` entries.
- Added a unit test for the newer checkpoint log shape and updated the missing-checkpoint assertion.
