### PR TITLE
fix(cnc): return actionable webhook event validation errors

### DIFF
--- a/apps/cnc/src/controllers/__tests__/webhooks.test.ts
+++ b/apps/cnc/src/controllers/__tests__/webhooks.test.ts
@@ -63,6 +63,58 @@ describe('WebhooksController', () => {
     expect(mockedWebhookModel.create).not.toHaveBeenCalled();
   });
 
+  it('returns actionable details for unsupported webhook event filters', async () => {
+    const req = createMockRequest({
+      body: {
+        url: 'https://example.com/hooks/woly',
+        events: ['host.updated'],
+      },
+    });
+    const res = createMockResponse();
+
+    await controller.createWebhook(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: 'Bad Request',
+        message: 'Invalid webhook payload',
+        supportedEvents: expect.arrayContaining(['host.awake', 'node.disconnected']),
+        details: expect.arrayContaining([
+          expect.objectContaining({
+            path: ['events', 0],
+          }),
+        ]),
+      }),
+    );
+    expect(mockedWebhookModel.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate webhook event filters before registration', async () => {
+    const req = createMockRequest({
+      body: {
+        url: 'https://example.com/hooks/woly',
+        events: ['host.awake', 'host.awake'],
+      },
+    });
+    const res = createMockResponse();
+
+    await controller.createWebhook(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.arrayContaining([
+          expect.objectContaining({
+            message: 'Webhook events must be unique',
+            path: ['events'],
+          }),
+        ]),
+      }),
+    );
+    expect(mockedWebhookModel.create).not.toHaveBeenCalled();
+  });
+
   it('creates webhooks when payload is valid', async () => {
     mockedWebhookModel.create.mockResolvedValue({
       id: 'webhook-1',

--- a/apps/cnc/src/controllers/webhooks.ts
+++ b/apps/cnc/src/controllers/webhooks.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
-import { createWebhookRequestSchema } from '@kaonis/woly-protocol';
+import { WEBHOOK_EVENT_TYPES, createWebhookRequestSchema } from '@kaonis/woly-protocol';
 import WebhookModel from '../models/Webhook';
 import logger from '../utils/logger';
 
@@ -15,6 +15,15 @@ const deliveriesParamsSchema = z.object({
 const deliveriesQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(500).optional(),
 }).passthrough();
+
+function webhookValidationResponse(issues: z.ZodIssue[]): Record<string, unknown> {
+  return {
+    error: 'Bad Request',
+    message: 'Invalid webhook payload',
+    details: issues,
+    supportedEvents: [...WEBHOOK_EVENT_TYPES],
+  };
+}
 
 export class WebhooksController {
   /**
@@ -49,11 +58,7 @@ export class WebhooksController {
   async createWebhook(req: Request, res: Response): Promise<void> {
     const parsed = createWebhookRequestSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({
-        error: 'Bad Request',
-        message: 'Invalid webhook payload',
-        details: parsed.error.issues,
-      });
+      res.status(400).json(webhookValidationResponse(parsed.error.issues));
       return;
     }
 

--- a/apps/cnc/src/swagger.ts
+++ b/apps/cnc/src/swagger.ts
@@ -659,6 +659,8 @@ const options: swaggerJsdoc.Options = {
             events: {
               type: 'array',
               minItems: 1,
+              uniqueItems: true,
+              description: 'Webhook event filters. Invalid or duplicate values are rejected with a 400 response.',
               items: {
                 $ref: '#/components/schemas/WebhookEventType',
               },
@@ -1532,6 +1534,21 @@ const options: swaggerJsdoc.Options = {
               type: 'string',
               description: 'Error code (for authentication errors)',
               example: 'AUTH_UNAUTHORIZED',
+            },
+            details: {
+              type: 'array',
+              description: 'Structured validation details when a request payload fails schema validation.',
+              items: {
+                type: 'object',
+                additionalProperties: true,
+              },
+            },
+            supportedEvents: {
+              type: 'array',
+              description: 'Supported webhook event filters returned with webhook validation errors.',
+              items: {
+                $ref: '#/components/schemas/WebhookEventType',
+              },
             },
           },
         },

--- a/docs/WEBHOOK_EVENT_FILTER_REPAIR.md
+++ b/docs/WEBHOOK_EVENT_FILTER_REPAIR.md
@@ -1,0 +1,57 @@
+# Webhook Event Filter Repair
+
+Webhook registrations should only store supported event filters:
+
+- `host.awake`
+- `host.asleep`
+- `host.discovered`
+- `host.removed`
+- `scan.complete`
+- `node.connected`
+- `node.disconnected`
+
+New registrations are validated at the API boundary. Invalid or duplicate event
+filters should receive a `400` response with validation details and the supported
+event list.
+
+## Existing Rows
+
+Older rows may contain malformed JSON or unsupported event names. Repair those
+rows before relying on webhook delivery routing.
+
+For PostgreSQL, inspect suspicious rows with:
+
+```sql
+SELECT id, events
+FROM webhooks
+WHERE jsonb_typeof(events) <> 'array'
+   OR EXISTS (
+     SELECT 1
+     FROM jsonb_array_elements_text(events) AS event(value)
+     WHERE event.value NOT IN (
+       'host.awake',
+       'host.asleep',
+       'host.discovered',
+       'host.removed',
+       'scan.complete',
+       'node.connected',
+       'node.disconnected'
+     )
+   );
+```
+
+For SQLite, inspect rows whose `events` field is not a valid JSON array or whose
+array includes values outside the supported list. Then either update the row to
+the intended supported event list or delete and recreate the webhook through the
+API.
+
+Example repair:
+
+```sql
+UPDATE webhooks
+SET events = '["host.awake","host.asleep"]',
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = '<webhook-id>';
+```
+
+Keep a copy of the original row before changing production data.

--- a/packages/woly-client/openapi/cnc.json
+++ b/packages/woly-client/openapi/cnc.json
@@ -656,6 +656,8 @@
           "events": {
             "type": "array",
             "minItems": 1,
+            "uniqueItems": true,
+            "description": "Webhook event filters. Invalid or duplicate values are rejected with a 400 response.",
             "items": {
               "$ref": "#/components/schemas/WebhookEventType"
             }
@@ -1539,6 +1541,21 @@
             "type": "string",
             "description": "Error code (for authentication errors)",
             "example": "AUTH_UNAUTHORIZED"
+          },
+          "details": {
+            "type": "array",
+            "description": "Structured validation details when a request payload fails schema validation.",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "supportedEvents": {
+            "type": "array",
+            "description": "Supported webhook event filters returned with webhook validation errors.",
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
           }
         }
       }

--- a/packages/woly-client/src/generated/cnc/models/CreateWebhookRequest.ts
+++ b/packages/woly-client/src/generated/cnc/models/CreateWebhookRequest.ts
@@ -5,6 +5,9 @@
 import type { WebhookEventType } from './WebhookEventType';
 export type CreateWebhookRequest = {
     url: string;
+    /**
+     * Webhook event filters. Invalid or duplicate values are rejected with a 400 response.
+     */
     events: Array<WebhookEventType>;
     secret?: string | null;
 };

--- a/packages/woly-client/src/generated/cnc/models/Error.ts
+++ b/packages/woly-client/src/generated/cnc/models/Error.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { WebhookEventType } from './WebhookEventType';
 export type Error = {
     /**
      * Error type
@@ -15,5 +16,13 @@ export type Error = {
      * Error code (for authentication errors)
      */
     code?: string;
+    /**
+     * Structured validation details when a request payload fails schema validation.
+     */
+    details?: Array<Record<string, any>>;
+    /**
+     * Supported webhook event filters returned with webhook validation errors.
+     */
+    supportedEvents?: Array<WebhookEventType>;
 };
 


### PR DESCRIPTION
## Summary

- Return actionable `400` responses for invalid webhook event filters, including the Zod issue details and the supported event list.
- Document uniqueness in the CNC OpenAPI schema and refresh the generated CNC client model types.
- Add a repair note for older `webhooks.events` rows that may already contain malformed JSON or unsupported event names.

Closes #439.

## Tests

- `npm ci`
- `npm run test -w apps/cnc -- src/controllers/__tests__/webhooks.test.ts --runInBand`
- `npm run test -w apps/cnc -- src/routes/__tests__/webhookRoutes.test.ts --runInBand`
- `npm run typecheck -w apps/cnc`
- `npm run build -w apps/cnc`
- `npm run lint -w apps/cnc`
- `npm run typecheck -w packages/woly-client`
- `npm run build`
- `git diff --check`
- pre-push hook: root `typecheck` PASS; related Jest PASS (`12` suites / `177` tests)
