### PR TITLE
chore: ignore local .codegraph index directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ logs/*.log
 npm-debug.log
 yarn-error.log
 apps/node-agent/logs/
+
+# Local code-index artifacts
+.codegraph/


### PR DESCRIPTION
The CodeGraph MCP index (`.codegraph/`) is a local artifact that shows up as untracked noise in every working tree. One-line .gitignore addition, found while building the improvement backlog (#424-#454).

## Review pass
- [x] I completed a final review pass after my latest implementation commit
- [x] I reviewed the final diff for correctness, scope control, and regression risk.
- [x] I addressed all review comments/threads with follow-up commits or explicit rationale.
- [x] I re-reviewed the updated diff after applying review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)