### PR TITLE
chore: align maintenance protocol checkpoints

### DIFF
--- a/apps/cnc/docs/compatibility.md
+++ b/apps/cnc/docs/compatibility.md
@@ -1,11 +1,14 @@
 # Compatibility Matrix (C&C <-> Node)
 
-Date: 2026-02-17
+Date: 2026-07-04
 
-| C&C Version | Node Version | Protocol Version | WS Auth Mode | Notes |
-|---|---|---|---|---|
-| 1.0.0 | 0.0.1 | 1.1.1 (current) | query token | Current baseline for new deployments; negotiated at registration |
-| 1.0.0 | 0.0.1 | 1.0.0 (legacy) | query token | Transitional compatibility while older nodes are still deployed |
+| C&C Version | Node Version | Protocol Version             | WS Auth Mode | Notes                                                                         |
+| ----------- | ------------ | ---------------------------- | ------------ | ----------------------------------------------------------------------------- |
+| 1.0.0       | 0.0.1        | 1.6.0 (current)              | query token  | Current baseline for new deployments; negotiated at registration              |
+| 1.0.0       | 0.0.1        | 1.5.0 - 1.0.0 (transitional) | query token  | Backward-compatible transitional support while older nodes are still deployed |
+
+The canonical protocol version list and migration notes live in
+[`docs/PROTOCOL_COMPATIBILITY.md`](../../../docs/PROTOCOL_COMPATIBILITY.md).
 
 ## Rules
 

--- a/apps/cnc/src/routes/__tests__/mobileCompatibility.smoke.test.ts
+++ b/apps/cnc/src/routes/__tests__/mobileCompatibility.smoke.test.ts
@@ -155,7 +155,7 @@ describe('Mobile API compatibility smoke checks', () => {
         metadata: {
           version: '1.0.0',
           platform: 'darwin',
-          protocolVersion: '1.1.1',
+          protocolVersion: PROTOCOL_VERSION,
           networkInfo: {
             subnet: '192.168.1.0/24',
             gateway: '192.168.1.1',

--- a/docs/CI_MANUAL_REVIEW_LOG.md
+++ b/docs/CI_MANUAL_REVIEW_LOG.md
@@ -242,6 +242,6 @@ Period reviewed: maintenance review loop after 2026-07-03T15:34:54Z
 
 - Unexpected automatic workflow runs observed: No
 - Local gate policy followed: Yes
-- Budget and throughput assessment: Dependency and health inventory ran locally under Node 24 after the Node 26 engine guard correctly blocked install; no GitHub Actions runs were needed.
+- Budget and throughput assessment: Scoped audit (`ci:audit:latest -- --since 2026-07-03T15:34:54Z --fail-on-unexpected`) observed no unexpected workflow events; dependency and health inventory ran locally under Node 24 after the Node 26 engine guard correctly blocked install; no GitHub Actions runs were needed.
 - Decision: Continue manual-only
 - Follow-up actions: Keep treating `npm outdated` as inventory, keep Node 26 deferred until the SQLite runtime supports it, and continue local-first validation before merge.

--- a/docs/ROADMAP_CNC_SYNC_V1.md
+++ b/docs/ROADMAP_CNC_SYNC_V1.md
@@ -1,11 +1,13 @@
 # CNC Sync Roadmap V1 (woly + woly-server + protocol)
 
 ## Scope
+
 - Mode: CNC only.
 - Out of scope: standalone node-agent API compatibility work, except where temporary compatibility is needed during migration.
 - Protocol location: `woly-protocol/protocol` repo was not found locally; canonical protocol package is `packages/protocol` in `woly-server`.
 
 ## Audit Baseline (What is currently out of sync)
+
 1. Frontend expects CNC host scan endpoints (`/api/hosts/ports/:fqn`, `/api/hosts/scan-ports/:fqn`) in `/Users/phantom/projects/woly/src/services/woly-service.ts`, but CNC routes in `/Users/phantom/projects/woly-server/apps/cnc/src/routes/index.ts` do not expose them.
 2. CNC command routing already supports scan in `/Users/phantom/projects/woly-server/apps/cnc/src/services/commandRouter.ts`, but route/controller wiring is missing.
 3. Frontend host type in `/Users/phantom/projects/woly/src/types.ts` does not include protocol host fields like `notes` and `tags` that already exist in `/Users/phantom/projects/woly-server/packages/protocol/src/index.ts` and backend update validation in `/Users/phantom/projects/woly-server/apps/cnc/src/controllers/hosts.ts`.
@@ -14,7 +16,9 @@
 6. Mobile compatibility smoke coverage in `/Users/phantom/projects/woly-server/apps/cnc/src/routes/__tests__/mobileCompatibility.smoke.test.ts` validates core hosts/nodes only, not richer CNC interactions.
 
 ## Cross-Repo Issue Map
+
 ### woly-server
+
 - #253 CNC: Add host port-scan API endpoints used by mobile app
   - https://github.com/kaonis/woly-server/issues/253
 - #254 CNC: Add capabilities endpoint for frontend feature negotiation
@@ -27,6 +31,7 @@
   - https://github.com/kaonis/woly-server/issues/257
 
 ### woly
+
 - #307 App: CNC-only networking mode (de-prioritize standalone fallback)
   - https://github.com/kaonis/woly/issues/307
 - #308 App: Adopt @kaonis/woly-protocol shared types for CNC entities
@@ -39,36 +44,46 @@
   - https://github.com/kaonis/woly/issues/311
 
 ## Delivery Order
+
 1. Contract and capability handshake
+
 - Complete #254, #257, #308.
 - Goal: app and backend share typed contracts and explicit capability negotiation.
 
 2. Scan parity in CNC mode
+
 - Complete #253, #311, then tighten #307 for CNC-only scan path.
 - Goal: port scan feature works through CNC APIs without standalone probing.
 
 3. Host metadata parity (notes/tags)
+
 - Complete #309 with backend contract validation and compatibility tests (#256).
 - Goal: notes/tags are truly server-synced and reflected across clients.
 
 4. Schedules as shared backend state
+
 - Complete #255 and #310.
 - Goal: schedules are authoritative in CNC backend, app uses local state only as cache/offline queue.
 
 5. Hardening gate
+
 - Finish #256 and block merge on contract + compatibility checks for CNC routes.
 
 ## Operating Model (How to keep frontend/backend in sync)
+
 1. Feature starts as a protocol/API contract change, then backend implementation, then frontend wiring.
 2. Every feature has linked issues in both repos and a clear dependency chain.
 3. No merge to default branch unless:
+
 - protocol types compile for app consumption,
 - backend compatibility tests pass,
 - frontend typecheck/tests pass against current contract.
+
 4. App should detect capabilities on startup and disable unsupported UI actions.
 5. Prefer additive API evolution; remove deprecated behavior only after app release has switched.
 
 ## Definition of Done for each CNC feature
+
 - Shared type/DTO exists in protocol package (or explicit adapter with rationale).
 - Backend endpoint/command path is implemented and documented.
 - Frontend uses CNC-only path for that feature.
@@ -76,9 +91,13 @@
 - Migration notes are added for any behavior changes.
 
 ## Decision Log Updates
+
 - 2026-02-18 (issue #323): Classified app-local LAN Wake-on-LAN fallback (`kaonis/woly`) as a protocol no-op with no CNC contract delta; capability negotiation and protocol request/response shapes remain unchanged.
 - 2026-02-18 (issue #324): Verified backend impact is unchanged for app-local LAN Wake-on-LAN fallback; existing remote wake endpoint (`POST /api/hosts/wakeup/:fqn`) and command flow remain unchanged.
 
 ## Rolling Manual-CI Progress
+
 - 2026-02-18: Completed weekly manual-first operations review for issue #280 using `npm run ci:audit:manual -- --since 2026-02-16T18:35:12Z --fail-on-unexpected` (PASS) and `npm run ci:policy:check` (PASS).
 - 2026-02-18: Logged review decision in `docs/CI_MANUAL_REVIEW_LOG.md` and checkpoint updates in `docs/DEPENDENCY_MAJOR_UPGRADE_PLAN.md`.
+- 2026-07-03: Completed maintenance dependency/policy review using local-first gates; `npm audit --omit=dev --audit-level=high`, ESLint 10 watchdog, and workflow policy checks passed.
+- 2026-07-03: Confirmed Node 26 remains deferred because of the pinned SQLite runtime; validation and dependency inventory must run under supported Node 24/25 until the runtime compatibility gate is updated.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -99,6 +99,9 @@ Output goes to `dist/`. Both `main` and `types` in package.json point there.
 - `1.1.x`: CNC app/backend API contracts (`CncCapabilitiesResponse`, schedules, host port scan DTOs/schemas) and wire protocol negotiation update.
 - `1.2.x`: Host metadata/scan enrichments (`openPorts`, `portsScannedAt`, `portsExpireAt`), ping/port-scan command/result payloads, and consumer typecheck fixture parity.
 - `1.3.x`: CNC capability-map enrichments (`hostStateStreaming`, optional `rateLimits`) and exported CNC rate-limit descriptor schemas.
+- `1.4.x`: Host uptime/history contracts, webhook contracts, merge/port metadata enrichments.
+- `1.5.x`: Push-notification contracts and host power-control contracts.
+- `1.6.x`: Capability-negotiation enrichments for remote power controls (`sleep`, `shutdown`).
 
 ## CNC Polling Identity Notes
 

--- a/packages/protocol/fixtures/app-consumer/index.ts
+++ b/packages/protocol/fixtures/app-consumer/index.ts
@@ -14,7 +14,7 @@ const capabilities: CncCapabilitiesResponse = {
   mode: 'cnc',
   versions: {
     cncApi: '1.0.0',
-    protocol: '1.3.0',
+    protocol: '1.6.0',
   },
   capabilities: {
     scan: { supported: true },
@@ -22,6 +22,9 @@ const capabilities: CncCapabilitiesResponse = {
     schedules: { supported: true, routes: ['/api/hosts/:fqn/schedules'] },
     hostStateStreaming: { supported: true, transport: 'websocket', routes: ['/ws/mobile/hosts'] },
     commandStatusStreaming: { supported: false, transport: null },
+    wakeVerification: { supported: true },
+    sleep: { supported: true, routes: ['/api/hosts/sleep/:fqn'] },
+    shutdown: { supported: true, routes: ['/api/hosts/shutdown/:fqn'] },
   },
   rateLimits: {
     strictAuth: { maxCalls: 5, windowMs: 900_000, scope: 'ip' },

--- a/packages/woly-client/scripts/generate-clients.mjs
+++ b/packages/woly-client/scripts/generate-clients.mjs
@@ -57,6 +57,10 @@ for (const target of targets) {
     }
   );
 
+  if (result.error) {
+    throw new Error(`Failed to generate ${target.name} client: ${result.error.message}`);
+  }
+
   if (result.status !== 0) {
     throw new Error(`Failed to generate ${target.name} client (exit ${result.status ?? 'unknown'})`);
   }


### PR DESCRIPTION
## CNC Sync Classification

- [x] This PR is a CNC feature change.

Maintenance-only classification note: this PR does not add a user-facing CNC feature, but it touches `apps/cnc/src/...` compatibility coverage, so it follows the CNC policy checklist.

## Linked Issues (required when CNC feature checkbox is checked)

- Protocol issue: kaonis/woly-server#257
- Backend issue: kaonis/woly-server#256
- Frontend issue: kaonis/woly#308

## 3-Part Chain Checklist (required for CNC feature changes)

- [x] Protocol contract updated or verified.
- [x] Backend endpoint/command implemented or explicitly unchanged.
- [x] Frontend integration implemented or tracked in linked issue.

## Ordering Gates

- [x] Capability negotiation endpoint is implemented/linked (kaonis/woly-server#254) before probe-based behavior changes.
- [x] Standalone probing de-scope work (kaonis/woly#307) is blocked until parity issues are complete.

## Review Pass (required for all PRs)

- [x] I completed a final review pass after my latest implementation commit (peer review preferred; self-review completed at minimum).
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

## Local Validation (required for CNC feature changes)

Commands run:

```bash
source ~/.nvm/nvm.sh
nvm use 24.13.0
npm ci
npm run deps:check
npm audit --omit=dev --audit-level=high
npm outdated
npm run ci:policy:check
npm run ci:audit:latest -- --fail-on-unexpected
npm run test:consumer-typecheck -w packages/protocol
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run client:build
npm run client:consumer-typecheck
npm run lint
npm run typecheck
npm run test:ci
npm run build
npm run deps:check
npm run ci:policy:check
npm run build -w packages/protocol
npm run test -w packages/protocol -- contract.cross-repo
npm run test -w apps/cnc -- src/routes/__tests__/mobileCompatibility.smoke.test.ts
npm run validate:standard
npm run test:ci
```

Result summary:

- [x] Local validation passed
- [x] Any known gaps are documented below

Notes:

- Validation was run under Node 24.13.0 / npm 11.6.2 because Node 26 is intentionally blocked by the current SQLite runtime guard.
- `npm outdated` remains inventory only; no dependency versions were changed.
- `npm run test:ci` was rerun after an earlier chained command showed a transient node-agent failure in truncated output; the isolated rerun passed.
- `client:build` rewrote tracked OpenAPI files with formatting-only, semantic-identical JSON changes; those generated formatting changes were excluded from this PR.